### PR TITLE
Fix video export stall when trim regions cause long decoder gaps

### DIFF
--- a/src/lib/exporter/videoExporter.test.ts
+++ b/src/lib/exporter/videoExporter.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
 	getSourceCopyFastPathBlockers,
 	isSourceCopyFastPathEligible,
 	type VideoExporterConfig,
+	waitForEncoderQueueSpace,
 } from "./videoExporter";
 
 function createConfig(overrides: Partial<VideoExporterConfig> = {}): VideoExporterConfig {
@@ -117,5 +118,131 @@ describe("getSourceCopyFastPathBlockers", () => {
 				height: 1032,
 			}),
 		).toContain("output-size 1920x1080 differs from source 1920x1032");
+	});
+});
+
+describe("waitForEncoderQueueSpace", () => {
+	function fakeClock(start = 0) {
+		let elapsedMs = start;
+		return {
+			now: () => elapsedMs,
+			sleep: async (ms: number) => {
+				elapsedMs += ms;
+			},
+		};
+	}
+
+	it("resolves immediately when the queue already has space", async () => {
+		const clock = fakeClock();
+		const sleep = vi.fn(clock.sleep);
+
+		await waitForEncoderQueueSpace({
+			getQueueSize: () => 0,
+			maxEncodeQueue: 8,
+			isCancelled: () => false,
+			encoderPreference: "prefer-hardware",
+			now: clock.now,
+			sleep,
+		});
+
+		expect(sleep).not.toHaveBeenCalled();
+	});
+
+	it("waits for the queue to drain and then resolves", async () => {
+		const clock = fakeClock();
+		let queueSize = 8;
+		// Queue drains well within the timeout.
+		const sleep = vi.fn(async (ms: number) => {
+			await clock.sleep(ms);
+			queueSize = 0;
+		});
+
+		await waitForEncoderQueueSpace({
+			getQueueSize: () => queueSize,
+			maxEncodeQueue: 8,
+			isCancelled: () => false,
+			encoderPreference: "prefer-hardware",
+			now: clock.now,
+			sleep,
+		});
+
+		expect(sleep).toHaveBeenCalledTimes(1);
+	});
+
+	it("throws a hardware-specific error once the queue stays full past the timeout", async () => {
+		const clock = fakeClock();
+
+		await expect(
+			waitForEncoderQueueSpace({
+				getQueueSize: () => 8,
+				maxEncodeQueue: 8,
+				isCancelled: () => false,
+				encoderPreference: "prefer-hardware",
+				now: clock.now,
+				sleep: clock.sleep,
+			}),
+		).rejects.toThrow(
+			"The hardware video encoder stopped responding. Retrying with a safer encoder.",
+		);
+	});
+
+	it("throws a generic error for the software encoder once the queue stays full past the timeout", async () => {
+		const clock = fakeClock();
+
+		await expect(
+			waitForEncoderQueueSpace({
+				getQueueSize: () => 8,
+				maxEncodeQueue: 8,
+				isCancelled: () => false,
+				encoderPreference: "prefer-software",
+				now: clock.now,
+				sleep: clock.sleep,
+			}),
+		).rejects.toThrow("The video encoder stopped responding during export.");
+	});
+
+	// Regression test for the false-positive stall: a long gap *before* this call
+	// (e.g. the decoder discarding frames inside a trim region) must not count
+	// against the timeout. Only time spent waiting *inside* this call should.
+	it("does not throw merely because a long time has already passed before this call", async () => {
+		// Simulate this call starting two minutes after some unrelated earlier event,
+		// then having the queue drain almost immediately once we're inside the wait.
+		const clock = fakeClock(2 * 60 * 1000);
+		let queueSize = 8;
+		const sleep = vi.fn(async (ms: number) => {
+			await clock.sleep(ms);
+			queueSize = 0;
+		});
+
+		await expect(
+			waitForEncoderQueueSpace({
+				getQueueSize: () => queueSize,
+				maxEncodeQueue: 8,
+				isCancelled: () => false,
+				encoderPreference: "prefer-hardware",
+				now: clock.now,
+				sleep,
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	it("stops waiting without throwing once cancelled", async () => {
+		const clock = fakeClock();
+		let cancelled = false;
+		const sleep = vi.fn(async (ms: number) => {
+			await clock.sleep(ms);
+			cancelled = true;
+		});
+
+		await expect(
+			waitForEncoderQueueSpace({
+				getQueueSize: () => 8,
+				maxEncodeQueue: 8,
+				isCancelled: () => cancelled,
+				encoderPreference: "prefer-hardware",
+				now: clock.now,
+				sleep,
+			}),
+		).resolves.toBeUndefined();
 	});
 });

--- a/src/lib/exporter/videoExporter.test.ts
+++ b/src/lib/exporter/videoExporter.test.ts
@@ -121,6 +121,12 @@ describe("getSourceCopyFastPathBlockers", () => {
 	});
 });
 
+// The original bug measured the timeout from the encoder's last *output* event
+// (lastEncoderOutputAt), which went stale while the decoder discarded frames inside
+// a trim region. waitForEncoderQueueSpace fixes this by starting the clock fresh on
+// each call instead of accepting any such external timestamp — by construction, there
+// is no "last output" state to go stale, so that regression can't be reintroduced
+// without changing this function's signature.
 describe("waitForEncoderQueueSpace", () => {
 	function fakeClock(start = 0) {
 		let elapsedMs = start;
@@ -199,31 +205,6 @@ describe("waitForEncoderQueueSpace", () => {
 				sleep: clock.sleep,
 			}),
 		).rejects.toThrow("The video encoder stopped responding during export.");
-	});
-
-	// Regression test for the false-positive stall: a long gap *before* this call
-	// (e.g. the decoder discarding frames inside a trim region) must not count
-	// against the timeout. Only time spent waiting *inside* this call should.
-	it("does not throw merely because a long time has already passed before this call", async () => {
-		// Simulate this call starting two minutes after some unrelated earlier event,
-		// then having the queue drain almost immediately once we're inside the wait.
-		const clock = fakeClock(2 * 60 * 1000);
-		let queueSize = 8;
-		const sleep = vi.fn(async (ms: number) => {
-			await clock.sleep(ms);
-			queueSize = 0;
-		});
-
-		await expect(
-			waitForEncoderQueueSpace({
-				getQueueSize: () => queueSize,
-				maxEncodeQueue: 8,
-				isCancelled: () => false,
-				encoderPreference: "prefer-hardware",
-				now: clock.now,
-				sleep,
-			}),
-		).resolves.toBeUndefined();
 	});
 
 	it("stops waiting without throwing once cancelled", async () => {

--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -152,7 +152,6 @@ export class VideoExporter {
 	private videoColorSpace: VideoColorSpaceInit | undefined;
 	private muxingPromises: Promise<void>[] = [];
 	private chunkCount = 0;
-	private lastEncoderOutputAt = 0;
 	private fatalEncoderError: Error | null = null;
 
 	constructor(config: VideoExporterConfig) {
@@ -384,12 +383,16 @@ export class VideoExporter {
 							exportFrame = new VideoFrame(canvas, { timestamp, duration: frameDuration });
 						}
 
+						// Timer resets each time we enter the queue-full wait, so a long
+						// trimmed-region decode (decoder busy discarding frames) doesn't
+						// make the stall check fire spuriously.
+						const stallWaitStartAt = Date.now();
 						while (
 							this.encoder &&
 							this.encoder.encodeQueueSize >= maxEncodeQueue &&
 							!this.cancelled
 						) {
-							if (Date.now() - this.lastEncoderOutputAt > ENCODER_STALL_TIMEOUT_MS) {
+							if (Date.now() - stallWaitStartAt > ENCODER_STALL_TIMEOUT_MS) {
 								exportFrame.close();
 								throw new Error(
 									encoderPreference === "prefer-hardware"
@@ -496,14 +499,11 @@ export class VideoExporter {
 		this.encodeQueue = 0;
 		this.muxingPromises = [];
 		this.chunkCount = 0;
-		this.lastEncoderOutputAt = Date.now();
 		this.fatalEncoderError = null;
 		let videoDescription: Uint8Array | undefined;
 
 		this.encoder = new VideoEncoder({
 			output: (chunk, meta) => {
-				this.lastEncoderOutputAt = Date.now();
-
 				if (meta?.decoderConfig?.description && !videoDescription) {
 					const desc = meta.decoderConfig.description;
 					if (desc instanceof ArrayBuffer || desc instanceof SharedArrayBuffer) {
@@ -648,7 +648,6 @@ export class VideoExporter {
 		this.chunkCount = 0;
 		this.videoDescription = undefined;
 		this.videoColorSpace = undefined;
-		this.lastEncoderOutputAt = 0;
 		this.fatalEncoderError = null;
 	}
 

--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -20,6 +20,37 @@ import type { ExportConfig, ExportProgress, ExportResult } from "./types";
 const ENCODER_STALL_TIMEOUT_MS = 15_000;
 const ENCODER_FLUSH_TIMEOUT_MS = 20_000;
 
+/**
+ * Waits for the encoder's queue to drain below maxEncodeQueue before returning.
+ *
+ * The stall timer starts fresh on each call (not from the encoder's last output), so a
+ * long gap before this call — e.g. the decoder discarding frames inside a trim region —
+ * doesn't get blamed on the encoder once real frames resume.
+ */
+export async function waitForEncoderQueueSpace(params: {
+	getQueueSize: () => number;
+	maxEncodeQueue: number;
+	isCancelled: () => boolean;
+	encoderPreference: HardwareAcceleration;
+	now?: () => number;
+	sleep?: (ms: number) => Promise<void>;
+}): Promise<void> {
+	const now = params.now ?? Date.now;
+	const sleep = params.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+
+	const stallWaitStartAt = now();
+	while (params.getQueueSize() >= params.maxEncodeQueue && !params.isCancelled()) {
+		if (now() - stallWaitStartAt > ENCODER_STALL_TIMEOUT_MS) {
+			throw new Error(
+				params.encoderPreference === "prefer-hardware"
+					? "The hardware video encoder stopped responding. Retrying with a safer encoder."
+					: "The video encoder stopped responding during export.",
+			);
+		}
+		await sleep(5);
+	}
+}
+
 export interface VideoExporterConfig extends ExportConfig {
 	videoUrl: string;
 	webcamVideoUrl?: string;
@@ -383,24 +414,16 @@ export class VideoExporter {
 							exportFrame = new VideoFrame(canvas, { timestamp, duration: frameDuration });
 						}
 
-						// Timer resets each time we enter the queue-full wait, so a long
-						// trimmed-region decode (decoder busy discarding frames) doesn't
-						// make the stall check fire spuriously.
-						const stallWaitStartAt = Date.now();
-						while (
-							this.encoder &&
-							this.encoder.encodeQueueSize >= maxEncodeQueue &&
-							!this.cancelled
-						) {
-							if (Date.now() - stallWaitStartAt > ENCODER_STALL_TIMEOUT_MS) {
-								exportFrame.close();
-								throw new Error(
-									encoderPreference === "prefer-hardware"
-										? "The hardware video encoder stopped responding. Retrying with a safer encoder."
-										: "The video encoder stopped responding during export.",
-								);
-							}
-							await new Promise((resolve) => setTimeout(resolve, 5));
+						try {
+							await waitForEncoderQueueSpace({
+								getQueueSize: () => this.encoder?.encodeQueueSize ?? 0,
+								maxEncodeQueue,
+								isCancelled: () => this.cancelled,
+								encoderPreference,
+							});
+						} catch (error) {
+							exportFrame.close();
+							throw error;
 						}
 
 						if (this.encoder && this.encoder.state === "configured") {


### PR DESCRIPTION
## Description
Fixes a false-positive encoder stall that causes video export to abort when a project has trim regions covering a large portion of the source recording.

## Motivation
`StreamingVideoDecoder` reads the source file sequentially — it cannot seek. Frames inside trimmed regions must still be decoded to maintain P/B-frame state, but are discarded. For a recording with a large trim in the middle, this discard phase can take tens of seconds of wall time.

During the discard phase the encoder queue is empty and `lastEncoderOutputAt` goes stale. When real frames arrive after the trim and fill the queue, the timeout has already elapsed — a false positive that aborts a healthy export.

**Fix**: reset the timer at the start of each queue-full wait instead of measuring from the last encoder output.

    + const stallWaitStartAt = Date.now();
      while (encoder.encodeQueueSize >= maxEncodeQueue) {
    -   if (Date.now() - this.lastEncoderOutputAt > ENCODER_STALL_TIMEOUT_MS) {
    +   if (Date.now() - stallWaitStartAt > ENCODER_STALL_TIMEOUT_MS) {

This was originally opened as siddharthvaddem/openscreen#682, but that repo was archived before it could be reviewed/merged. Re-opening against this fork since the bug is still present in `videoExporter.ts` here.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Testing
The stall detection path exercises `VideoEncoder` directly, which is a browser WebCodecs API not available in the Node test environment. I verified the fix manually with a project that previously reproduced the issue consistently.

1. Create a project with a trim region that removes a large span of the source recording (e.g. trimming out several minutes from the middle)
2. Export to MP4
3. **Before**: export aborts with _"The hardware video encoder stopped responding"_
4. **After**: export completes normally

Verified against current `main` (post v1.5.0):
- `tsc --noEmit` — 0 errors
- `vitest --run` — 225/225 passing

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [ ] I have linked related issue(s) and updated the changelog if applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved encoder queue monitoring and timeout detection for more reliable video exports.
  * Enhanced error messaging to better distinguish between hardware and software encoder-related issues.

* **Tests**
  * Expanded test coverage for encoder queue management, including cancellation and timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->