### PR TITLE
Keep HUD interactive on Linux so the drag handle can receive pointer events

### DIFF
--- a/src/components/launch/LaunchWindow.test.tsx
+++ b/src/components/launch/LaunchWindow.test.tsx
@@ -8,6 +8,8 @@ type SelectedSourceChangedListener = Parameters<
 	Window["electronAPI"]["onSelectedSourceChanged"]
 >[0];
 
+const platformState = vi.hoisted(() => ({ value: "darwin" }));
+
 const recorderState = vi.hoisted(() => ({
 	value: {
 		recording: false,
@@ -71,7 +73,7 @@ vi.mock("../../lib/requestCameraAccess", () => ({
 vi.mock("@/native", () => ({
 	nativeBridgeClient: {
 		system: {
-			getPlatform: vi.fn(async () => "darwin"),
+			getPlatform: vi.fn(async () => platformState.value),
 		},
 	},
 }));
@@ -190,6 +192,7 @@ function emitSourceSelectorClosed() {
 
 describe("LaunchWindow record button", () => {
 	beforeEach(() => {
+		platformState.value = "darwin";
 		class ResizeObserver {
 			observe() {
 				return undefined;
@@ -326,5 +329,15 @@ describe("LaunchWindow record button", () => {
 
 		expect(recorderState.value.toggleRecording).toHaveBeenCalledTimes(1);
 		expect(window.electronAPI.openSourceSelector).not.toHaveBeenCalled();
+	});
+
+	it("keeps the HUD interactive on Linux so the drag handle can receive pointer events", async () => {
+		platformState.value = "linux";
+
+		renderLaunchWindow();
+
+		await waitFor(() => {
+			expect(window.electronAPI.setHudOverlayIgnoreMouseEvents).toHaveBeenLastCalledWith(false);
+		});
 	});
 });

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -143,6 +143,7 @@ export function LaunchWindow() {
 		() => loadUserPreferences().trayLayout,
 	);
 	const [supportsCursorModeToggle, setSupportsCursorModeToggle] = useState(false);
+	const [isLinuxHud, setIsLinuxHud] = useState(false);
 	const languageTriggerRef = useRef<HTMLButtonElement | null>(null);
 	const languageMenuPanelRef = useRef<HTMLDivElement | null>(null);
 	const hudBarRef = useRef<HTMLDivElement | null>(null);
@@ -212,11 +213,13 @@ export function LaunchWindow() {
 			.then((platform) => {
 				if (!cancelled) {
 					setSupportsCursorModeToggle(platform === "win32" || platform === "darwin");
+					setIsLinuxHud(platform === "linux");
 				}
 			})
 			.catch(() => {
 				if (!cancelled) {
 					setSupportsCursorModeToggle(false);
+					setIsLinuxHud(false);
 				}
 			});
 
@@ -400,14 +403,18 @@ export function LaunchWindow() {
 		[observeHudElement],
 	);
 
-	const hudMouseEventsEnabledRef = useRef<boolean | undefined>(undefined);
-	const setHudMouseEventsEnabled = useCallback((enabled: boolean) => {
-		if (hudMouseEventsEnabledRef.current === enabled) {
-			return;
-		}
-		hudMouseEventsEnabledRef.current = enabled;
-		window.electronAPI?.setHudOverlayIgnoreMouseEvents?.(!enabled);
-	}, []);
+	const hudIgnoreMouseEventsRef = useRef<boolean | undefined>(undefined);
+	const setHudMouseEventsEnabled = useCallback(
+		(enabled: boolean) => {
+			const shouldIgnoreMouseEvents = !enabled && !isLinuxHud;
+			if (hudIgnoreMouseEventsRef.current === shouldIgnoreMouseEvents) {
+				return;
+			}
+			hudIgnoreMouseEventsRef.current = shouldIgnoreMouseEvents;
+			window.electronAPI?.setHudOverlayIgnoreMouseEvents?.(shouldIgnoreMouseEvents);
+		},
+		[isLinuxHud],
+	);
 
 	useEffect(() => {
 		setHudMouseEventsEnabled(false);


### PR DESCRIPTION
Fixes #12

## Problem
On Linux (Manjaro KDE Wayland), the HUD launch widget shows a drag handle but cannot be moved: clicks on the handle have no effect and the window stays stuck in place. macOS and Windows are unaffected.

## Root cause
`LaunchWindow` toggles the HUD overlay into `setIgnoreMouseEvents(true)` whenever the pointer leaves interactive regions. On macOS/Windows this is fine because `setIgnoreMouseEvents` only affects regions marked as "transparent" — but on Linux/Wayland the whole window stops receiving pointer events, so the drag handle never sees the `pointerdown` that starts a drag.

## Fix
In `src/components/launch/LaunchWindow.tsx`, treat the HUD as always interactive on Linux:

- Track the platform via `getPlatform()` and keep an `isLinuxHud` flag.
- When computing the value sent to Electron, force `shouldIgnoreMouseEvents = false` on Linux.
- Adjust the IPC cache so the cache key reflects the value actually sent, not just the React "enabled" flag — otherwise a platform switch could fail to push an update to Electron.

## Test
Added a unit test in `src/components/launch/LaunchWindow.test.tsx`:
- Mocks `getPlatform` to return `linux`.
- Renders `LaunchWindow` and asserts `setHudOverlayIgnoreMouseEvents` is called with `false`, so the HUD stays clickable.

## Validation
- `npx vitest --run src/components/launch/LaunchWindow.test.tsx` passes.
- `npm run build-vite` passes.
- Pre-commit Biome hook passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved HUD overlay behavior on Linux systems—the overlay now remains interactive instead of becoming unresponsive when certain toggles are adjusted, enhancing user experience on Linux platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->