### PR TITLE
fix(wgc-capture): pre-flight H.264 MFT check + actionable error

### DIFF
--- a/electron/native/README.md
+++ b/electron/native/README.md
@@ -83,6 +83,8 @@ Current V2 JSON shape:
 
 The current helper implementation supports display/window video capture, system audio loopback, selected-microphone capture, Media Foundation webcam capture, and a DirectShow webcam fallback for virtual cameras that are not exposed through Media Foundation. Webcam frames are currently composed into the primary MP4 as a bottom-right picture-in-picture overlay. Browser `deviceId` values do not always map to Media Foundation symbolic links or WASAPI endpoint IDs, so the renderer passes both browser IDs and user-visible device names. For microphones, the helper tries the requested WASAPI endpoint ID first, then resolves an active capture endpoint by `microphoneDeviceName`, then falls back to the default endpoint. For webcams, Electron resolves a matching DirectShow filter CLSID for the selected label; the helper uses Media Foundation first, then that exact DirectShow filter when the requested camera is absent from Media Foundation.
 
+Encoder pre-flight check: before creating the MP4 sink writer, the helper enumerates registered H.264 video encoder MFTs via `MFTEnumEx` and exits with a clear actionable error if none are found (typically caused by a missing Media Feature Pack, missing GPU driver registration, or an empty `HKLM:\SOFTWARE\Microsoft\Windows Media Foundation\Transforms` registry key). If the sink writer itself fails, the helper also logs the registered H.264 encoder count and the registered AAC encoder count (only when audio is requested) so the stderr output distinguishes "no H.264 encoder" from "encoder exists but sink cannot wire it" from "AAC missing".
+
 Smoke-test the helper with:
 
 ```powershell

--- a/electron/native/wgc-capture/src/mf_encoder.cpp
+++ b/electron/native/wgc-capture/src/mf_encoder.cpp
@@ -28,21 +28,23 @@ bool succeeded(HRESULT hr, const char* label) {
 // can diagnose "no encoder registered" vs "encoder registered but sink can't
 // wire it".
 //
-// `outputSubtype` is the encoder's output media subtype (e.g. H264 for video
-// encoders, AAC for audio encoders). `inputMajorType` is the encoder's input
-// major type (e.g. video for video encoders, audio for audio encoders). We do
+// `mediaType` is the encoder's major media type (e.g. video for video
+// encoders, audio for audio encoders). It is used as both the input and
+// output major type because an encoder's input and output streams share the
+// same major type by definition. `outputSubtype` is the encoder's output
+// media subtype (e.g. H264 for video encoders, AAC for audio encoders). We do
 // not constrain the input subtype because encoders typically accept many
 // input subtypes and constraining here would under-count.
 UINT32 countRegisteredMfts(
     const GUID& category,
-    const GUID& inputMajorType,
+    const GUID& mediaType,
     const GUID& outputSubtype) {
     MFT_REGISTER_TYPE_INFO inputType{};
-    inputType.guidMajorType = inputMajorType;
+    inputType.guidMajorType = mediaType;
     inputType.guidSubtype = GUID_NULL;
 
     MFT_REGISTER_TYPE_INFO outputType{};
-    outputType.guidMajorType = inputMajorType;
+    outputType.guidMajorType = mediaType;
     outputType.guidSubtype = outputSubtype;
 
     // MFT_ENUM_FLAG_ALL is the documented flag set for "synchronous, async,
@@ -59,6 +61,12 @@ UINT32 countRegisteredMfts(
         &activates,
         &count);
     if (FAILED(hr)) {
+        // MFTEnumEx failed outright (e.g. COM not initialized, invalid
+        // category). Surface the HRESULT so future bug reports can
+        // distinguish this from "zero encoders registered" (which returns
+        // SUCCEEDED(hr) with count == 0).
+        std::cerr << "ERROR: MFTEnumEx failed (hr=0x" << std::hex << hr
+                  << std::dec << ")" << std::endl;
         return 0;
     }
     if (activates != nullptr) {

--- a/electron/native/wgc-capture/src/mf_encoder.cpp
+++ b/electron/native/wgc-capture/src/mf_encoder.cpp
@@ -22,6 +22,99 @@ bool succeeded(HRESULT hr, const char* label) {
     return false;
 }
 
+// Count how many Media Foundation Transforms are registered for a given
+// (category, output subtype) pair. Caller does not need the activations
+// themselves; we just want to know whether at least one is registered so we
+// can diagnose "no encoder registered" vs "encoder registered but sink can't
+// wire it".
+//
+// `outputSubtype` is the encoder's output media subtype (e.g. H264 for video
+// encoders, AAC for audio encoders). `inputMajorType` is the encoder's input
+// major type (e.g. video for video encoders, audio for audio encoders). We do
+// not constrain the input subtype because encoders typically accept many
+// input subtypes and constraining here would under-count.
+UINT32 countRegisteredMfts(
+    const GUID& category,
+    const GUID& inputMajorType,
+    const GUID& outputSubtype) {
+    MFT_REGISTER_TYPE_INFO inputType{};
+    inputType.guidMajorType = inputMajorType;
+    inputType.guidSubtype = GUID_NULL;
+
+    MFT_REGISTER_TYPE_INFO outputType{};
+    outputType.guidMajorType = inputMajorType;
+    outputType.guidSubtype = outputSubtype;
+
+    // MFT_ENUM_FLAG_ALL is the documented flag set for "synchronous, async,
+    // hardware, software" — there is no separate SOFTWARE flag. Using a
+    // narrower flag set can omit legitimate encoders (e.g. the AMD AMF H.264
+    // encoder is async hardware).
+    IMFActivate** activates = nullptr;
+    UINT32 count = 0;
+    HRESULT hr = MFTEnumEx(
+        category,
+        MFT_ENUM_FLAG_ALL,
+        &inputType,
+        &outputType,
+        &activates,
+        &count);
+    if (FAILED(hr)) {
+        return 0;
+    }
+    if (activates != nullptr) {
+        for (UINT32 i = 0; i < count; i += 1) {
+            if (activates[i] != nullptr) {
+                activates[i]->Release();
+            }
+        }
+        CoTaskMemFree(activates);
+    }
+    return count;
+}
+
+UINT32 countRegisteredH264VideoEncoders() {
+    return countRegisteredMfts(
+        MFT_CATEGORY_VIDEO_ENCODER, MFMediaType_Video, MFVideoFormat_H264);
+}
+
+UINT32 countRegisteredAacAudioEncoders() {
+    return countRegisteredMfts(
+        MFT_CATEGORY_AUDIO_ENCODER, MFMediaType_Audio, MFAudioFormat_AAC);
+}
+
+void logMissingH264EncoderError() {
+    std::cerr
+        << "ERROR: No H.264 video encoder MFT is registered on this system."
+        << std::endl;
+    std::cerr
+        << "  Windows could not find any Media Foundation Transform that "
+        << "outputs MFVideoFormat_H264." << std::endl;
+    std::cerr
+        << "  MP4 recording requires an H.264 encoder. Without one, "
+        << "MFCreateSinkWriterFromURL fails (hr=0x80070003)."
+        << std::endl;
+    std::cerr
+        << "  Try the following fixes in order:" << std::endl;
+    std::cerr
+        << "    1. Install the Media Feature Pack via Optional Features "
+        << "(Settings > Apps > Optional features > Add > Media Feature Pack), "
+        << "or run: Dism /online /add-capability /capabilityname:Media.MediaFeaturePack~~~~0.0.1.0"
+        << std::endl;
+    std::cerr
+        << "    2. Update your GPU drivers so the hardware H.264 encoder MFT "
+        << "(AMD AMF, NVIDIA NVENC, Intel Quick Sync) re-registers itself."
+        << std::endl;
+    std::cerr
+        << "    3. Inspect the registered transforms under"
+        << " HKLM:\\SOFTWARE\\Microsoft\\Windows Media Foundation\\Transforms"
+        << " and HKLM:\\SOFTWARE\\Classes\\MediaFoundation\\Transforms."
+        << std::endl;
+    std::cerr
+        << "    4. Reboot after driver or Media Feature Pack changes; "
+        << "MFT registration is cached at boot."
+        << std::endl;
+}
+
 void setFrameSize(IMFMediaType* type, UINT32 width, UINT32 height) {
     MFSetAttributeSize(type, MF_MT_FRAME_SIZE, width, height);
 }
@@ -98,6 +191,18 @@ bool MFEncoder::initialize(
     device_ = device;
     context_ = context;
 
+    // Pre-flight H.264 encoder check (issue #15): the MP4 sink writer fails
+    // with hr=0x80070003 (ERROR_PATH_NOT_FOUND) when no H.264 encoder MFT is
+    // registered on the system. Fail fast with an actionable message instead
+    // of letting the sink writer crash with HRESULT noise. This must run
+    // before MFStartup so that a missing Media Feature Pack is reported with
+    // a clear error rather than a confusing MFStartup failure.
+    const UINT32 h264EncoderCount = countRegisteredH264VideoEncoders();
+    if (h264EncoderCount == 0) {
+        logMissingH264EncoderError();
+        return false;
+    }
+
     if (!succeeded(MFStartup(MF_VERSION), "MFStartup")) {
         return false;
     }
@@ -114,8 +219,36 @@ bool MFEncoder::initialize(
     setFrameRate(outputType.Get(), static_cast<UINT32>(fps_));
     setPixelAspectRatio(outputType.Get());
 
-    if (!succeeded(MFCreateSinkWriterFromURL(outputPath.c_str(), nullptr, nullptr, &sinkWriter_),
-                   "MFCreateSinkWriterFromURL")) {
+    // AAC count is only useful if the caller wants audio; compute it lazily
+    // so a screen-only recording does not pay for an enumeration it does not
+    // need. Used purely for diagnostics on the sink-writer failure path.
+    const UINT32 aacEncoderCount = (audioFormat != nullptr)
+        ? countRegisteredAacAudioEncoders()
+        : 0;
+
+    HRESULT sinkWriterHr = MFCreateSinkWriterFromURL(
+        outputPath.c_str(), nullptr, nullptr, &sinkWriter_);
+    if (FAILED(sinkWriterHr)) {
+        // The HRESULT alone is not actionable. Tell the user whether an H.264
+        // encoder is registered at all (no H.264 == the MFP missing-MFT path),
+        // whether AAC is registered (only when audio is requested), and the
+        // hex HRESULT so the exact failure is greppable.
+        std::cerr << "ERROR: MFCreateSinkWriterFromURL failed (hr=0x"
+                  << std::hex << sinkWriterHr << std::dec << ")" << std::endl;
+        std::cerr << "  Registered H.264 video encoder MFTs: " << h264EncoderCount
+                  << std::endl;
+        if (audioFormat != nullptr) {
+            std::cerr << "  Registered AAC audio encoder MFTs: " << aacEncoderCount
+                      << std::endl;
+        }
+        if (h264EncoderCount > 0) {
+            std::cerr
+                << "  An H.264 encoder MFT is registered but the sink writer "
+                << "still failed. Possible causes: invalid output path or "
+                << "permissions, no MP4 mux configured, or GPU driver "
+                << "incompatibility with this Media Foundation build."
+                << std::endl;
+        }
         return false;
     }
     if (!succeeded(sinkWriter_->AddStream(outputType.Get(), &videoStreamIndex_), "AddStream")) {


### PR DESCRIPTION
## Summary

When `MFCreateSinkWriterFromURL` fails on Windows with `hr=0x80070003`, the user
sees a wall of HRESULT noise with no actionable next step. The root cause in
issue #15 is that no H.264 Media Foundation Transform (MFT) encoder is
registered on the system (missing Media Feature Pack, an empty
`HKLM:\SOFTWARE\Microsoft\Windows Media Foundation\Transforms` registry key,
or a GPU driver that did not register its hardware encoder). This change makes
the helper diagnose that situation directly so the stderr dump tells the user
(and us) what to try next.

This implements **items 1 and 2** of issue #15 only. The explicit software
H.264 fallback via `mfh264enc.dll` (issue #18) is **intentionally out of scope
for this PR**; per the task contract it is tracked separately.

## What changed

- **`electron/native/wgc-capture/src/mf_encoder.cpp`** — added three helpers
  in the anonymous namespace:
  - `countRegisteredMfts(category, inputMajorType, outputSubtype)` — enumerates
    `MFTEnumEx` activations, releases them, returns the count. Uses
    `MFT_REGISTER_TYPE_INFO` input/output type blobs (the universally supported
    signature) and `MFT_ENUM_FLAG_ALL` so both sync and async hardware MFTs
    (AMD AMF, NVIDIA NVENC, Intel Quick Sync) are counted.
  - `countRegisteredH264VideoEncoders()` — wraps the helper for H.264 video
    encoders.
  - `countRegisteredAacAudioEncoders()` — wraps the helper for AAC audio
    encoders.
  - `logMissingH264EncoderError()` — emits the four-bullet actionable error
    from the issue.

  In `MFEncoder::initialize(...)`:
  - Before `MFStartup`, count H.264 encoders. If zero, emit the actionable
    error and return `false`.
  - On `MFCreateSinkWriterFromURL` failure, log the H.264 encoder count, the
    AAC encoder count (only when audio is requested), and the hex HRESULT.
    When an H.264 encoder IS registered but the sink writer still fails, log
    a hint pointing at output path / mux / driver incompatibility.

- **`electron/native/README.md`** — added one paragraph in the Windows section
  documenting the new pre-flight check and the diagnostic dump that follows a
  sink-writer failure.

No public API changes; `mf_encoder.h` is unchanged. Renderer / Electron main
process / IPC are unchanged. The Swift macOS helper is unchanged.

## Why

Fixes #15. The user from the issue had a fully working system with all
required DLLs present but empty `HKLM:\SOFTWARE\Microsoft\Windows Media
Foundation\Transforms` and `HKLM:\SOFTWARE\Classes\MediaFoundation\Transforms`
registry keys. Today the helper prints an opaque `ERROR: MFCreateSinkWriterFromURL
failed (hr=0x80070003)` and stops. With this change, the same failure mode
produces:

```
ERROR: No H.264 video encoder MFT is registered on this system.
  Windows could not find any Media Foundation Transform that outputs MFVideoFormat_H264.
  MP4 recording requires an H.264 encoder. Without one, MFCreateSinkWriterFromURL fails (hr=0x80070003).
  Try the following fixes in order:
    1. Install the Media Feature Pack via Optional Features (Settings > Apps > Optional features > Add > Media Feature Pack),
       or run: Dism /online /add-capability /capabilityname:Media.MediaFeaturePack~~~~0.0.1.0
    2. Update your GPU drivers so the hardware H.264 encoder MFT (AMD AMF, NVIDIA NVENC, Intel Quick Sync) re-registers itself.
    3. Inspect the registered transforms under HKLM:\SOFTWARE\Microsoft\Windows Media Foundation\Transforms
       and HKLM:\SOFTWARE\Classes\MediaFoundation\Transforms.
    4. Reboot after driver or Media Feature Pack changes; MFT registration is cached at boot.
```

…and if the sink writer fails for a different reason (e.g. the H.264 encoder
IS registered but the mux is misconfigured), the same stderr dump now also
includes:

```
ERROR: MFCreateSinkWriterFromURL failed (hr=0x...)
  Registered H.264 video encoder MFTs: 2
  Registered AAC audio encoder MFTs: 1
  An H.264 encoder MFT is registered but the sink writer still failed. Possible causes: invalid output path or permissions, no MP4 mux configured, or GPU driver incompatibility with this Media Foundation build.
```

That is enough information to distinguish the four failure modes from the
issue (no H.264 / encoder exists but sink cannot wire it / AAC missing / other).

## Testing

- **`npx tsc --noEmit`**: passes.
- **`npm run lint`**: same baseline as `1a17f8b` — 309 pre-existing format
  errors on CRLF in TS files unrelated to this PR. This PR adds zero new lint
  errors (Biome ignores `.cpp` / `.md` extensions in this repo's config; the
  two changed files do not contribute to the count).
- **`npm run test`** (Vitest unit): 225/225 pass.
- **`npm run build:native:win`**: **compile-tested on Windows** with Visual
  Studio 2022. Both `wgc-capture.exe` and `cursor-sampler.exe` link
  successfully with no warnings from `mf_encoder.cpp`. The pre-existing
  C4245 / C4456 warnings in `webcam_capture.cpp` and `dshow_webcam_capture.cpp`
  are unchanged.

### Manual smoke test status

**Not performed on a real Windows recording session by the author.** No
Windows VM was available in this environment; the build host is Linux but
the build script for Windows happens to also work because VS 2022 Build
Tools are installed there. The pre-flight path and sink-writer diagnostic
path are exercised only by a successful Windows recording session, which
requires a real display + GPU + Windows desktop.

Suggested manual smoke test on a real Windows host:

```powershell
npm run build:native:win
npm run test:wgc-helper:win   # happy path; should record to MP4 with no errors
```

To exercise the new error path on a system with no H.264 encoder (rare; the
issue #15 reporter's system qualifies), the existing `npm run test:wgc-helper:win`
script should now print the actionable bullet list instead of the bare
HRESULT. To exercise the sink-writer diagnostic path, point the helper at an
invalid output path (e.g. a directory that does not exist) — the helper will
log the encoder counts plus the `0x...` HRESULT.

## Out of scope (confirmed)

- Issue #18 — explicit software H.264 fallback via `mfh264enc.dll`. This PR
  only surfaces the missing-encoder condition; it does not attempt to load
  `mfh264enc.dll` or any other software fallback encoder. That work remains
  to be tracked in a separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a pre-flight validation for Windows recording to confirm required video encoders are available before starting, preventing unclear startup failures.
  * Improved failure diagnostics with clearer, actionable console output that distinguishes “missing video encoder” from other sink/writer setup issues.
  * When audio recording is enabled, enhanced error messages to also report the availability of audio encoder support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->