### PR TITLE
docs: add Discord badge, tech/platform badges, and Need help link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,26 +20,10 @@
   <a href="https://github.com/EtienneLescot/openscreen/blob/main/LICENSE"><img src="https://img.shields.io/github/license/EtienneLescot/openscreen?style=for-the-badge&label=License" alt="License" /></a>
   <a href="https://github.com/EtienneLescot/openscreen/releases/latest"><img src="https://img.shields.io/github/v/release/EtienneLescot/openscreen?style=for-the-badge&label=Release" alt="Latest Release" /></a>
   <a href="https://github.com/EtienneLescot/openscreen/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/EtienneLescot/openscreen/ci.yml?style=for-the-badge&label=CI" alt="CI Status" /></a>
-</p>
-
-<p align="center">
   <a href="https://discord.gg/VvT6Vtnyh"><img src="https://img.shields.io/badge/Discord-Join%20us-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" /></a>
-  <a href="https://github.com/EtienneLescot/openscreen/stargazers"><img src="https://img.shields.io/github/stars/EtienneLescot/openscreen?style=for-the-badge&logo=github&label=Stars" alt="Stars" /></a>
+  <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey?style=for-the-badge" alt="Platform" />
 </p>
 
-<p align="center">
-  <img src="https://img.shields.io/badge/Electron-47848F?style=for-the-badge&logo=electron&logoColor=white" alt="Electron" />
-  <img src="https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white" alt="TypeScript" />
-  <img src="https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB" alt="React" />
-</p>
-
-<p align="center">
-  <img src="https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS" />
-  <img src="https://img.shields.io/badge/Windows-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows" />
-  <img src="https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux" />
-</p>
-
-<p align="center">💬 <strong>Need help?</strong> <a href="https://discord.gg/VvT6Vtnyh">Join the OpenScreen Discord</a></p>
 
 OpenScreen was originally positioned as a free, open-source alternative to Screen Studio: something you can use to create quick, polished product demos and walkthroughs for X, Reddit, YouTube, documentation, landing pages, or internal demos.
 
@@ -176,6 +160,13 @@ Official / trusted links:
 * Community continuation: https://github.com/EtienneLescot/openscreen
 
 For safety, download OpenScreen only from the official GitHub Releases linked from this repository. Third-party websites using the OpenScreen name are not affiliated with this continuation unless explicitly listed here.
+
+## Community
+
+OpenScreen is community-driven. If you need help, want to report a bug, or just want to chat with other users and contributors:
+
+- 💬 **Discord** — [Join the OpenScreen Discord](https://discord.gg/VvT6Vtnyh) for real-time help, showcase, and discussion
+- 🐞 **GitHub Issues** — bug reports and feature requests
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,31 @@
 
 <p align="center"><strong>OpenScreen is a free, open-source tool for creating polished screen recordings, product demos, and walkthroughs.</strong></p>
 
+<p align="center">
+  <a href="https://github.com/EtienneLescot/openscreen/blob/main/LICENSE"><img src="https://img.shields.io/github/license/EtienneLescot/openscreen?style=for-the-badge&label=License" alt="License" /></a>
+  <a href="https://github.com/EtienneLescot/openscreen/releases/latest"><img src="https://img.shields.io/github/v/release/EtienneLescot/openscreen?style=for-the-badge&label=Release" alt="Latest Release" /></a>
+  <a href="https://github.com/EtienneLescot/openscreen/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/EtienneLescot/openscreen/ci.yml?style=for-the-badge&label=CI" alt="CI Status" /></a>
+</p>
+
+<p align="center">
+  <a href="https://discord.gg/VvT6Vtnyh"><img src="https://img.shields.io/badge/Discord-Join%20us-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" /></a>
+  <a href="https://github.com/EtienneLescot/openscreen/stargazers"><img src="https://img.shields.io/github/stars/EtienneLescot/openscreen?style=for-the-badge&logo=github&label=Stars" alt="Stars" /></a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Electron-47848F?style=for-the-badge&logo=electron&logoColor=white" alt="Electron" />
+  <img src="https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white" alt="TypeScript" />
+  <img src="https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB" alt="React" />
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS" />
+  <img src="https://img.shields.io/badge/Windows-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows" />
+  <img src="https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux" />
+</p>
+
+<p align="center">💬 <strong>Need help?</strong> <a href="https://discord.gg/VvT6Vtnyh">Join the OpenScreen Discord</a></p>
+
 OpenScreen was originally positioned as a free, open-source alternative to Screen Studio: something you can use to create quick, polished product demos and walkthroughs for X, Reddit, YouTube, documentation, landing pages, or internal demos.
 
 It is not a 1:1 clone of Screen Studio. Screen Studio is an excellent commercial product. OpenScreen focuses on covering the core open-source workflow: recording, zooms, cursor effects, webcam overlay, captions, editing, annotations, and export.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ For safety, download OpenScreen only from the official GitHub Releases linked fr
 OpenScreen is community-driven. If you need help, want to report a bug, or just want to chat with other users and contributors:
 
 - 💬 **Discord** — [Join the OpenScreen Discord](https://discord.gg/VvT6Vtnyh) for real-time help, showcase, and discussion
-- 🐞 **GitHub Issues** — bug reports and feature requests
+- 🐞 **[GitHub Issues](https://github.com/EtienneLescot/openscreen/issues)** — bug reports and feature requests
 
 ---
 


### PR DESCRIPTION
Adds a row of dynamic badges to the top of the README (license, latest release, CI status, Discord, stars, tech stack, supported platforms), plus a \Need help?\ callout in the body pointing at the OpenScreen Discord.

**Changes**
- 4 centered rows of badges under the subtitle (status / community / stack / platforms)
- One-line \Need help?\ link to the Discord right below the badges

**Source of truth**
- Discord invite: https://discord.gg/VvT6Vtnyh
- All other badges pull from the GitHub repo (license, releases, Actions workflows, stargazers)
- Tech/platform badges are static (Electron / TypeScript / React / macOS / Windows / Linux)

<!-- discord-thread-id:1519293379316420739 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README with a new badge section near the top, including license, release, build status, community, stars, and platform/technology badges.
  * Added a clearer “Need help?” link for quick access to community support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->