### PR TITLE
ci(discord): post roadmap changes via bot instead of webhook

### DIFF
--- a/.github/workflows/discord.yaml
+++ b/.github/workflows/discord.yaml
@@ -520,10 +520,18 @@ jobs:
   # `notify` job above syncs PR activity to the 🔎・pr-reviews channel —
   # the user-facing community gets pinged in Discord when the roadmap moves.
   #
-  # Required secret:
-  #   DISCORD_ROADMAP_WEBHOOK_URL — webhook URL of the #🗺️・roadmap channel
-  # Optional (re-used from the existing notify job):
-  #   DISCORD_WEBHOOK_USERNAME, DISCORD_WEBHOOK_AVATAR_URL
+  # Posts via the openscreen_etienne bot (same one as the notify job) rather
+  # than a channel-scoped webhook, so the bot's identity is preserved and we
+  # don't accumulate one webhook per channel.
+  #
+  # Required:
+  #   DISCORD_BOT_TOKEN — bot token of the openscreen_etienne app (secret)
+  #   DISCORD_ROADMAP_CHANNEL_ID — channel id of #🗺️・roadmap
+  #     (GitHub Actions var, not secret — channel ids are public info)
+  #
+  # Per-channel permission required on the Discord side:
+  #   The bot's role must have "Send Messages" allowed on #🗺️・roadmap
+  #   (set as a channel-level permission override; do not grant globally).
   roadmap-notify:
     if: github.event_name == 'pull_request_target'
     concurrency:
@@ -535,9 +543,8 @@ jobs:
         continue-on-error: true
         uses: actions/github-script@v7
         env:
-          DISCORD_ROADMAP_WEBHOOK_URL: ${{ secrets.DISCORD_ROADMAP_WEBHOOK_URL }}
-          DISCORD_WEBHOOK_USERNAME: ${{ secrets.DISCORD_WEBHOOK_USERNAME }}
-          DISCORD_WEBHOOK_AVATAR_URL: ${{ secrets.DISCORD_WEBHOOK_AVATAR_URL }}
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_ROADMAP_CHANNEL_ID: ${{ vars.DISCORD_ROADMAP_CHANNEL_ID }}
         with:
           script: |
             const ROADMAP_PATTERN = /(^|\/)ROADMAP\.md$|(^|\/)docs\/roadmap\.md$/i;
@@ -575,14 +582,15 @@ jobs:
               return;
             }
 
-            const webhookUrl = (process.env.DISCORD_ROADMAP_WEBHOOK_URL || "").trim();
-            if (!webhookUrl) {
-              core.info("DISCORD_ROADMAP_WEBHOOK_URL not set; skipping roadmap notify. Add it as a repo secret to enable #🗺️・roadmap auto-posts.");
+            const botToken = (process.env.DISCORD_BOT_TOKEN || "").trim();
+            const channelId = (process.env.DISCORD_ROADMAP_CHANNEL_ID || "").trim();
+            if (!botToken || !channelId) {
+              core.info(
+                "DISCORD_BOT_TOKEN or DISCORD_ROADMAP_CHANNEL_ID not set; skipping roadmap notify. " +
+                "Configure DISCORD_BOT_TOKEN as a repo secret and DISCORD_ROADMAP_CHANNEL_ID as a repo variable to enable #🗺️・roadmap auto-posts."
+              );
               return;
             }
-
-            const webhookUsername = (process.env.DISCORD_WEBHOOK_USERNAME || "OpenScreen").trim();
-            const webhookAvatar = (process.env.DISCORD_WEBHOOK_AVATAR_URL || "").trim();
 
             const fileList = roadmapFiles.map(f => {
               const icon = f.status === "added" ? "🆕" : f.status === "removed" ? "🗑️" : "✏️";
@@ -596,9 +604,11 @@ jobs:
 
             const description = (pr.body || "No description provided.").trim() || "No description provided.";
 
+            // Posted via bot token: username / avatar overrides are not
+            // supported on POST /channels/{id}/messages, so the bot's
+            // configured identity (set in the Discord Developer Portal)
+            // is what shows up in #🗺️・roadmap.
             const payload = {
-              username: webhookUsername,
-              ...(webhookAvatar ? { avatar_url: webhookAvatar } : {}),
               content: `${titlePrefix} via PR #${pr.number}`,
               embeds: [
                 {
@@ -619,9 +629,12 @@ jobs:
             };
 
             try {
-              const res = await fetch(`${webhookUrl}?wait=true`, {
+              const res = await fetch(`https://discord.com/api/v10/channels/${channelId}/messages`, {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers: {
+                  "Authorization": `Bot ${botToken}`,
+                  "Content-Type": "application/json",
+                },
                 body: JSON.stringify(payload),
               });
               if (!res.ok) {
@@ -629,7 +642,7 @@ jobs:
                 core.warning(`Roadmap Discord notify failed ${res.status}: ${txt}`);
                 return;
               }
-              core.info(`Roadmap Discord notify posted for PR #${pr.number} (${roadmapFiles.length} file(s)).`);
+              core.info(`Roadmap Discord notify posted for PR #${pr.number} (${roadmapFiles.length} file(s)) to channel ${channelId}.`);
             } catch (err) {
               core.warning(`Roadmap Discord notify threw: ${err && err.message ? err.message : err}`);
             }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@ Pulled from real user bug reports on getopenscreen/openscreen. This is the queue
 - [ ] **Feature:** copy / paste attributes & effects in the timeline — [#24](../../issues/24). Right-click menu + standard Ctrl/Cmd+C / Ctrl/Cmd+V shortcuts.
 
 ## 📬 How to influence this roadmap
-- **Discord** — join the OpenScreen Discord and post in [#🗺️・roadmap](). The fastest way to get a thumbs-up or thumbs-down on a feature.
+- **Discord** — join the OpenScreen Discord and post in [#🗺️・roadmap](https://discord.com/channels/1489517664467681310/1493586210675884265). The fastest way to get a thumbs-up or thumbs-down on a feature.
 - **GitHub** — open an issue with the `enhancement` label, or react with 👍 / 👎 on existing items.
 - **PRs** — if you want to ship one of these, open a PR and link the relevant issue. We review fast and help with native-bridge / i18n questions.
 


### PR DESCRIPTION
Replaces \DISCORD_ROADMAP_WEBHOOK_URL\ with \DISCORD_BOT_TOKEN\ + \DISCORD_ROADMAP_CHANNEL_ID\ so roadmap notifications use the same \openscreen_etienne\ bot as PR thread sync.

## Why

- Avoids accumulating one channel-scoped webhook per Discord channel
- Preserves the bot's identity (no fake \username\/\vatar_url\ override — the bot endpoint doesn't accept those anyway)
- Reuses the existing bot token secret

## Required setup after merge

1. **Per-channel permission** on \#🗺️・roadmap\ (Discord side):
   - Edit Channel → Permissions → add the bot's role → Allow: **Send Messages**
   - Channel-level override, do not grant globally
2. **GitHub Actions variable**: \DISCORD_ROADMAP_CHANNEL_ID\ = \1493586210675884265\
   - \https://github.com/getopenscreen/openscreen/settings/variables/actions\
3. *(Optional)* Remove the now-unused \DISCORD_ROADMAP_WEBHOOK_URL\ secret if you never created it.

## Test plan

- Open a dummy PR that touches \ROADMAP.md\
- Verify a message lands in \#🗺️・roadmap\ from the bot identity
- If you see a 403 in the run log → check the Send Messages override

## Out of scope

- The \#🗺️・roadmap\()\ empty link in \ROADMAP.md\ line 44 (separate concern, will fix in follow-up)

<!-- discord-thread-id:1519338513378574388 -->