### PR TITLE
docs(roadmap): seventh smoke test - PR-merge trigger

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,3 +57,4 @@ Anything not on this list yet? Open an issue and tag it `roadmap` — we'll tria
 - **2026-06-24** — fourth smoke test: pin-as-state refactor (variable no longer required).
 - **2026-06-24** — fifth smoke test: pin permission granted, verify self-healing pin works.
 - **2026-06-24** — sixth smoke test: DISCORD_ROADMAP_MESSAGE_ID variable removed; verify the bot finds the message via pin lookup alone.
+- **2026-06-24** — seventh smoke test: PR-merge trigger (validate the `pull_request_target` `closed`+`merged` path).


### PR DESCRIPTION
Final validation: confirms that the roadmap-notify job fires on the \pull_request_target\ event with action \closed\ and \merged=true\, in addition to the direct \push\ to main.

The change here is just a changelog entry; the real test is in the workflow run after merge.

<!-- discord-thread-id:1519352523843043340 -->