### PR TITLE
chore(release): bump to 1.5.1-rc.99

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "openscreen",
 	"private": true,
-	"version": "1.5.0",
+	"version": "1.5.1-rc.99",
 	"type": "module",
 	"packageManager": "npm@10.9.4",
 	"engines": {


### PR DESCRIPTION
Automated version bump from the prerelease workflow. Rebase-merged via PAT; bypass applies because EtienneLescot is a ruleset bypass actor.

<!-- discord-thread-id:1521431771760037930 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to `1.5.1-rc.99` for the next release candidate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->