### PR TITLE
docs(secrets): fix typo in header

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,6 +1,6 @@
 # Secrets and tokens
 
-OpenScreen uses a small set of GitHub Actions secrets and repository variables. This file documents what each one does and how to create or rotate it.
+OpenScreen uses a small set of GitHub Actions secrets and repository variables. This file documents what each one does and how to create or rotate them.
 
 ## Required for releases
 


### PR DESCRIPTION
Trivial typo to trigger the Discord PR-sync workflow and validate the bot setup end-to-end.

<!-- discord-thread-id:1521493112331960351 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the wording in the secrets documentation for clearer grammar and consistency when referring to multiple secrets or variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->