### PR TITLE
chore: bump nix package to v1.6.0

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -11,7 +11,7 @@
 buildNpmPackage {
   nodejs = nodejs_22;
   pname = "openscreen";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src =
     let
@@ -33,7 +33,7 @@ buildNpmPackage {
       );
     };
 
-  npmDepsHash = "sha256-lx38H0qG5IrjQRekLG2N+x90Zq/emPfbxOo/qDSn7iE=";
+  npmDepsHash = "sha256-IZypOLWlDShIjCKWxlJcrdtIkMu0P/DuXaq4c0HW3FY=";
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 


### PR DESCRIPTION
Automated bump triggered by release `v1.6.0` (the workflow's `gh pr create` step hit the org-level GITHUB_TOKEN restriction, so the PR is being opened manually from the already-pushed branch).

- `version` → `1.6.0`
- `npmDepsHash` → `sha256-IZypOLWlDShIjCKWxlJcrdtIkMu0P/DuXaq4c0HW3FY=` (computed via `prefetch-npm-deps package-lock.json`)

Merge this so Nix users (NixOS, Home Manager, `nix run github:getopenscreen/openscreen`) pick up the new release.

<!-- discord-thread-id:1523253764805365792 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the package version to 1.6.0 and refreshed the dependency checksum to match the latest package contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->