### PR TITLE
fix(export): project native cursor onto cropped rect, not mask rect

### DIFF
--- a/electron/native-bridge/cursor/recording/windowsNativeRecordingSession.ts
+++ b/electron/native-bridge/cursor/recording/windowsNativeRecordingSession.ts
@@ -229,15 +229,16 @@ export class WindowsNativeRecordingSession implements CursorRecordingSession {
 		// The cursor-sampler reports raw x/y in physical screen pixels (Win32
 		// GetCursorInfo). `payload.bounds` from the sampler's GetWindowRect is also
 		// physical, so use it as-is. Bounds from Electron's `screen` API (or the
-		// fallback for display captures) are logical pixels (DIP) â€” convert to
-		// physical via the display's scaleFactor so the normalized position matches
-		// the WGC video, which is captured in physical pixels.
-		const isPhysicalBounds = payload.bounds != null;
-		const scaleFactor = isPhysicalBounds ? 1 : (screen.getDisplayMatching(bounds).scaleFactor ?? 1);
-		const physicalX = bounds.x * scaleFactor;
-		const physicalY = bounds.y * scaleFactor;
-		const width = Math.max(1, bounds.width * scaleFactor);
-		const height = Math.max(1, bounds.height * scaleFactor);
+		// fallback for display captures) are in DIPs — convert to physical screen
+		// coordinates via `dipToScreenRect`, which correctly handles the virtual-screen
+		// origin across multi-monitor and mixed-DPI setups (a naive
+		// `bounds.x * scaleFactor` would misplace the origin on non-primary
+		// displays).
+		const physicalBounds = payload.bounds != null ? bounds : screen.dipToScreenRect(null, bounds);
+		const physicalX = physicalBounds.x;
+		const physicalY = physicalBounds.y;
+		const width = Math.max(1, physicalBounds.width);
+		const height = Math.max(1, physicalBounds.height);
 		const normalizedX = (payload.x - physicalX) / width;
 		const normalizedY = (payload.y - physicalY) / height;
 		const withinBounds =

--- a/electron/native-bridge/cursor/recording/windowsNativeRecordingSession.ts
+++ b/electron/native-bridge/cursor/recording/windowsNativeRecordingSession.ts
@@ -226,10 +226,20 @@ export class WindowsNativeRecordingSession implements CursorRecordingSession {
 	): NormalizedSample {
 		const bounds =
 			payload.bounds ?? this.options.getDisplayBounds() ?? screen.getPrimaryDisplay().bounds;
-		const width = Math.max(1, bounds.width);
-		const height = Math.max(1, bounds.height);
-		const normalizedX = (payload.x - bounds.x) / width;
-		const normalizedY = (payload.y - bounds.y) / height;
+		// The cursor-sampler reports raw x/y in physical screen pixels (Win32
+		// GetCursorInfo). `payload.bounds` from the sampler's GetWindowRect is also
+		// physical, so use it as-is. Bounds from Electron's `screen` API (or the
+		// fallback for display captures) are logical pixels (DIP) â€” convert to
+		// physical via the display's scaleFactor so the normalized position matches
+		// the WGC video, which is captured in physical pixels.
+		const isPhysicalBounds = payload.bounds != null;
+		const scaleFactor = isPhysicalBounds ? 1 : (screen.getDisplayMatching(bounds).scaleFactor ?? 1);
+		const physicalX = bounds.x * scaleFactor;
+		const physicalY = bounds.y * scaleFactor;
+		const width = Math.max(1, bounds.width * scaleFactor);
+		const height = Math.max(1, bounds.height * scaleFactor);
+		const normalizedX = (payload.x - physicalX) / width;
+		const normalizedY = (payload.y - physicalY) / height;
 		const withinBounds =
 			normalizedX >= 0 && normalizedX <= 1 && normalizedY >= 0 && normalizedY <= 1;
 		const leftButtonDown = payload.leftButtonDown === true;

--- a/src/lib/cursor/nativeCursor.test.ts
+++ b/src/lib/cursor/nativeCursor.test.ts
@@ -4,6 +4,7 @@ import {
 	getNativeCursorClickBounceProgress,
 	getNativeCursorClickBounceScale,
 	hasNativeCursorRecordingData,
+	projectNativeCursorToLocal,
 	resolveInterpolatedNativeCursorFrame,
 	resolveNativeCursorRenderAsset,
 } from "./nativeCursor";
@@ -215,5 +216,70 @@ describe("custom cursor themes", () => {
 		);
 
 		expect(rendered.id).toBe("pretty:text");
+	});
+});
+
+describe("projectNativeCursorToLocal", () => {
+	const identityCrop = { x: 0, y: 0, width: 1, height: 1 };
+
+	it("maps a sample onto the supplied painted rectangle 1:1 with no crop", () => {
+		const point = projectNativeCursorToLocal({
+			cropRegion: identityCrop,
+			maskRect: { x: 100, y: 200, width: 1280, height: 720 },
+			sample: { timeMs: 0, cx: 0.25, cy: 0.5, visible: true },
+		});
+
+		expect(point?.x).toBeCloseTo(100 + 0.25 * 1280);
+		expect(point?.y).toBeCloseTo(200 + 0.5 * 720);
+	});
+
+	it("maps a sample into the cropped region of the painted rectangle", () => {
+		const point = projectNativeCursorToLocal({
+			cropRegion: { x: 0.25, y: 0.0, width: 0.5, height: 1.0 },
+			maskRect: { x: 0, y: 0, width: 1920, height: 1080 },
+			sample: { timeMs: 0, cx: 0.5, cy: 0.5, visible: true },
+		});
+
+		expect(point?.x).toBeCloseTo(0 + ((0.5 - 0.25) / 0.5) * 1920);
+		expect(point?.y).toBeCloseTo(0 + (0.5 / 1.0) * 1080);
+	});
+
+	it("projects onto the cropped (cover-letterboxed) painted rect, not the mask rect", () => {
+		const screenRect = { x: 0, y: 0, width: 1920, height: 1080 };
+		const croppedRect = { x: 0, y: -540, width: 1920, height: 2160 };
+
+		const point = projectNativeCursorToLocal({
+			cropRegion: { x: 0.0, y: 0.0, width: 0.5, height: 1.0 },
+			maskRect: croppedRect,
+			sample: { timeMs: 0, cx: 0.25, cy: 0.25, visible: true },
+		});
+
+		const wrong = screenRect.y + 0.25 * screenRect.height;
+		expect(wrong).toBe(270);
+
+		expect(point?.x).toBeCloseTo(croppedRect.x + ((0.25 - 0) / 0.5) * croppedRect.width);
+		expect(point?.y).toBeCloseTo(croppedRect.y + (0.25 / 1.0) * croppedRect.height);
+		expect(point?.y).toBe(0);
+		expect(point?.y).not.toBe(wrong);
+	});
+
+	it("returns null for a sample outside the cropped region", () => {
+		const point = projectNativeCursorToLocal({
+			cropRegion: { x: 0.25, y: 0.25, width: 0.5, height: 0.5 },
+			maskRect: { x: 0, y: 0, width: 1920, height: 1080 },
+			sample: { timeMs: 0, cx: 0.1, cy: 0.5, visible: true },
+		});
+
+		expect(point).toBeNull();
+	});
+
+	it("returns null for a degenerate (zero-size) crop region", () => {
+		const point = projectNativeCursorToLocal({
+			cropRegion: { x: 0, y: 0, width: 0, height: 1 },
+			maskRect: { x: 0, y: 0, width: 1920, height: 1080 },
+			sample: { timeMs: 0, cx: 0.5, cy: 0.5, visible: true },
+		});
+
+		expect(point).toBeNull();
 	});
 });

--- a/src/lib/cursor/nativeCursor.test.ts
+++ b/src/lib/cursor/nativeCursor.test.ts
@@ -244,7 +244,7 @@ describe("projectNativeCursorToLocal", () => {
 		expect(point?.y).toBeCloseTo(0 + (0.5 / 1.0) * 1080);
 	});
 
-	it("projects onto the cropped (cover-letterboxed) painted rect, not the mask rect", () => {
+	it("projects onto the cropped (cover-overflowing) painted rect, not the mask rect", () => {
 		const screenRect = { x: 0, y: 0, width: 1920, height: 1080 };
 		const croppedRect = { x: 0, y: -540, width: 1920, height: 2160 };
 

--- a/src/lib/exporter/frameRenderer.ts
+++ b/src/lib/exporter/frameRenderer.ts
@@ -126,6 +126,7 @@ interface LayoutCache {
 	baseScale: number;
 	baseOffset: { x: number; y: number };
 	maskRect: { x: number; y: number; width: number; height: number };
+	croppedRect: { x: number; y: number; width: number; height: number };
 	maskBorderRadius: number;
 	webcamRect: StyledRenderRect | null;
 }
@@ -573,7 +574,7 @@ export class FrameRenderer {
 
 		const projectedPoint = projectNativeCursorToLocal({
 			cropRegion: this.config.cropRegion,
-			maskRect: this.layoutCache.maskRect,
+			maskRect: this.layoutCache.croppedRect,
 			sample: displaySample,
 		});
 		if (!projectedPoint) {
@@ -761,6 +762,12 @@ export class FrameRenderer {
 				y: compositeLayout.screenRect.y + coverOffsetY - cropPixelY,
 			},
 			maskRect: compositeLayout.screenRect,
+			croppedRect: {
+				x: compositeLayout.screenRect.x + coverOffsetX,
+				y: compositeLayout.screenRect.y + coverOffsetY,
+				width: croppedDisplayWidth,
+				height: croppedDisplayHeight,
+			},
 			maskBorderRadius: scaledBorderRadius,
 			webcamRect: compositeLayout.webcamRect,
 		};

--- a/src/lib/exporter/frameRenderer.ts
+++ b/src/lib/exporter/frameRenderer.ts
@@ -602,8 +602,10 @@ export class FrameRenderer {
 				getNativeCursorClickBounceProgress(this.config.cursorRecordingData, timeMs),
 			);
 		const appliedScale = this.animationState.appliedScale;
-		// Normalize cursor size to the same fraction of video width as the preview;
-		// both paths use maskRect.width / croppedVideoWidth.
+		// Normalize cursor size to croppedRect.width (the painted video width).
+		// The preview path still uses screenRect.width; they agree in cover mode but
+		// differ in fit-to-height letterbox — known asymmetry pending the preview-path
+		// follow-up to project the cursor onto the cropped sub-rect as well.
 		const sizeNorm =
 			this.layoutCache.videoSize.width > 0
 				? this.layoutCache.maskRect.width / this.layoutCache.videoSize.width


### PR DESCRIPTION
## Summary

After cropping the recorded video, the exported cursor drifted from where it should sit. The export pipeline was projecting the recorded cursor sample onto the screen mask rect (`compositeLayout.screenRect`) instead of the rectangle the cropped video is *actually* painted on. In cover layouts where the cropped video letterboxes inside `screenRect` (`coverOffset != 0`), the cursor's offset was proportional to the letterbox margin — visible immediately after applying a crop.

This adds a `croppedRect` field to `FrameRenderer`'s `LayoutCache` (computed from the existing `coverOffsetX/Y` and `croppedDisplayWidth/Height` in `updateLayout`) and passes it to `projectNativeCursorToLocal` so the cursor lands on the same pixels the cropped video is drawn on. `maskRect` is still used for `cursorClipToBounds` viewport clipping — that behavior is unchanged.

Adds a `projectNativeCursorToLocal` regression test suite covering identity, cropped-region mapping, the cover-letterbox drift case, out-of-region culling, and a degenerate crop.

### Follow-up: Windows cursor-position DPI normalization

While validating this fix end-to-end on Windows, a pre-existing latent bug in the native cursor pipeline surfaced (it had been there since 1.5.0 but was invisible before the native helpers were built — browser-capture fallback handled DPI internally). The Windows cursor-sampler (`Win32 GetCursorInfo`) reports raw x/y in **physical screen pixels**, but the Electron session was normalizing against bounds from Electron's `screen` API, which are in **logical pixels (DIP)**. On a 100% DPI display these coincide; on any high-DPI display the normalized cursor position is wrong by the scale factor, and the error compounds through `projectNativeCursorToLocal` in the export, producing a visible cursor offset proportional to the DPI ratio.

Fix in `windowsNativeRecordingSession.ts`: convert the logical bounds to physical screen coordinates via `screen.dipToScreenRect(null, bounds)`, which correctly handles the virtual-screen origin across multi-monitor and mixed-DPI setups. A naive `bounds.x * scaleFactor` (the first attempt) was wrong for non-primary displays — a secondary 200% DPI monitor to the right of a 100% primary has DIP bounds `{x:1920, y:0, w:1920, h:1080}` but physical bounds `{x:1920, y:0, w:3840, h:2160}`, so multiplying the origin by 2 would have pushed it to x=3840. `payload.bounds` (from the sampler's `GetWindowRect`, used for window captures) is already physical and is left as-is.

The macOS path (`macNativeCursorRecordingSession.ts`) is unaffected: `screen.getCursorScreenPoint()` and `screen.getDisplayNearestPoint().bounds` both return Cocoa points, the macOS helper doesn't report raw `bounds` in its sample events, and the [0,1] normalization is scale-invariant between points and the video's pixels.

## Related issue
Fixes #64

## Type of change
- [x] Bug fix

## Release impact
- [x] Patch

## Desktop impact
- [x] Windows (native cursor position DPI normalization)
- [x] Not platform-specific (cursor projection onto cropped rect)

## Screenshots / video
N/A — export rendering geometry fix.

## Testing
- `npx tsc --noEmit` clean.
- `npx vitest run --pool=vmThreads src/lib/cursor src/lib/exporter/frameRenderer.test.ts` → 40/40 passing (12 pre-existing + 4 new `projectNativeCursorToLocal` cases + the rest of the cursor/export suites).
- Biome check clean on the changed files.
- Manual smoke test on real Windows: recorded a short clip with the native helpers enabled, verified the cursor lands on the correct pixel (e.g. on a 1920×1080 physical / 1536×864 logical @ 125% DPI display, the diagnostic log shows `normalizedX/Y` matching `rawX/Y ÷ 1920/1080` instead of `÷ 1536/864`).

Manual smoke test on real macOS is still recommended for native-capture changes per the AGENTS.md guidance, though the DPI fix is Windows-specific and the cursor-projection fix is platform-agnostic. The macOS cursor path was reviewed for the same DPI issue and is unaffected (see PR description).

<!-- discord-thread-id:1523763057027973235 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native cursor positioning over cropped and cover-letterboxed video by projecting pointer samples using the actual on-stage cropped region geometry.
  * Fixed Windows cursor sample normalization to correctly use physical-screen coordinates across mixed-DPI and virtual desktop layouts.
* **Tests**
  * Expanded unit tests to validate native cursor point projection for non-cropped, cropped, and cover-letterboxed scenarios, including cases where the crop region is outside or degenerate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
