### PR TITLE
fix(release): pin build dispatch to the tag, fix release-branch naming

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -133,7 +133,14 @@ jobs:
           # GITHUB_TOKEN tag pushes don't fire the build.yml trigger in this setup,
           # so dispatch it explicitly. The PAT ensures the build's release creation
           # propagates to Tier 3 (homebrew/winget/nix/aur) via release: published.
+          #
+          # --ref is REQUIRED: the RC version bump lives ONLY on the release branch /
+          # RC tag, never on the default branch. Without --ref the build runs on main
+          # (still the previous stable version), so build.yml's publish-release step
+          # fails its guard ("package.json version X does not match <rc> from tag").
+          # Pin the build to the RC tag so checkout gets the bumped package.json + code.
           gh workflow run build.yml \
+            --ref "${RC_TAG}" \
             -f release_tag="${RC_TAG}" \
             -f arch=both \
             --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -75,34 +75,43 @@ jobs:
           NEXT: ${{ steps.version.outputs.next }}
         run: node .github/scripts/release-milestone-migrate.mjs
 
-      - name: Bump package.json to pre-release version
-        env:
-          PRERELEASE: ${{ steps.version.outputs.prerelease }}
-        run: |
-          set -euo pipefail
-          sed -i -E "s|(\"version\"[[:space:]]*:[[:space:]]*\")[^\"]*(\")|\1${PRERELEASE}\2|" package.json
-          echo "package.json version:"
-          grep '"version"' package.json
-
-      - name: Commit package.json bump on a release branch
+      - name: Create or reuse the release branch and bump package.json
         env:
           TOKEN: ${{ secrets.OPENSCREEN_RELEASE_TOKEN }}
           PRERELEASE: ${{ steps.version.outputs.prerelease }}
+          NEXT: ${{ steps.version.outputs.next }}
         run: |
           set -euo pipefail
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # The release branch is FROZEN between RC cut and stable promotion. The bump
-          # commit lives on release/v${PRERELEASE} only; nothing is merged into main
-          # until promote.yml publishes the stable tag, so any features merged into
-          # main after this step are NOT in the RC build.
-          BRANCH="release/v${PRERELEASE}"
-          # Delete remote branch first so the push below is always fast-forward (idempotent on rerun).
-          git push "https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.git" ":${BRANCH}" 2>/dev/null || true
-          git checkout -b "$BRANCH"
+          # ONE release branch per STABLE version (release/vX.Y.Z), created at rc.1 and
+          # FROZEN until promote publishes the stable tag. Later RCs (rc.2, rc.3, ...) are
+          # cut from this same branch, so they carry the rc.1 snapshot plus any
+          # cherry-picked bugfixes and NOT whatever has landed on main since.
+          #
+          # The name must stay in sync with promote.yml, which resolves
+          # release/v${STABLE_VERSION}. Naming this branch release/v${PRERELEASE}
+          # (with the -rc.N suffix) breaks promote and makes every re-cut a fresh
+          # branch off main, which silently defeats the freeze.
+          BRANCH="release/v${NEXT}"
+          REMOTE="https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            # Re-cut (rc.2+): build on the frozen branch. Never delete it — it carries the
+            # cherry-picks that make this RC differ from the previous one.
+            echo "Reusing frozen release branch ${BRANCH}"
+            git fetch origin "$BRANCH"
+            git checkout -B "$BRANCH" "origin/${BRANCH}"
+          else
+            # First cut (rc.1): branch from the dispatched ref (main).
+            echo "Creating release branch ${BRANCH} from ${GITHUB_REF_NAME}"
+            git checkout -b "$BRANCH"
+          fi
+          sed -i -E "s|(\"version\"[[:space:]]*:[[:space:]]*\")[^\"]*(\")|\1${PRERELEASE}\2|" package.json
+          echo "package.json version:"
+          grep '"version"' package.json
           git add package.json
-          git commit -m "chore(release): bump to ${PRERELEASE} [skip ci]"
-          git push "https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$BRANCH"
+          git commit -m "chore(release): bump to ${PRERELEASE} [skip ci]" || echo "(version already at ${PRERELEASE})"
+          git push "$REMOTE" "$BRANCH"
 
       - name: Push RC tag on the release branch
         env:
@@ -111,10 +120,10 @@ jobs:
           # Note: GITHUB_TOKEN tag pushes do NOT trigger build.yml in this org's setup,
           # so we explicitly trigger it via gh workflow run right after.
           RC_TAG: ${{ steps.version.outputs.rc_tag }}
-          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+          NEXT: ${{ steps.version.outputs.next }}
         run: |
           set -euo pipefail
-          BRANCH="release/v${PRERELEASE}"
+          BRANCH="release/v${NEXT}"
           git fetch origin "$BRANCH"
           git checkout "$BRANCH"
           git reset --hard "origin/${BRANCH}"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -142,7 +142,13 @@ jobs:
         run: |
           set -euo pipefail
           # GITHUB_TOKEN tag pushes don't fire build.yml in this setup, dispatch it.
+          #
+          # --ref pins the build to the stable tag (the frozen release-branch tip). The
+          # prior main-merge step usually leaves main at the stable version already, but
+          # relying on that is fragile; building the tag guarantees checkout has the
+          # matching package.json + code and enables signing/notarization (tag has no '-').
           gh workflow run build.yml \
+            --ref "${STABLE_TAG}" \
             -f release_tag="${STABLE_TAG}" \
             -f arch=both \
             --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
Two bugs in the release pipeline, both found while cutting **v1.7.0-rc.1** (the first RC under the release-branch freeze, so neither path had ever run).

## 1. Build dispatched on the wrong ref

`prerelease.yml` ran `gh workflow run build.yml` **without `--ref`**, so the build dispatched on the **default branch (`main`)**, where `package.json` is still the previous stable version. The RC bump lives only on the release branch, so `build.yml`'s publish guard rejected it:

```
##[error]package.json version 1.6.0 does not match 1.7.0-rc.1 from tag v1.7.0-rc.1
```

No release was created, and the installers were stamped `1.6.0`. Fixed by pinning `--ref "${RC_TAG}"` (and `--ref "${STABLE_TAG}"` in `promote.yml`, which only worked before because the preceding main-merge happened to leave `main` at the stable version).

## 2. Release branch naming breaks promote and defeats the freeze

- `prerelease.yml` created `release/v${PRERELEASE}` → **`release/v1.7.0-rc.1`**
- `promote.yml` resolves `release/v${STABLE_VERSION}` → **`release/v1.7.0`**

That branch doesn't exist, so **promote would have failed** at `git fetch origin release/v1.7.0`.

Worse: each re-cut created a *new* branch off `main` and force-deleted the remote branch first. Cutting rc.2 would therefore sweep in anything landed on `main` **and** destroy the cherry-picks on the rc.1 branch — silently defeating the freeze the contract exists to guarantee.

Fixed by using **one branch per stable version** (`release/vX.Y.Z`), created at rc.1 and reused for later RCs: fetch + check out when it exists, branch from the dispatched ref when it doesn't, never delete. The `package.json` bump moved into the same step so the version is written *after* the correct branch is checked out.

## Verification

- `build.yml --ref v1.7.0-rc.1` (equivalent of fix 1) ran green on Windows/macOS(arm64+x64)/Linux and published `v1.7.0-rc.1` with 6 assets.
- Fix 2 is exercised by the next cut (rc.2), which will create `release/v1.7.0` and let promote resolve it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prerelease (RC) branch and prerelease version handling so release candidates are cut and recut reliably from the same frozen release snapshot.
  * Ensured build workflows are dispatched against the intended RC and promoted stable tags, using the matching package version to avoid stale default-branch state.
  * Updated release tagging/build behavior during promotion to prevent mismatched version checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->