### PR TITLE
fix(recording): disable Vulkan on Wayland so PipeWire capture can import DMA-BUF frames

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -46,6 +46,12 @@ if (process.platform === "linux") {
 		app.commandLine.appendSwitch("ozone-platform", "wayland");
 		// Enable WebRTCPipeWireCapturer for screen capture on Wayland
 		app.commandLine.appendSwitch("enable-features", "WaylandWindowDrag,WebRTCPipeWireCapturer");
+		// Chromium's Wayland Ozone backend can't use Vulkan. When it tries, the WebRTC
+		// PipeWire capturer fails to import DMA-BUF frames into EGL (EGL_BAD_MATCH), the
+		// stream renegotiates, and screen recording yields no usable frames. Force the
+		// GL/EGL path so DMA-BUF import works. (Chromium itself logs this suggestion:
+		// "'--ozone-platform=wayland' is not compatible with Vulkan ... disabling Vulkan".)
+		app.commandLine.appendSwitch("disable-features", "Vulkan");
 	}
 }
 


### PR DESCRIPTION
Closes #92.
Closes #93.

## Problem

A tester on **v1.7.0-rc.1** (Wayland, Intel iGPU) reported screen recording not working, with these logs:

```
'--ozone-platform=wayland' is not compatible with Vulkan.
Consider switching to '--ozone-platform=x11' or disabling Vulkan
Failed to record frame: Error creating EGLImage - EGL_BAD_MATCH
DMA-BUF modifier 72057594037927944 failed for format 12 (Spa:Enum:VideoFormat:BGRA),
marking as failed and renegotiating stream parameters
```

In `electron/main.ts` we force `ozone-platform=wayland` and enable `WebRTCPipeWireCapturer`, but leave Vulkan enabled. Chromium's Wayland Ozone backend **can't use Vulkan**; when it initializes Vulkan, the PipeWire desktop-capture frames fail to import into EGL (`EGL_BAD_MATCH`), the stream renegotiates, and recording produces no usable frames. Chromium prints the fix itself in the first log line.

## Fix

Append `disable-features=Vulkan` on Wayland so capture uses the GL/EGL path, which is what the DMA-BUF import expects.

```ts
app.commandLine.appendSwitch("disable-features", "Vulkan");
```

## Validation needed — cannot reproduce in CI

CI runs on Linux headless with no Wayland session, and maintainers here are on macOS/Windows, so this **can't be verified automatically**. It needs a real Wayland box.

@reporter — could you build this branch and confirm recording works?

```bash
git fetch origin claude/fix-wayland-vulkan-capture
git checkout claude/fix-wayland-vulkan-capture
npm ci && npm run dev
```

Then start a screen recording and check the logs no longer show `EGL_BAD_MATCH` / DMA-BUF renegotiation, and the output has real frames.

## Also, to help triage the rest

The shared logs evidence this one capture defect (two symptoms). The report mentioned **4 bugs total** — could you list the other three, each with a short repro + its own log slice? And to confirm scope for this one:

- Compositor: GNOME / KDE / Sway / other?
- Mesa version (`glxinfo | grep "OpenGL version"` or `eglinfo`)?
- Confirm GPU is Intel (the failing DMA-BUF modifier decodes to an Intel tiled modifier)?

If `EGL_BAD_MATCH` persists even with Vulkan disabled, the next levers are pinning the GL backend (`--use-gl=egl` / ANGLE) or forcing linear buffers — but let's confirm this narrower fix first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1527221276387573851 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application compatibility and stability when running on Linux systems using Wayland.
  * Disabled Vulkan usage in Wayland sessions to help prevent graphics-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Validated by the reporter on a real Wayland + Intel setup:** capture works and runs at 60 fps in and out. This confirms the fps drop (#93) was downstream of the DMA-BUF import failure, not an encoder bug. Cursor issues (#94) are unaffected and tracked separately.
