### PR TITLE
ci: bump pinned GitHub Actions to their Node 24 majors

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,7 @@ description: Install Node 22, restore npm cache, run npm ci
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v7
       with:
         node-version: 22
         cache: npm

--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: ./.github/actions/setup

--- a/.github/workflows/build-whisper-stt.yml
+++ b/.github/workflows/build-whisper-stt.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: ./.github/actions/setup
@@ -138,7 +138,7 @@ jobs:
           echo "CMAKE_PREFIX_PATH=${VCPKG_ROOT_DIR}/installed/x64-windows" >> "$GITHUB_ENV"
 
       - name: Cache whisper.cpp build tree
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           # Matches scripts/build-whisper-stt.sh's own BUILD_ROOT default for
           # each OS (short `C:/wstbuild` on Windows to dodge the vulkan-shaders-gen
@@ -195,7 +195,7 @@ jobs:
           echo "Staged ${BAG}.tar.gz"
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: whisper-stt-${{ matrix.tag }}
           path: whisper-stt-${{ matrix.tag }}.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: ./.github/actions/setup
@@ -53,7 +53,7 @@ jobs:
         run: npm run build:win -- --publish never
 
       - name: Upload Windows installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: openscreen-windows
           path: release/**/Openscreen.Setup.*.exe
@@ -65,7 +65,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: ./.github/actions/setup
@@ -139,7 +139,7 @@ jobs:
           Write-Output "$($expected.Count) tile assets present in $($appx.Name), byte-identical to build/appx/"
 
       - name: Upload Windows Store package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: openscreen-windows-store
           path: release/**/Openscreen.Setup.*.appx
@@ -167,13 +167,13 @@ jobs:
         arch: ${{ fromJSON((github.event_name == 'workflow_dispatch' && github.event.inputs.arch != 'both') && format('["{0}"]', github.event.inputs.arch) || '["arm64", "x64"]') }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: ./.github/actions/setup
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -268,7 +268,7 @@ jobs:
       # installed app, silently. `scripts/before-pack.cjs` now refuses to package
       # that, so this is also what keeps the job from failing at the pack step.
       - name: Cache LGPL ffmpeg tree
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           # fetch-ffmpeg-macos.mjs BUILDS ffmpeg from source (~5 min): BtbN ships no
           # macOS target and every circulating macOS build is GPL, which would
@@ -281,7 +281,7 @@ jobs:
         run: npm run fetch:ffmpeg:mac
 
       - name: Cache cargo + compositor build tree
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -477,7 +477,7 @@ jobs:
           spctl -a -vv -t install "${{ steps.dmg.outputs.dmg_path }}"
 
       - name: Upload macOS DMG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: openscreen-mac-${{ matrix.arch }}
           path: ${{ steps.dmg.outputs.dmg_path }}
@@ -493,7 +493,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: ./.github/actions/setup
@@ -517,7 +517,7 @@ jobs:
         run: npm run build:linux -- --publish never
 
       - name: Upload Linux packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: openscreen-linux
           path: |
@@ -543,7 +543,7 @@ jobs:
     if: ${{ (github.event_name == 'push' && github.ref_type == 'tag') || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag != '') }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Full history + tags: the RC notes below are built from `git log` over the
           # range since the previous RC tag, and resolving that tag needs the tags.
@@ -620,25 +620,25 @@ jobs:
           echo "notes_start_tag=$NOTES_START_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Download Windows installer
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: openscreen-windows
           path: artifacts/windows
 
       - name: Download macOS arm64 DMG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: openscreen-mac-arm64
           path: artifacts/mac-arm64
 
       - name: Download macOS x64 DMG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: openscreen-mac-x64
           path: artifacts/mac-x64
 
       - name: Download Linux packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: openscreen-linux
           path: artifacts/linux

--- a/.github/workflows/bump-nix-package.yml
+++ b/.github/workflows/bump-nix-package.yml
@@ -39,7 +39,7 @@ jobs:
           echo "branch=$BRANCH"   >> "$GITHUB_OUTPUT"
 
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: npm run lint
 
@@ -27,7 +27,7 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: npx tsc --noEmit
 
@@ -48,7 +48,7 @@ jobs:
     # fixing on the spot, fix the fixture anyway: re-introducing a baseline
     # re-opens the drift this closed.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - name: Typecheck tests
         run: npx tsc -p tsconfig.test.json --noEmit
@@ -57,11 +57,11 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # No ./.github/actions/setup: check-docs.mjs imports only node builtins,
       # so npm ci would be a minute of install for nothing. Node 22 is here for
       # import.meta.dirname (needs >= 20.11).
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
       - run: npm run docs:check
@@ -70,7 +70,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: npm run test
 
@@ -78,7 +78,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
       - run: npx vite build
 
@@ -122,7 +122,7 @@ jobs:
     name: Rust test (macOS compositor)
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --target aarch64-apple-darwin
@@ -168,8 +168,8 @@ jobs:
     name: Rust check (Windows compositor)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
       # bindgen needs libclang. `crates/.cargo/config.toml` pins LIBCLANG_PATH to
@@ -209,10 +209,10 @@ jobs:
     name: Rust test (Linux compositor)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # Pas de ./.github/actions/setup : `fetch-ffmpeg.mjs` n'importe que des
       # builtins node, donc `npm ci` serait une minute d'installation pour rien.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
       # libclang-dev, pas libclang1 : bindgen a besoin de libclang pour lire les
@@ -269,7 +269,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/diagnostic-artifact.yml
+++ b/.github/workflows/diagnostic-artifact.yml
@@ -18,7 +18,7 @@ jobs:
     name: Windows x64 diagnostic bundle
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup
 
@@ -61,7 +61,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "diagnostic.bat --help exited $LASTEXITCODE" }
 
       - name: Upload Windows diagnostic bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: openscreen-diagnostic-windows-x64
           path: openscreen-diagnostic-windows-x64.zip
@@ -76,7 +76,7 @@ jobs:
       matrix:
         arch: [arm64, x64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup
 
@@ -101,7 +101,7 @@ jobs:
           tar -czf "$bundle.tar.gz" "$bundle"
 
       - name: Upload macOS diagnostic bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: openscreen-diagnostic-macos-${{ matrix.arch }}
           path: openscreen-diagnostic-macos-${{ matrix.arch }}.tar.gz

--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: ./.github/actions/setup

--- a/.github/workflows/discord-roadmap-sync.yml
+++ b/.github/workflows/discord-roadmap-sync.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: ./.github/actions/setup

--- a/.github/workflows/discord-weekly-leaderboard.yml
+++ b/.github/workflows/discord-weekly-leaderboard.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: ./.github/actions/setup

--- a/.github/workflows/merged-pr-bookkeeping.yml
+++ b/.github/workflows/merged-pr-bookkeeping.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update closing issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -42,7 +42,7 @@ jobs:
     name: npmDepsHash matches package-lock.json
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: cachix/install-nix-action@v27
         with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/update-homebrew-cask.yml
+++ b/.github/workflows/update-homebrew-cask.yml
@@ -125,7 +125,7 @@ jobs:
           echo "x64_sha=$X64_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Checkout tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ env.TAP_OWNER }}/${{ env.TAP_REPO }}
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Problem

Every workflow run logs:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4 ...
```

GitHub is dropping the Node 20 shim. These actions still declare `using: node20` at the pinned majors in this repo, so runners are already silently forcing them onto Node 24 — a warning today, a hard break later.

## Fix

Bump each action to the major that declares `using: node24` natively (verified directly against each repo's `action.yml` at the release tag, not against changelog claims):

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-node` | v4 | v7 |
| `actions/setup-python` | v5 | v6 |
| `actions/cache` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `amannn/action-semantic-pull-request` | v5 | v6 |
| `actions/github-script` | v7 | v8 |

Applied across all 15 workflow/composite-action files that pin them by version tag — 47 call sites. Rebased onto current `main`, so it also covers `announce-release.yml`, `build-whisper-stt.yml` and `nix-check.yml`, which landed after this branch was first cut.

Also verified empirically rather than by inspection alone: `ci.yml` on `main` emits the deprecation warning on every job, and the same run on this branch emits none.

## Breaking changes checked

Read the release notes for every intermediate major and checked each against how this repo actually calls these actions:

- **download-artifact v5** — changed the output path for single downloads *by artifact-id*. All four call sites here download by `name:`, so unaffected.
- **download-artifact v8** — now defaults `digest-mismatch` to `error` instead of logging a warning. Kept as-is: a corrupt installer should fail the release job rather than be published silently.
- **setup-node v5** — auto-enables npm caching when `package.json` declares `packageManager`, and this repo declares `npm@10.9.4`. The composite action already sets `cache: npm` explicitly; the three *direct* `setup-node` steps in `ci.yml` gain caching they did not have before. `package-lock.json` is at the repo root, so detection resolves rather than erroring.
- **checkout v5+ / github-script v8** — both require runner `>= v2.327.1`. Every job here runs on a GitHub-hosted runner, so that is satisfied automatically; there are no self-hosted runners in this repo.
- **checkout v7** — refuses to check out fork PR code under `pull_request_target` / `workflow_run`. The guard only runs when the step overrides `repository:` or `ref:` (`src/input-helper.ts` exempts the default self-checkout). The three `pull_request_target` workflows here do a bare default checkout, and the two workflows that *do* override a ref (`update-homebrew-cask`, `bump-nix-package`) run on `release` / `workflow_dispatch`, where the guard early-returns. No call site trips it.
- **amannn v6** — the only breaking change is the Node 24 + ESM migration itself. This repo passes `types` and `requireScope`, both unchanged.
- **github-script v8** — a pure runtime bump (`v7.1.0...v8.0.0` is the Node 24 change plus a README). Stopped at v8 rather than v9 deliberately: v9 injects `getOctokit` as a script parameter and drops `require('@actions/github')`. The 252-line script in `merged-pr-bookkeeping.yml` uses neither, so v9 would also work, but v8 leaves the script context byte-for-byte identical.
- Everything else across these ranges is the Node 24 runtime bump, an ESM migration transparent to callers, or new opt-in inputs (e.g. upload-artifact's `archive: false`) that nothing here uses.

## Deliberately not in this PR

- **`ilammy/msvc-dev-cmd@v1`** is still `node20` and upstream has published no newer major, so one deprecation line survives until it does.
- **`.github/workflows/docs.yml`** is SHA-pinned rather than tag-pinned, and its four actions are node20 too. It is left alone because `upload-pages-artifact` v4 stopped including dotfiles, which would drop the `.nojekyll` Docusaurus emits into `website/build`. Fixing it means `v5` plus `include-hidden-files: true`, and it touches the production Pages deploy — the deploy job only runs on push to `main`, so a PR run cannot validate it. Worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1527343776446812364 -->
