### PR TITLE
fix(zoom): auto-placed zoom regions follow the cursor for their whole span

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -1136,6 +1136,11 @@ export default function VideoEditor() {
 
 	// Builds fresh "auto" zoom regions from cursor telemetry without overlapping
 	// existing ones. Used by both the on-load auto-suggest pass and the wand toggle.
+	// These regions always follow the cursor for their whole span (focusMode "auto") —
+	// that's the entire point of an auto-placed zoom: it should pan to track the cursor
+	// as it moves, not freeze at the dwell point that triggered the suggestion. This is
+	// independent of the global "Auto Focus All" toggle, which only affects the default
+	// for manually-drawn zoom regions.
 	const buildAutoZoomRegions = useCallback(
 		(existingRegions: ZoomRegion[]): ZoomRegion[] => {
 			const totalMs = Math.round(duration * 1000);
@@ -1152,11 +1157,11 @@ export default function VideoEditor() {
 				depth: DEFAULT_ZOOM_DEPTH,
 				customScale: ZOOM_DEPTH_SCALES[DEFAULT_ZOOM_DEPTH],
 				focus: clampFocusToDepth(suggestion.focus, DEFAULT_ZOOM_DEPTH),
-				focusMode: autoFocusAll ? ("auto" as const) : undefined,
+				focusMode: "auto" as const,
 				source: "auto" as const,
 			}));
 		},
-		[cursorTelemetry, duration, autoFocusAll],
+		[cursorTelemetry, duration],
 	);
 
 	// Auto-suggest zooms once per fresh recording (no existing zooms, telemetry

--- a/src/components/video-editor/videoPlayback/zoomRegionUtils.test.ts
+++ b/src/components/video-editor/videoPlayback/zoomRegionUtils.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { CursorTelemetryPoint, ZoomRegion } from "../types";
+import { DEFAULT_ZOOM_DEPTH, ZOOM_DEPTH_SCALES } from "../types";
+import { findDominantRegion } from "./zoomRegionUtils";
+
+/**
+ * Regression coverage for issue #72: an auto-placed zoom region must pan to follow
+ * the cursor for its whole span, not freeze at the focus point captured when the
+ * region was created/suggested.
+ */
+describe("findDominantRegion — auto-zoom cursor following", () => {
+	const baseRegion: ZoomRegion = {
+		id: "zoom-1",
+		startMs: 0,
+		endMs: 4000,
+		depth: DEFAULT_ZOOM_DEPTH,
+		customScale: ZOOM_DEPTH_SCALES[DEFAULT_ZOOM_DEPTH],
+		// The static focus captured at suggestion time (e.g. the dwell centroid) — should
+		// be ignored in favor of the live cursor position once focusMode is "auto". Kept
+		// within the depth-3 focus bounds (~0.28-0.72) so clamping doesn't distort assertions.
+		focus: { cx: 0.35, cy: 0.5 },
+		focusMode: "auto",
+		source: "auto",
+	};
+
+	// Cursor sweeps steadily from the left edge to the right edge across the region.
+	const movingTelemetry: CursorTelemetryPoint[] = [
+		{ timeMs: 0, cx: 0.1, cy: 0.5 },
+		{ timeMs: 2000, cx: 0.5, cy: 0.5 },
+		{ timeMs: 4000, cx: 0.9, cy: 0.5 },
+	];
+
+	it("tracks the cursor across the region instead of freezing at the initial focus", () => {
+		const early = findDominantRegion([baseRegion], 200, { cursorTelemetry: movingTelemetry });
+		const mid = findDominantRegion([baseRegion], 2000, { cursorTelemetry: movingTelemetry });
+		const late = findDominantRegion([baseRegion], 3800, { cursorTelemetry: movingTelemetry });
+
+		expect(early.region).not.toBeNull();
+		expect(mid.region).not.toBeNull();
+		expect(late.region).not.toBeNull();
+
+		// The focus must move meaningfully between samples (cursor-following), not stay pinned.
+		expect(mid.region?.focus.cx).toBeGreaterThan(early.region?.focus.cx ?? 0);
+		expect(late.region?.focus.cx).toBeGreaterThan(mid.region?.focus.cx ?? 0);
+
+		// And it must not equal the static creation-time focus baked into the region.
+		expect(mid.region?.focus.cx).not.toBeCloseTo(baseRegion.focus.cx, 2);
+	});
+
+	it("stays frozen at the static focus when focusMode is not auto (manual regions unaffected)", () => {
+		const manualRegion: ZoomRegion = { ...baseRegion, focusMode: "manual", source: "manual" };
+
+		const early = findDominantRegion([manualRegion], 200, { cursorTelemetry: movingTelemetry });
+		const late = findDominantRegion([manualRegion], 3800, { cursorTelemetry: movingTelemetry });
+
+		expect(early.region?.focus.cx).toBeCloseTo(manualRegion.focus.cx, 5);
+		expect(late.region?.focus.cx).toBeCloseTo(manualRegion.focus.cx, 5);
+	});
+});


### PR DESCRIPTION
## Summary
- Auto zoom regions (created by the magic-wand cursor-dwell suggestion pass, `source: "auto"`) were built with `focusMode` left `undefined` unless the separate, global "Auto Focus All" toggle was on.
- With `focusMode` not `"auto"`, the zoom/pan render used the static dwell-centroid `focus` point captured when the region was suggested and never tracked the cursor for the rest of the region — matching the reported symptom of the zoom "jumping to the cursor's position at the start and then staying fixed."
- The cursor-follow interpolation logic (`zoomRegionUtils.ts` / `cursorFollowUtils.ts`) already existed and worked correctly when `focusMode: "auto"` — it just wasn't being applied by default to auto-suggested regions.
- Fix: `buildAutoZoomRegions` in `src/components/video-editor/VideoEditor.tsx` now always sets `focusMode: "auto"` for regions with `source: "auto"`, independent of the "Auto Focus All" toggle (which still only controls the default for manually-drawn zoom regions — unchanged).

## Root cause
`src/components/video-editor/VideoEditor.tsx` — `buildAutoZoomRegions()` set `focusMode: autoFocusAll ? "auto" : undefined` for every auto-suggested region. Since `autoFocusAll` defaults to `false`, freshly auto-placed zoom regions got `focusMode: undefined`, which `getResolvedFocus()` in `src/components/video-editor/videoPlayback/zoomRegionUtils.ts` treats as "manual" (static `focus` point), so the pan never sampled cursor telemetry across the region's time range.

## Test plan
- [x] Added `src/components/video-editor/videoPlayback/zoomRegionUtils.test.ts`: regression test asserting an auto-zoom region's resolved focus tracks moving cursor telemetry across its span, and that a manual-focus-mode region stays pinned to its static focus (manual regions unaffected).
- [x] `npx tsc --noEmit` — no new errors (2 pre-existing unrelated errors for optional `@xenova/transformers` / `onnxruntime-web` deps).
- [x] `npm run lint` (biome check on changed files) — clean.
- [x] `npm run test` — all 52 test files / 409 tests pass.
- [ ] Live app smoke test (record → auto-zoom → playback) was not performed in this session due to the setup cost of driving real screen capture from a worktree; verification here is unit-test only. A manual smoke test recording a clip with cursor movement, letting the magic wand auto-place a zoom region, and confirming the pan follows the cursor during playback is recommended before merge.

Fixes #72

<!-- discord-thread-id:1528295671923347468 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-placed zoom regions now continuously follow the cursor throughout their duration.
  * Manual zoom regions continue to preserve their fixed focus.
  * Improved zoom behavior consistency when automatic focus settings are enabled or disabled.

* **Tests**
  * Added regression coverage for cursor-following behavior in automatic zoom regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->