### PR TITLE
fix(wgc): stop holding the frame mutex across blocking WriteSample calls

### DIFF
--- a/electron/native/wgc-capture/src/main.cpp
+++ b/electron/native/wgc-capture/src/main.cpp
@@ -606,6 +606,11 @@ int main(int argc, char* argv[]) {
         int64_t lastEncodedVideoTimestampHns = -1;
 
         while (!control.stopRequested && !encodeFailed) {
+            Microsoft::WRL::ComPtr<IMFSample> videoSample;
+            Microsoft::WRL::ComPtr<IMFSample> webcamSample;
+            bool hasVideoSample = false;
+            bool hasWebcamSample = false;
+
             {
                 std::unique_lock lock(mutex);
                 control.cv.wait(lock, [&] {
@@ -653,27 +658,57 @@ int main(int argc, char* argv[]) {
                     latestWebcamSequence != lastWrittenWebcamSequence) {
                     const int64_t webcamTimestampHns = static_cast<int64_t>(
                         (webcamOutputFrameIndex * 10'000'000ULL) / std::max(1, webcamCapture.fps()));
-                    if (!webcamEncoder.writeBgraFrame(webcamFrame, webcamTimestampHns)) {
+                    hasWebcamSample = webcamEncoder.captureBgraSample(webcamFrame, webcamTimestampHns, webcamSample);
+                    if (!hasWebcamSample) {
                         encodeFailed = true;
                         control.stopRequested = true;
                         control.cv.notify_all();
-                        return;
+                        break;
                     }
                     lastWrittenWebcamSequence = latestWebcamSequence;
                     webcamOutputFrameIndex += 1;
                 }
-                if (latestFrameTexture && !encoder.writeFrame(
+                if (latestFrameTexture) {
+                    // captureVideoSample performs the GPU readback
+                    // (CopyResource/Map) from latestFrameTexture, which must
+                    // stay serialized (via `mutex`) against the WGC
+                    // frame-arrival callback above, which writes new data
+                    // into the same texture on another thread.
+                    hasVideoSample = encoder.captureVideoSample(
                         latestFrameTexture.Get(),
                         frameTimestampHns,
-                        !writeSeparateWebcam && webcamFrame.data ? &webcamFrame : nullptr)) {
-                    encodeFailed = true;
-                    control.stopRequested = true;
-                    control.cv.notify_all();
-                    return;
-                }
-                if (latestFrameTexture) {
+                        !writeSeparateWebcam && webcamFrame.data ? &webcamFrame : nullptr,
+                        videoSample);
+                    if (!hasVideoSample) {
+                        encodeFailed = true;
+                        control.stopRequested = true;
+                        control.cv.notify_all();
+                        break;
+                    }
                     lastEncodedVideoTimestampHns = frameTimestampHns;
                 }
+            }
+
+            // Submit the captured samples to their sink writers OUTSIDE
+            // `mutex`. IMFSinkWriter::WriteSample runs the H.264 encode
+            // synchronously and can be slow (especially the software encoder
+            // fallback used when preferSoftwareEncoder is set). Holding
+            // `mutex` across it would block the main thread's stop-wait
+            // (which locks the same mutex to check control.stopRequested)
+            // for as long as this thread keeps re-acquiring the lock faster
+            // than the main thread can, hanging the helper indefinitely
+            // after a stop request (issue #115).
+            if (hasWebcamSample && !webcamEncoder.submitVideoSample(webcamSample.Get())) {
+                encodeFailed = true;
+                control.stopRequested = true;
+                control.cv.notify_all();
+                break;
+            }
+            if (hasVideoSample && !encoder.submitVideoSample(videoSample.Get())) {
+                encodeFailed = true;
+                control.stopRequested = true;
+                control.cv.notify_all();
+                break;
             }
 
             frameIndex += 1;

--- a/electron/native/wgc-capture/src/mf_encoder.cpp
+++ b/electron/native/wgc-capture/src/mf_encoder.cpp
@@ -603,23 +603,38 @@ bool MFEncoder::copyBgraFrameToBuffer(const BgraFrameView& frame, BYTE* destinat
     return true;
 }
 
-bool MFEncoder::writeFrame(ID3D11Texture2D* texture, int64_t timestampHns, const BgraFrameView* webcamFrame) {
-    std::scoped_lock writerLock(writerMutex_);
-    if (!sinkWriter_ || finalized_) {
-        return false;
-    }
+bool MFEncoder::captureVideoSample(
+    ID3D11Texture2D* texture,
+    int64_t timestampHns,
+    const BgraFrameView* webcamFrame,
+    Microsoft::WRL::ComPtr<IMFSample>& outSample) {
+    outSample.Reset();
 
-    if (firstTimestampHns_ < 0) {
-        firstTimestampHns_ = timestampHns;
-    }
-
-    int64_t sampleTime = timestampHns - firstTimestampHns_;
-    if (sampleTime <= lastTimestampHns_) {
-        sampleTime = lastTimestampHns_ + (10'000'000LL / fps_);
-    }
     const int64_t sampleDuration = 10'000'000LL / fps_;
-    lastTimestampHns_ = sampleTime;
+    int64_t sampleTime = 0;
+    {
+        std::scoped_lock writerLock(writerMutex_);
+        if (!sinkWriter_ || finalized_) {
+            return false;
+        }
 
+        if (firstTimestampHns_ < 0) {
+            firstTimestampHns_ = timestampHns;
+        }
+
+        sampleTime = timestampHns - firstTimestampHns_;
+        if (sampleTime <= lastTimestampHns_) {
+            sampleTime = lastTimestampHns_ + sampleDuration;
+        }
+        lastTimestampHns_ = sampleTime;
+    }
+
+    // The GPU readback below (copyFrameToBuffer -> CopyResource/Map on
+    // `texture`) is not internally synchronized here. Callers must hold their
+    // own lock around this call that also serializes against whatever thread
+    // writes new frame data into `texture` (see main.cpp's writeVideoFrames,
+    // which holds the shared frame-state mutex across this call but not
+    // across submitVideoSample).
     Microsoft::WRL::ComPtr<IMFMediaBuffer> buffer;
     const DWORD frameBytes = static_cast<DWORD>(width_ * height_ * 4);
     if (!succeeded(MFCreateMemoryBuffer(frameBytes, &buffer), "MFCreateMemoryBuffer")) {
@@ -648,25 +663,34 @@ bool MFEncoder::writeFrame(ID3D11Texture2D* texture, int64_t timestampHns, const
     sample->SetSampleTime(sampleTime);
     sample->SetSampleDuration(sampleDuration);
 
-    return succeeded(sinkWriter_->WriteSample(videoStreamIndex_, sample.Get()), "WriteSample");
+    outSample = sample;
+    return true;
 }
 
-bool MFEncoder::writeBgraFrame(const BgraFrameView& frame, int64_t timestampHns) {
-    std::scoped_lock writerLock(writerMutex_);
-    if (!sinkWriter_ || finalized_) {
-        return false;
-    }
+bool MFEncoder::captureBgraSample(
+    const BgraFrameView& frame,
+    int64_t timestampHns,
+    Microsoft::WRL::ComPtr<IMFSample>& outSample) {
+    outSample.Reset();
 
-    if (firstTimestampHns_ < 0) {
-        firstTimestampHns_ = timestampHns;
-    }
-
-    int64_t sampleTime = timestampHns - firstTimestampHns_;
-    if (sampleTime <= lastTimestampHns_) {
-        sampleTime = lastTimestampHns_ + (10'000'000LL / fps_);
-    }
     const int64_t sampleDuration = 10'000'000LL / fps_;
-    lastTimestampHns_ = sampleTime;
+    int64_t sampleTime = 0;
+    {
+        std::scoped_lock writerLock(writerMutex_);
+        if (!sinkWriter_ || finalized_) {
+            return false;
+        }
+
+        if (firstTimestampHns_ < 0) {
+            firstTimestampHns_ = timestampHns;
+        }
+
+        sampleTime = timestampHns - firstTimestampHns_;
+        if (sampleTime <= lastTimestampHns_) {
+            sampleTime = lastTimestampHns_ + sampleDuration;
+        }
+        lastTimestampHns_ = sampleTime;
+    }
 
     Microsoft::WRL::ComPtr<IMFMediaBuffer> buffer;
     const DWORD frameBytes = static_cast<DWORD>(width_ * height_ * 4);
@@ -696,7 +720,25 @@ bool MFEncoder::writeBgraFrame(const BgraFrameView& frame, int64_t timestampHns)
     sample->SetSampleTime(sampleTime);
     sample->SetSampleDuration(sampleDuration);
 
-    return succeeded(sinkWriter_->WriteSample(videoStreamIndex_, sample.Get()), "WriteSample(webcam)");
+    outSample = sample;
+    return true;
+}
+
+bool MFEncoder::submitVideoSample(IMFSample* sample) {
+    if (!sample) {
+        return false;
+    }
+
+    // This is the potentially slow, blocking step (especially with the
+    // software H.264 encoder fallback): IMFSinkWriter::WriteSample runs the
+    // encode synchronously on the calling thread. Callers must NOT hold any
+    // lock shared with a thread that needs to make timely progress (e.g. a
+    // stop-request check) across this call.
+    std::scoped_lock writerLock(writerMutex_);
+    if (!sinkWriter_ || finalized_) {
+        return false;
+    }
+    return succeeded(sinkWriter_->WriteSample(videoStreamIndex_, sample), "WriteSample");
 }
 
 bool MFEncoder::writeAudio(const BYTE* data, DWORD byteCount, int64_t timestampHns, int64_t durationHns) {

--- a/electron/native/wgc-capture/src/mf_encoder.h
+++ b/electron/native/wgc-capture/src/mf_encoder.h
@@ -53,8 +53,25 @@ public:
         ID3D11DeviceContext* context,
         const AudioInputFormat* audioFormat = nullptr,
         MFEncoderOptions options = {});
-    bool writeFrame(ID3D11Texture2D* texture, int64_t timestampHns, const BgraFrameView* webcamFrame = nullptr);
-    bool writeBgraFrame(const BgraFrameView& frame, int64_t timestampHns);
+    // Capturing a video/webcam sample (GPU readback + IMFSample creation) is
+    // split from submitting it to the sink writer (IMFSinkWriter::WriteSample)
+    // so callers that hold an external lock across the GPU-touching capture
+    // step (to serialize against a producer thread writing into the same
+    // texture) are not forced to also hold that lock across the potentially
+    // slow, blocking WriteSample call. See main.cpp's writeVideoFrames for why
+    // this split exists: holding the shared frame-state mutex across
+    // WriteSample let the software H.264 encoder path starve the main
+    // thread's stop-request check indefinitely (issue #115).
+    bool captureVideoSample(
+        ID3D11Texture2D* texture,
+        int64_t timestampHns,
+        const BgraFrameView* webcamFrame,
+        Microsoft::WRL::ComPtr<IMFSample>& outSample);
+    bool captureBgraSample(
+        const BgraFrameView& frame,
+        int64_t timestampHns,
+        Microsoft::WRL::ComPtr<IMFSample>& outSample);
+    bool submitVideoSample(IMFSample* sample);
     bool writeAudio(const BYTE* data, DWORD byteCount, int64_t timestampHns, int64_t durationHns);
     bool finalize();
     const char* videoEncoderSelection() const;


### PR DESCRIPTION
## Summary
- Fixes #115: Windows native recorder never stops after the stdin `stop` command when `preferSoftwareEncoder: true` and system audio/mic/webcam/cursor are all disabled.
- Root cause: `writeVideoFrames` (main.cpp) held the shared frame-state mutex across `IMFSinkWriter::WriteSample`, which the main thread's stop-wait also locks to check `control.stopRequested`. With the software H.264 fallback, `WriteSample` is slow enough that the writer thread could keep re-acquiring the lock every frame faster than the main thread could win it after a stop request, starving the stop-wait — matching the report that no `[stop-timing]` line ever printed at all.
- Fix: split `MFEncoder::writeFrame`/`writeBgraFrame` into a `captureVideoSample`/`captureBgraSample` step (GPU readback + `IMFSample` construction, still under the shared mutex since it touches `latestFrameTexture`) and a `submitVideoSample` step (the blocking `WriteSample` call, only under the encoder's own low-contention `writerMutex_`). `main.cpp`'s `writeVideoFrames` now calls submit *outside* the shared mutex.

## Test plan
- [x] Built `wgc-capture.exe` locally via MSVC (VS 18 Insiders) + CMake/Ninja — compiles cleanly, no new warnings.
- [x] Ran the exact repro (display capture, `captureSystemAudio/captureMic/captureCursor/webcamEnabled: false`, `preferSoftwareEncoder: true`), sent `stop` over stdin after 4s: helper now exits ~97ms later with a valid non-zero MP4 (previously the process could hang indefinitely).
- [ ] Not independently reproduced on hardware matching the original report (Windows 10, Intel UHD 620 + NVIDIA MX150 hybrid laptop) — the hang did not occur even on the pre-fix build on this dev machine (Windows 11, different scheduler/hardware), so this fix addresses a confirmed code-level hazard (blocking I/O under a contended mutex) but the exact reproduction on the reporter's hardware is unverified. Recommend the reporter test this branch/build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1528298065658908694 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video and webcam frame processing to reduce blocking during recording.
  * Increased capture stability by separating frame capture from encoding submission.
  * Improved failure handling so recording stops cleanly when frame processing encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->