### PR TITLE
fix(timeline): decouple playhead from ancestor re-renders so it tracks playback

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -1004,6 +1004,16 @@ export default function VideoEditor() {
 		video.currentTime = time;
 	}
 
+	// Reads the live playhead position directly off the <video> element, bypassing
+	// `currentTime` React state entirely. The timeline's playhead subscribes to this
+	// via its own rAF loop so it stays in lockstep with actual playback regardless of
+	// how long this (large) component's own re-render takes — see issue #111.
+	const getPlaybackTimeMs = useCallback(() => {
+		const video = videoPlaybackRef.current?.video;
+		if (video) return video.currentTime * 1000;
+		return currentTimeRef.current * 1000;
+	}, []);
+
 	const handleSelectZoom = useCallback((id: string | null) => {
 		setSelectedZoomId(id);
 		if (id) {
@@ -3213,6 +3223,7 @@ export default function VideoEditor() {
 								<TimelineEditor
 									videoDuration={duration}
 									currentTime={currentTime}
+									getPlaybackTimeMs={getPlaybackTimeMs}
 									onSeek={handleSeek}
 									zoomRegions={zoomRegions}
 									onZoomAdded={handleZoomAdded}

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -1308,25 +1308,26 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 			layoutVideoContentRef.current?.();
 			video.pause();
 
-			const { handlePlay, handlePause, handleSeeked, handleSeeking } = createVideoEventHandlers({
-				video,
-				isSeekingRef,
-				isPlayingRef,
-				allowPlaybackRef,
-				currentTimeRef,
-				timeUpdateAnimationRef,
-				onPlayStateChange: (playing) => onPlayStateChangeRef.current(playing),
-				onTimeUpdate: (time) => onTimeUpdateRef.current(time),
-				trimRegionsRef,
-				speedRegionsRef,
-				isScrubbingRef,
-				scrubEndTimerRef,
-				onScrubChange: (scrubbing) => setIsScrubbing(scrubbing),
-				seekSteppingRef,
-				stepVirtualSecRef,
-				stepLastTsRef,
-				stepPrevMutedRef,
-			});
+			const { handlePlay, handlePause, handleSeeked, handleSeeking, dispose } =
+				createVideoEventHandlers({
+					video,
+					isSeekingRef,
+					isPlayingRef,
+					allowPlaybackRef,
+					currentTimeRef,
+					timeUpdateAnimationRef,
+					onPlayStateChange: (playing) => onPlayStateChangeRef.current(playing),
+					onTimeUpdate: (time) => onTimeUpdateRef.current(time),
+					trimRegionsRef,
+					speedRegionsRef,
+					isScrubbingRef,
+					scrubEndTimerRef,
+					onScrubChange: (scrubbing) => setIsScrubbing(scrubbing),
+					seekSteppingRef,
+					stepVirtualSecRef,
+					stepLastTsRef,
+					stepPrevMutedRef,
+				});
 
 			video.addEventListener("play", handlePlay);
 			video.addEventListener("pause", handlePause);
@@ -1344,6 +1345,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 				if (timeUpdateAnimationRef.current) {
 					cancelAnimationFrame(timeUpdateAnimationRef.current);
 				}
+				dispose();
 
 				if (videoSprite) {
 					videoContainer.removeChild(videoSprite);

--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -316,7 +316,9 @@ function PlaybackCursor({
 	// ancestor's (much heavier) re-render is in flight — see issue #111.
 	const [liveTimeMs, setLiveTimeMs] = useState(currentTimeMs);
 	const getPlaybackTimeMsRef = useRef(getPlaybackTimeMs);
-	getPlaybackTimeMsRef.current = getPlaybackTimeMs;
+	useEffect(() => {
+		getPlaybackTimeMsRef.current = getPlaybackTimeMs;
+	}, [getPlaybackTimeMs]);
 
 	useEffect(() => {
 		if (!getPlaybackTimeMsRef.current) {

--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -58,6 +58,12 @@ interface TimelineEditorProps {
 	videoDuration: number;
 	hasVideoSource?: boolean;
 	currentTime: number;
+	/**
+	 * Reads the live playhead position (ms) directly, bypassing `currentTime` React
+	 * state. The playhead subscribes to this via its own rAF loop so it stays in sync
+	 * with actual playback regardless of how long an ancestor's re-render takes.
+	 */
+	getPlaybackTimeMs?: () => number;
 	onSeek?: (time: number) => void;
 	zoomRegions: ZoomRegion[];
 	onZoomAdded: (span: Span) => void;
@@ -284,6 +290,7 @@ function shouldStartTimelineScrub(target: EventTarget | null, timelineElement: H
 function PlaybackCursor({
 	currentTimeMs,
 	videoDurationMs,
+	getPlaybackTimeMs,
 	onSeek,
 	onRangeChange,
 	timelineRef,
@@ -291,6 +298,7 @@ function PlaybackCursor({
 }: {
 	currentTimeMs: number;
 	videoDurationMs: number;
+	getPlaybackTimeMs?: () => number;
 	onSeek?: (time: number) => void;
 	onRangeChange?: (updater: (previous: Range) => Range) => void;
 	timelineRef: React.RefObject<HTMLDivElement>;
@@ -300,6 +308,36 @@ function PlaybackCursor({
 	const sideProperty = direction === "rtl" ? "right" : "left";
 	const [isDragging, setIsDragging] = useState(false);
 	const [dragPreviewTimeMs, setDragPreviewTimeMs] = useState<number | null>(null);
+
+	// Drives the playhead position from the video element every animation frame,
+	// isolated from the rest of the tree: this component's own `useState` call only
+	// re-renders this small subtree, not TimelineEditor/VideoEditor above it. That
+	// decoupling is what keeps the playhead glued to actual playback even while an
+	// ancestor's (much heavier) re-render is in flight — see issue #111.
+	const [liveTimeMs, setLiveTimeMs] = useState(currentTimeMs);
+	const getPlaybackTimeMsRef = useRef(getPlaybackTimeMs);
+	getPlaybackTimeMsRef.current = getPlaybackTimeMs;
+
+	useEffect(() => {
+		if (!getPlaybackTimeMsRef.current) {
+			return;
+		}
+
+		let rafId: number;
+		const tick = () => {
+			const getter = getPlaybackTimeMsRef.current;
+			if (getter) {
+				const latest = getter();
+				setLiveTimeMs((previous) => (previous === latest ? previous : latest));
+			}
+			rafId = requestAnimationFrame(tick);
+		};
+		rafId = requestAnimationFrame(tick);
+
+		return () => cancelAnimationFrame(rafId);
+	}, []);
+
+	const resolvedTimeMs = getPlaybackTimeMs ? liveTimeMs : currentTimeMs;
 
 	useEffect(() => {
 		if (!isDragging) return;
@@ -399,7 +437,7 @@ function PlaybackCursor({
 	]);
 
 	const displayTimeMs =
-		isDragging && dragPreviewTimeMs !== null ? dragPreviewTimeMs : currentTimeMs;
+		isDragging && dragPreviewTimeMs !== null ? dragPreviewTimeMs : resolvedTimeMs;
 
 	if (videoDurationMs <= 0 || displayTimeMs < 0) {
 		return null;
@@ -428,7 +466,7 @@ function PlaybackCursor({
 				}}
 				onMouseDown={(e) => {
 					e.stopPropagation(); // Prevent timeline click
-					setDragPreviewTimeMs(currentTimeMs);
+					setDragPreviewTimeMs(resolvedTimeMs);
 					setIsDragging(true);
 				}}
 			>
@@ -571,6 +609,7 @@ function Timeline({
 	items,
 	videoDurationMs,
 	currentTimeMs,
+	getPlaybackTimeMs,
 	onSeek,
 	onRangeChange,
 	onSelectZoom,
@@ -592,6 +631,7 @@ function Timeline({
 	items: TimelineRenderItem[];
 	videoDurationMs: number;
 	currentTimeMs: number;
+	getPlaybackTimeMs?: () => number;
 	onSeek?: (time: number) => void;
 	onRangeChange?: (updater: (previous: Range) => Range) => void;
 	onSelectZoom?: (id: string | null) => void;
@@ -797,6 +837,7 @@ function Timeline({
 			<PlaybackCursor
 				currentTimeMs={currentTimeMs}
 				videoDurationMs={videoDurationMs}
+				getPlaybackTimeMs={getPlaybackTimeMs}
 				onSeek={onSeek}
 				onRangeChange={onRangeChange}
 				timelineRef={localTimelineRef}
@@ -934,6 +975,7 @@ export default function TimelineEditor({
 	videoDuration,
 	hasVideoSource = false,
 	currentTime,
+	getPlaybackTimeMs,
 	onSeek,
 	zoomRegions,
 	onZoomAdded,
@@ -1803,6 +1845,7 @@ export default function TimelineEditor({
 						items={timelineItems}
 						videoDurationMs={totalMs}
 						currentTimeMs={currentTimeMs}
+						getPlaybackTimeMs={getPlaybackTimeMs}
 						onSeek={onSeek}
 						onRangeChange={setRange}
 						onSelectZoom={onSelectZoom}

--- a/src/components/video-editor/videoPlayback/rafCoalescer.test.ts
+++ b/src/components/video-editor/videoPlayback/rafCoalescer.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRafCoalescer } from "./rafCoalescer";
+
+describe("createRafCoalescer", () => {
+	let rafCallbacks: FrameRequestCallback[];
+	let nextRafId: number;
+
+	beforeEach(() => {
+		rafCallbacks = [];
+		nextRafId = 1;
+		vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+			rafCallbacks.push(cb);
+			return nextRafId++;
+		});
+		vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+			// Mark the callback as a no-op instead of removing it, to mirror the
+			// browser's index-stable semantics.
+			const index = id - 1;
+			if (rafCallbacks[index]) {
+				rafCallbacks[index] = () => {
+					// Cancelled: no-op.
+				};
+			}
+		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	function flushOneFrame(timeMs = 0) {
+		const callbacks = rafCallbacks;
+		rafCallbacks = [];
+		for (const cb of callbacks) cb(timeMs);
+	}
+
+	it("does not call flush until an animation frame runs", () => {
+		const flush = vi.fn();
+		const coalescer = createRafCoalescer<number>(flush);
+
+		coalescer.schedule(1);
+
+		expect(flush).not.toHaveBeenCalled();
+	});
+
+	it("collapses multiple schedule calls within the same frame into a single flush", () => {
+		const flush = vi.fn();
+		const coalescer = createRafCoalescer<number>(flush);
+
+		coalescer.schedule(1);
+		coalescer.schedule(2);
+		coalescer.schedule(3);
+
+		flushOneFrame();
+
+		expect(flush).toHaveBeenCalledTimes(1);
+		expect(flush).toHaveBeenCalledWith(3);
+	});
+
+	it("schedules a fresh frame for values reported after the previous frame flushed", () => {
+		const flush = vi.fn();
+		const coalescer = createRafCoalescer<number>(flush);
+
+		coalescer.schedule(1);
+		flushOneFrame();
+		coalescer.schedule(2);
+		flushOneFrame();
+
+		expect(flush).toHaveBeenCalledTimes(2);
+		expect(flush).toHaveBeenNthCalledWith(1, 1);
+		expect(flush).toHaveBeenNthCalledWith(2, 2);
+	});
+
+	it("cancel() prevents a pending flush from firing", () => {
+		const flush = vi.fn();
+		const coalescer = createRafCoalescer<number>(flush);
+
+		coalescer.schedule(1);
+		coalescer.cancel();
+		flushOneFrame();
+
+		expect(flush).not.toHaveBeenCalled();
+	});
+
+	it("a schedule() call after cancel() still flushes on the next frame", () => {
+		const flush = vi.fn();
+		const coalescer = createRafCoalescer<number>(flush);
+
+		coalescer.schedule(1);
+		coalescer.cancel();
+		coalescer.schedule(2);
+		flushOneFrame();
+
+		expect(flush).toHaveBeenCalledTimes(1);
+		expect(flush).toHaveBeenCalledWith(2);
+	});
+});

--- a/src/components/video-editor/videoPlayback/rafCoalescer.ts
+++ b/src/components/video-editor/videoPlayback/rafCoalescer.ts
@@ -1,0 +1,41 @@
+/**
+ * Coalesces rapid-fire calls into at most one flush per animation frame.
+ *
+ * Used so a ref-backed value can be updated synchronously on every call (cheap),
+ * while an expensive side effect — e.g. a React state commit — is deferred to
+ * once per frame. Without this, a burst of calls within the same frame (many
+ * `seeking` events fired while dragging the timeline playhead) would otherwise
+ * force one state commit per call, saturating the main thread and making both
+ * the drag and the playhead's own rendering feel laggy.
+ */
+export function createRafCoalescer<T>(flush: (value: T) => void) {
+	let pendingValue: T | undefined;
+	let hasPending = false;
+	let rafId: number | null = null;
+
+	const schedule = (value: T) => {
+		pendingValue = value;
+		hasPending = true;
+		if (rafId !== null) return;
+		rafId = requestAnimationFrame(() => {
+			rafId = null;
+			if (hasPending) {
+				hasPending = false;
+				const valueToFlush = pendingValue as T;
+				pendingValue = undefined;
+				flush(valueToFlush);
+			}
+		});
+	};
+
+	const cancel = () => {
+		if (rafId !== null) {
+			cancelAnimationFrame(rafId);
+			rafId = null;
+		}
+		hasPending = false;
+		pendingValue = undefined;
+	};
+
+	return { schedule, cancel };
+}

--- a/src/components/video-editor/videoPlayback/videoEventHandlers.ts
+++ b/src/components/video-editor/videoPlayback/videoEventHandlers.ts
@@ -1,5 +1,6 @@
 import type React from "react";
 import { MAX_NATIVE_PLAYBACK_RATE, type SpeedRegion, type TrimRegion } from "../types";
+import { createRafCoalescer } from "./rafCoalescer";
 
 // Keep "scrub mode" on for a brief tail after `seeked`: rapid drag-scrubbing fires
 // `seeking`/`seeked` dozens of times a second and toggling effects each time would flicker.
@@ -77,9 +78,16 @@ export function createVideoEventHandlers(params: VideoEventHandlersParams) {
 		}
 	};
 
+	// currentTimeRef is updated synchronously on every call (cheap; other imperative
+	// consumers like the Pixi renderer read it directly). The React state commit
+	// (`onTimeUpdate`) is coalesced to at most once per animation frame so a burst of
+	// `seeking` events (fast timeline drag) or the per-frame rAF playback loop can't
+	// force more than one parent re-render per frame.
+	const timeUpdateCoalescer = createRafCoalescer<number>(onTimeUpdate);
+
 	const emitTime = (timeValue: number) => {
 		currentTimeRef.current = timeValue * 1000;
-		onTimeUpdate(timeValue);
+		timeUpdateCoalescer.schedule(timeValue);
 	};
 
 	const findActiveTrimRegion = (currentTimeMs: number): TrimRegion | null => {
@@ -331,5 +339,6 @@ export function createVideoEventHandlers(params: VideoEventHandlersParams) {
 		handlePause,
 		handleSeeked,
 		handleSeeking,
+		dispose: () => timeUpdateCoalescer.cancel(),
 	};
 }


### PR DESCRIPTION
## Summary

Fixes #111 — the timeline playhead/scrubber visually lagged behind actual video playback, and dragging it while the video was playing felt laggy/unresponsive.

## Root cause

The playhead's position came from `currentTime` React state, set by `VideoEditor` (~3300 lines) via `setCurrentTime` on every `requestAnimationFrame` tick during playback, and on every `seeking` event fired while dragging. Each of those calls forced a full re-render of `VideoEditor` → `VideoPlayback` (~2300 lines) → `TimelineEditor` (~1800 lines) before the playhead's DOM position actually moved. At 60 ticks/sec (or dozens of `seeking` events/sec while scrubbing), that render cascade couldn't keep up, so the playhead visibly fell behind the video and dragging felt sluggish.

Playback itself was already driven by `requestAnimationFrame` reading `video.currentTime` (not the low-rate `timeupdate` event), so the fix is specifically about decoupling the playhead's *rendering* from the rest of the tree, not about the playback clock itself.

## Fix

- `PlaybackCursor` (in `src/components/video-editor/timeline/TimelineEditor.tsx`) now reads the video element's current time directly through a new `getPlaybackTimeMs` getter, in its own `requestAnimationFrame` loop with its own local `useState`. Only this small component re-renders per frame — React re-renders start at the component whose state changed, not its ancestors, so `VideoEditor`'s render cost no longer gates how quickly the playhead moves.
- `VideoEditor` exposes `getPlaybackTimeMs` (reading `videoPlaybackRef.current.video.currentTime`) and threads it down through `TimelineEditor` → `Timeline` → `PlaybackCursor`.
- Added `src/components/video-editor/videoPlayback/rafCoalescer.ts`: coalesces the `onTimeUpdate` → `setCurrentTime` state commit (still used by everything else that reads `currentTime`) to at most once per animation frame, so a burst of `seeking` events from a fast timeline drag doesn't force one React state commit per event. `currentTimeRef` (read by other imperative consumers like the Pixi renderer) is still updated synchronously on every call — only the state commit is deferred.

Scoped narrowly to the playhead rendering/update path, per the project's timeline-model-cleanup notes — no changes to the clip in/out/trim/effects region logic.

## Verification

- `npx tsc --noEmit`: clean (two pre-existing unrelated errors — missing `@xenova/transformers`/`onnxruntime-web` type declarations — reproduce identically on `main` before this change, confirmed via `git stash`).
- `npm run lint`: clean.
- `npm run test`: 412/412 passing, including a new `rafCoalescer.test.ts` covering the coalescing behavior (collapses same-frame calls, schedules a fresh frame for later values, `cancel()` semantics).
- **Honesty note on desktop verification**: I did not drive the real Electron app end-to-end for this change. This worktree's `node_modules` was empty and its `package.json`/lockfile has diverged from the main checkout (unrelated agent-tooling dependencies added there), so a full native launch (junctioned bins, HUD, record → editor flow) needed more setup than fit this task's scope. Verification here is unit tests + careful reading of the render/re-render path (confirmed React only re-renders the state-owning component and its descendants, so isolating the tick to `PlaybackCursor`'s own `useState` genuinely decouples it from `VideoEditor`/`TimelineEditor`'s render cost). A manual smoke test (play a clip, watch the playhead track it; drag the playhead mid-playback) is recommended before merge.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run test` (412 passing)
- [ ] Manual smoke test: record/open a clip, play it, confirm the playhead visually tracks the video without lag; drag the playhead while playing and confirm it feels responsive

<!-- discord-thread-id:1528298253081116703 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timeline playhead accuracy by syncing it to the video’s live playback time, with a fallback when live time isn’t available.
  - Kept timeline time updates smooth by batching playback time events to at most once per animation frame.
  - Improved cleanup during video playback teardown to prevent stray pending updates.
- **Tests**
  - Added unit tests for animation-frame coalescing, covering flush timing, cancellation, and rescheduling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->