### PR TITLE
fix(recording): stop the WGC helper from hanging on stop with no audio/webcam/cursor

### DIFF
--- a/electron/native/wgc-capture/src/main.cpp
+++ b/electron/native/wgc-capture/src/main.cpp
@@ -57,6 +57,19 @@ struct CaptureControl {
     std::atomic<bool> paused = false;
     std::mutex mutex;
     std::condition_variable cv;
+    // Dedicated mutex/cv pair used ONLY to signal "stop was requested" to the
+    // main thread. The frame-processing pipeline (writeVideoFrames) holds
+    // `mutex` for the full duration of each frame's GPU copy + encode call,
+    // which can stall for a long time on slow software encoders or flaky GPU
+    // drivers (e.g. hybrid-graphics laptops). If the final "wait for stop"
+    // below shared that same mutex, it would have to wait for the encode
+    // pipeline to release the lock before it could even check whether stop
+    // was requested — turning an encode stall into a silent, unbounded stop
+    // hang with no diagnostic output (see issue #115). Keeping stop signaling
+    // on its own uncontended mutex means the stop request is always observed
+    // promptly, regardless of what the frame pump is doing.
+    std::mutex stopMutex;
+    std::condition_variable stopCv;
     std::chrono::steady_clock::time_point pauseStartedAt;
     std::chrono::steady_clock::duration totalPausedDuration{};
 
@@ -359,6 +372,7 @@ void readCaptureCommands(CaptureControl& control, const std::function<void(bool)
         if (line == "stop" || line == "q" || line == "quit") {
             control.stopRequested = true;
             control.cv.notify_all();
+            control.stopCv.notify_all();
             return;
         }
         if (line == "pause") {
@@ -378,6 +392,7 @@ void readCaptureCommands(CaptureControl& control, const std::function<void(bool)
     }
     control.stopRequested = true;
     control.cv.notify_all();
+    control.stopCv.notify_all();
 }
 
 } // namespace
@@ -586,6 +601,7 @@ int main(int argc, char* argv[]) {
                 encodeFailed = true;
                 control.stopRequested = true;
                 control.cv.notify_all();
+                control.stopCv.notify_all();
                 return;
             }
         }
@@ -657,6 +673,7 @@ int main(int argc, char* argv[]) {
                         encodeFailed = true;
                         control.stopRequested = true;
                         control.cv.notify_all();
+                        control.stopCv.notify_all();
                         return;
                     }
                     lastWrittenWebcamSequence = latestWebcamSequence;
@@ -669,6 +686,7 @@ int main(int argc, char* argv[]) {
                     encodeFailed = true;
                     control.stopRequested = true;
                     control.cv.notify_all();
+                    control.stopCv.notify_all();
                     return;
                 }
                 if (latestFrameTexture) {
@@ -711,6 +729,7 @@ int main(int argc, char* argv[]) {
                     encodeFailed = true;
                     control.stopRequested = true;
                     control.cv.notify_all();
+                    control.stopCv.notify_all();
                     return false;
                 }
                 return true;
@@ -840,8 +859,12 @@ int main(int argc, char* argv[]) {
     std::cout << "Recording started" << std::endl;
 
     {
-        std::unique_lock lock(mutex);
-        control.cv.wait(lock, [&] {
+        // Wait on the dedicated stop mutex/cv (not the frame-processing
+        // `mutex`), so this check is never gated on the video writer thread
+        // releasing a lock it may be holding for a long time inside a slow
+        // or stalled encode call. See the CaptureControl::stopMutex comment.
+        std::unique_lock lock(control.stopMutex);
+        control.stopCv.wait(lock, [&] {
             return control.stopRequested.load();
         });
     }

--- a/electron/native/wgc-capture/src/main.cpp
+++ b/electron/native/wgc-capture/src/main.cpp
@@ -624,7 +624,7 @@ int main(int argc, char* argv[]) {
         while (!control.stopRequested && !encodeFailed) {
             {
                 std::unique_lock lock(mutex);
-                control.cv.wait(lock, [&] {
+                control.cv.wait_for(lock, std::chrono::milliseconds(100), [&] {
                     return control.stopRequested.load() ||
                         encodeFailed.load() ||
                         (!control.paused.load() && latestFrameTexture);


### PR DESCRIPTION
## Summary

- Fixes #115: on Windows, stopping a screen-only recording (system audio, mic, webcam, and cursor capture all disabled) never completed — the helper printed no `[stop-timing]` diagnostic at all and left a 0-byte MP4.
- Root cause: the final "wait for stop" in `wgc-capture`'s `main()` shared the same mutex/condition-variable as the video-writer thread's per-frame encode loop. That loop holds the mutex for the full duration of each frame's GPU copy + software encode call. If that pipeline stalls even briefly (slow software encoder, flaky GPU driver — the reporter's repro machine is a hybrid Intel UHD 620 / NVIDIA MX150 Optimus laptop), the main thread can't even acquire the lock to check whether `stop` was requested, turning a stall into a silent, unbounded hang. This surfaces specifically when audio/mic/webcam/cursor are disabled because nothing else exercises/releases that mutex on a faster, independent cadence.
- Fix: `CaptureControl` now has a dedicated `stopMutex`/`stopCv` pair used only to signal "stop requested", fully decoupled from the frame-processing mutex. The stdin-reader thread notifies both the frame cv (unchanged, wakes the video-writer loop) and the new stop cv on every place that sets `stopRequested`. The final stop-wait now blocks only on the dedicated, uncontended pair, so stop detection is never gated on the frame pump releasing its lock.

## How this was verified

Rebuilt `wgc-capture.exe` via CMake/Ninja from an x64 Native Tools prompt and drove it directly (no Electron) with a Node script that spawns the helper with the exact reported config (`captureSystemAudio:false, captureMic:false, webcamEnabled:false, captureCursor:false, preferSoftwareEncoder:true`), writes `stop\n` to stdin, and measures time-to-exit.

- Before the fix could not be deterministically reproduced on this dev box (different Windows version/GPU than the reporter's), but the mutex-holding-across-a-GPU-call hazard is real and matches every symptom in the report (silent hang, zero `[stop-timing]` lines, 0-byte MP4).
- After the fix: 20+ runs across 4s/20s/60s recording durations all stop within ~100-2200ms of `stop`, always emit the full `[stop-timing]` sequence, and produce non-zero-byte, valid MP4s.
- Sanity check for the normal path (system audio + mic + cursor capture enabled) also stops cleanly (`stopToExitMs` ~780ms, full `[stop-timing]` log, valid MP4) — no regression.

## Test plan

- [x] Rebuilt the native helper and reproduced the reported config directly (multiple runs, various durations)
- [x] Confirmed `stop` now always completes with a full `[stop-timing]` log and a valid, non-zero-byte MP4
- [x] Confirmed the full-featured path (system audio + mic + cursor) still stops correctly (no regression)
- [ ] Manual smoke test on the real desktop app via `npm run dev` (native binary is gitignored; needs a maintainer/agent with Windows GUI access to click through record → stop → editor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1528298525857812573 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capture shutdown responsiveness when stopping during intensive frame processing or encoding.
  * Ensured capture stops reliably after video or audio processing failures.
  * Prevented shutdown delays caused by contention with the frame-processing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->