### PR TITLE
fix(recording): bound the video-writer frame wait as a hang safety net

### DIFF
--- a/electron/native/wgc-capture/src/main.cpp
+++ b/electron/native/wgc-capture/src/main.cpp
@@ -613,7 +613,7 @@ int main(int argc, char* argv[]) {
 
             {
                 std::unique_lock lock(mutex);
-                control.cv.wait(lock, [&] {
+                control.cv.wait_for(lock, std::chrono::milliseconds(100), [&] {
                     return control.stopRequested.load() ||
                         encodeFailed.load() ||
                         (!control.paused.load() && latestFrameTexture);


### PR DESCRIPTION
## Summary
Small follow-up to #119 (Fixes #115). CodeRabbit flagged this on the now-superseded #121: the video-writer thread's per-frame `cv.wait()` in `writeVideoFrames` has no timeout. If a notification were ever missed, the thread would block indefinitely, hanging `videoWriterThread.join()` and the whole stop sequence — the exact failure mode #115/#119 already fixed for the common case.

#119 already fixed the actual root cause (the blocking `WriteSample` call no longer runs under the shared mutex, so the main thread's stop-wait is never starved). This is a defense-in-depth hardening on top: switch the video-writer's own wait to `wait_for(100ms)` so it always re-checks `stopRequested`/`encodeFailed` periodically, instead of relying solely on a notification reaching an already-waiting thread.

## Verification
Rebuilt `wgc-capture.exe` on top of current `main` (includes #119) via CMake/Ninja:
- Re-ran the exact #115 repro (screen-only, system audio/mic/webcam/cursor all disabled, `preferSoftwareEncoder: true`): stops in ~89ms with a full `[stop-timing]` log and a valid non-zero MP4.
- Full-featured regression (system audio + cursor capture enabled): stops in ~107ms, full timing log, valid MP4. No regression.

## Test plan
- [x] Rebuilt native helper on top of latest main
- [x] Re-verified the #115 repro still stops promptly
- [x] Verified the full-featured path is unaffected

Related to #115 (already closed by #119) — no functional bug left open, this is a pure hardening commit.

<!-- discord-thread-id:1528332269788598405 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video frame processing responsiveness by periodically checking for new frames and stop requests.
  * Helps prevent capture operations from remaining idle when an expected wake-up signal is missed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->