### PR TITLE
fix(editor): fix annotation placeholder text and post-reload duration cap

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -404,6 +404,11 @@ export default function VideoEditor() {
 			} catch {
 				// no-op
 			}
+			// This inferred duration is only a placeholder until the video element's real
+			// metadata resolves (see VideoPlayback's syncResolvedDuration). Reset its memoized
+			// last-resolved-duration guard so that resolution isn't skipped just because the
+			// real duration happens to match a value already seen from before this load.
+			videoPlaybackRef.current?.resetDurationResolution();
 			setIsPlaying(false);
 			setCurrentTime(0);
 			setDuration(inferredDurationMs > 0 ? inferredDurationMs / 1000 : 0);
@@ -1477,7 +1482,7 @@ export default function VideoEditor() {
 				startMs: Math.round(span.start),
 				endMs: Math.round(span.end),
 				type: "text",
-				content: "Enter text...",
+				content: "",
 				position: { ...DEFAULT_ANNOTATION_POSITION },
 				size: { ...DEFAULT_ANNOTATION_SIZE },
 				style: { ...DEFAULT_ANNOTATION_STYLE },
@@ -1616,7 +1621,7 @@ export default function VideoEditor() {
 					if (region.id !== id) return region;
 					const updatedRegion = { ...region, type };
 					if (type === "text") {
-						updatedRegion.content = region.textContent || "Enter text...";
+						updatedRegion.content = region.textContent || "";
 					} else if (type === "image") {
 						updatedRegion.content = region.imageContent || "";
 					} else if (type === "figure") {

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -109,6 +109,7 @@ import {
 	type BlurData,
 	type CameraFullscreenRegion,
 	clampFocusToDepth,
+	createTextAnnotationRegion,
 	DEFAULT_ANNOTATION_POSITION,
 	DEFAULT_ANNOTATION_SIZE,
 	DEFAULT_ANNOTATION_STYLE,
@@ -119,6 +120,7 @@ import {
 	type FigureData,
 	type PlaybackSpeed,
 	type Rotation3DPreset,
+	resolveTextAnnotationContent,
 	type SpeedRegion,
 	type TrimRegion,
 	ZOOM_DEPTH_SCALES,
@@ -404,13 +406,10 @@ export default function VideoEditor() {
 			} catch {
 				// no-op
 			}
-			// This inferred duration is only a placeholder until the video element's real
-			// metadata resolves (see VideoPlayback's syncResolvedDuration). Reset its memoized
-			// last-resolved-duration guard so that resolution isn't skipped just because the
-			// real duration happens to match a value already seen from before this load.
-			videoPlaybackRef.current?.resetDurationResolution();
 			setIsPlaying(false);
 			setCurrentTime(0);
+			// This inferred duration is only a placeholder until the video element's real
+			// metadata resolves (see VideoPlayback's syncResolvedDuration).
 			setDuration(inferredDurationMs > 0 ? inferredDurationMs / 1000 : 0);
 
 			setError(null);
@@ -420,6 +419,13 @@ export default function VideoEditor() {
 			setWebcamVideoPath(webcamSourcePath ? toFileUrl(webcamSourcePath) : null);
 			setRecordingCursorCaptureMode(projectCursorCaptureMode);
 			setCurrentProjectPath(path ?? null);
+			// Reset the memoized last-resolved-duration guard so resolution isn't skipped
+			// just because the real duration happens to match a value already seen from
+			// before this load (e.g. reloading a project referencing the same video file,
+			// whose src may not change and so never re-fires `loadedmetadata`). Must run
+			// after the setDuration placeholder above, or its correction gets clobbered by
+			// the same-tick placeholder assignment winning the state-batch race.
+			videoPlaybackRef.current?.resetDurationResolution();
 
 			// A loaded project keeps its zooms exactly as saved, so never auto-suggest
 			// over it (even if it has zero zooms because the user deleted them all).
@@ -1477,17 +1483,12 @@ export default function VideoEditor() {
 		(span: Span) => {
 			const id = `annotation-${nextAnnotationIdRef.current++}`;
 			const zIndex = nextAnnotationZIndexRef.current++;
-			const newRegion: AnnotationRegion = {
+			const newRegion = createTextAnnotationRegion({
 				id,
 				startMs: Math.round(span.start),
 				endMs: Math.round(span.end),
-				type: "text",
-				content: "",
-				position: { ...DEFAULT_ANNOTATION_POSITION },
-				size: { ...DEFAULT_ANNOTATION_SIZE },
-				style: { ...DEFAULT_ANNOTATION_STYLE },
 				zIndex,
-			};
+			});
 			pushState((prev) => ({
 				annotationRegions: [...prev.annotationRegions, newRegion],
 			}));
@@ -1621,7 +1622,7 @@ export default function VideoEditor() {
 					if (region.id !== id) return region;
 					const updatedRegion = { ...region, type };
 					if (type === "text") {
-						updatedRegion.content = region.textContent || "";
+						updatedRegion.content = resolveTextAnnotationContent(region.textContent);
 					} else if (type === "image") {
 						updatedRegion.content = region.imageContent || "";
 					} else if (type === "figure") {

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -705,6 +705,16 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 			},
 			resetDurationResolution: () => {
 				lastResolvedDurationRef.current = null;
+				// If the video element is already loaded (e.g. reloading a project that
+				// references the same file, so its src never actually changes and
+				// `loadedmetadata` won't fire again), clearing the guard alone leaves
+				// nothing to trigger a re-sync. Resolve immediately in that case too.
+				const video = videoRef.current;
+				if (video && video.readyState >= HTMLMediaElement.HAVE_METADATA) {
+					if (!syncResolvedDuration(video)) {
+						forceResolveDuration(video);
+					}
+				}
 			},
 		}));
 

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -165,6 +165,14 @@ export interface VideoPlaybackRef {
 	containerRef: React.RefObject<HTMLDivElement>;
 	play: () => Promise<void>;
 	pause: () => void;
+	/**
+	 * Clears the memoized last-resolved-duration guard so the next metadata load
+	 * re-syncs `duration` even if the video's real (resolved) duration happens to
+	 * match a value already seen — needed when a caller (e.g. loading a saved
+	 * project) sets `duration` to something else in between, which the guard has
+	 * no other way to detect.
+	 */
+	resetDurationResolution: () => void;
 }
 
 function getResolvedVideoDuration(video: HTMLVideoElement): number | null {
@@ -694,6 +702,9 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 				}
 				video.pause();
 				supplementalAudioRef.current?.pause();
+			},
+			resetDurationResolution: () => {
+				lastResolvedDurationRef.current = null;
 			},
 		}));
 

--- a/src/components/video-editor/types.test.ts
+++ b/src/components/video-editor/types.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { createTextAnnotationRegion, resolveTextAnnotationContent } from "./types";
+
+// Regression coverage for #127: a freshly created text annotation must start with
+// truly empty content so the properties panel's placeholder shows and typing
+// replaces rather than appends to baked-in text.
+describe("createTextAnnotationRegion", () => {
+	it("starts with empty content, not a baked-in placeholder string", () => {
+		const region = createTextAnnotationRegion({
+			id: "annotation-1",
+			startMs: 1000,
+			endMs: 2000,
+			zIndex: 1,
+		});
+
+		expect(region.content).toBe("");
+		expect(region.type).toBe("text");
+	});
+});
+
+describe("resolveTextAnnotationContent", () => {
+	it("falls back to empty content when no prior text was stored", () => {
+		expect(resolveTextAnnotationContent(undefined)).toBe("");
+	});
+
+	it("preserves existing text content when converting an existing region to text", () => {
+		expect(resolveTextAnnotationContent("hello world")).toBe("hello world");
+	});
+});

--- a/src/components/video-editor/types.ts
+++ b/src/components/video-editor/types.ts
@@ -337,6 +337,37 @@ export const DEFAULT_ANNOTATION_STYLE: AnnotationTextStyle = {
 	textAnimation: "none",
 };
 
+/**
+ * A freshly created text annotation starts with no content: the properties panel's
+ * textarea has a real `placeholder` attribute for the empty-state hint, so the
+ * actual value must be empty for it to show and for typing to replace rather than
+ * append to baked-in text (see #127).
+ */
+export function createTextAnnotationRegion(params: {
+	id: string;
+	startMs: number;
+	endMs: number;
+	zIndex: number;
+}): AnnotationRegion {
+	return {
+		id: params.id,
+		startMs: params.startMs,
+		endMs: params.endMs,
+		type: "text",
+		content: "",
+		position: { ...DEFAULT_ANNOTATION_POSITION },
+		size: { ...DEFAULT_ANNOTATION_SIZE },
+		style: { ...DEFAULT_ANNOTATION_STYLE },
+		zIndex: params.zIndex,
+	};
+}
+
+/** Resolves the content for a region whose type is being switched to "text" -- same
+ * empty-by-default rule as a freshly created one when no prior text was stored. */
+export function resolveTextAnnotationContent(existingTextContent?: string): string {
+	return existingTextContent || "";
+}
+
 export const DEFAULT_FIGURE_DATA: FigureData = {
 	arrowDirection: "right",
 	color: "#34B27B",


### PR DESCRIPTION
## Summary
Two bugs found during a full end-to-end RC validation pass (real recording, real mic/webcam/system-audio, real export — see `docs/testing/rc-e2e-checklist.md`).

**1. Annotation placeholder text baked into content**
New text annotations were created with the literal string `"Enter text..."` as their actual content instead of starting empty. The properties panel's textarea already had a correct `placeholder` attribute, but since the value was never actually empty, the placeholder never showed — clicking in and typing appended after the baked-in text instead of replacing it. Fixed by defaulting new text annotations' content to `""`, matching the existing pattern for image/figure/blur types.

**2. Post-reload duration capped at last element's end time**
After Save Project → Load Project, the editor's scrubber/seek range was capped at the last timeline element's end time (e.g. 0:47) instead of the true recording duration (e.g. 1:10). Root cause: `applyLoadedProject` sets `duration` to an inferred placeholder (max of all region `endMs`) before the real video metadata resolves, expecting `VideoPlayback`'s `syncResolvedDuration` to correct it. But that correction is gated by a memoization ref (`lastResolvedDurationRef`) that skips the update whenever the resolved value matches what it already remembers — which it does whenever reloading the *same* video file, since the real duration hasn't changed even though `duration` state was just overwritten with something else. Fixed by exposing `resetDurationResolution()` on `VideoPlaybackRef`, called from `applyLoadedProject` to force the next metadata load to always re-sync.

## Verification
Verified via computer-use against a real dev build, not just code review:
- New annotation's text field shows a genuine empty value (timeline label reads "Empty text"); typing replaces cleanly.
- Loading a saved project with a trim region now correctly shows and scrubs to the full original duration (1:10) instead of being capped at 0:47.

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `biome check` — clean
- [x] Full suite: 53 files / 423 tests pass
- [x] Live computer-use verification of both fixes on a real build

<!-- discord-thread-id:1528361021046263809 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video duration synchronization when loading projects by re-syncing duration resolution.
  * Ensured duration metadata can refresh even when it matches a previously detected value.
  * New text annotations now start truly blank (no placeholder text).
  * Converting annotations to text now preserves existing content or initializes empty when none exists.
* **Tests**
  * Added regression tests to verify text annotation initialization and content normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->