### PR TITLE
chore: bump nix package to v1.7.0

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -11,7 +11,7 @@
 buildNpmPackage {
   nodejs = nodejs_22;
   pname = "openscreen";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src =
     let
@@ -33,7 +33,7 @@ buildNpmPackage {
       );
     };
 
-  npmDepsHash = "sha256-IZypOLWlDShIjCKWxlJcrdtIkMu0P/DuXaq4c0HW3FY=";
+  npmDepsHash = "sha256-cb8loUzQs4fz3um0xbYgtjQdcRZh/Ptk2YPgv3FHP/s=";
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 


### PR DESCRIPTION
Automated bump triggered by release `v1.7.0` (opened manually — the bot-triggered PR creation failed because GitHub Actions isn't permitted to create PRs on this repo).

- `version` → `1.7.0`
- `npmDepsHash` → `sha256-cb8loUzQs4fz3um0xbYgtjQdcRZh/Ptk2YPgv3FHP/s=` (computed via `prefetch-npm-deps package-lock.json` by the bump-nix-package workflow)

Merge this so Nix users (NixOS, Home Manager, `nix run github:getopenscreen/openscreen`) pick up the new release.

<!-- discord-thread-id:1528544518260129894 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version 1.7.0.
  * Refreshed the recorded dependency integrity data for builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->