### PR TITLE
chore: temp workflow to fire the missed v1.7.0 Discord announce

### DIFF
--- a/.github/workflows/temp-discord-announce.yml
+++ b/.github/workflows/temp-discord-announce.yml
@@ -1,0 +1,33 @@
+name: TEMP - Announce stable on Discord
+
+on:
+  workflow_dispatch:
+    inputs:
+      stable_tag:
+        description: "Stable tag to announce (e.g. v1.7.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  announce:
+    name: Announce stable on Discord
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup
+
+      - name: Announce stable on Discord
+        env:
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_RELEASE_CHANNEL_ID: ${{ vars.DISCORD_RELEASE_CHANNEL_ID }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STABLE_TAG: ${{ inputs.stable_tag }}
+          KIND: stable
+        run: node .github/scripts/discord-release-announce.mjs


### PR DESCRIPTION
Promote RC failed at the merge step twice, so the Discord-announce step in `promote.yml` never ran for the v1.7.0 stable release (which is already published: https://github.com/getopenscreen/openscreen/releases/tag/v1.7.0). This is a one-off workflow to re-run just that step. Will be removed via a follow-up PR right after use.

<!-- discord-thread-id:1528544773361897573 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow for announcing stable releases in Discord.
  * Release announcements can be targeted using a specified stable release tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->