### PR TITLE
fix(launch): use native window drag for HUD grip on Linux

### DIFF
--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -924,14 +924,22 @@ export function LaunchWindow() {
 					}
 				}}
 			>
-				{/* Drag handle */}
+				{/* Drag handle. On Linux (notably Wayland), BrowserWindow.setPosition() used by
+				the pointer-capture drag below is a platform no-op -- compositors don't let
+				clients reposition themselves outside an OS-initiated interactive move. Fall
+				back to native `-webkit-app-region: drag` there, same as the HUD bar's border,
+				which already goes through the OS's own move gesture and works. */}
 				<div
 					data-testid="hud-drag-handle"
-					className={`flex ${trayLayout === "vertical" ? "h-6 w-8" : "h-8 w-7"} cursor-grab items-center justify-center active:cursor-grabbing ${styles.electronNoDrag}`}
-					onPointerDown={handleHudDragPointerDown}
-					onPointerMove={handleHudDragPointerMove}
-					onPointerUp={handleHudDragPointerEnd}
-					onPointerCancel={handleHudDragPointerEnd}
+					className={`flex ${trayLayout === "vertical" ? "h-6 w-8" : "h-8 w-7"} cursor-grab items-center justify-center active:cursor-grabbing ${isLinuxHud ? styles.electronDrag : styles.electronNoDrag}`}
+					{...(isLinuxHud
+						? {}
+						: {
+								onPointerDown: handleHudDragPointerDown,
+								onPointerMove: handleHudDragPointerMove,
+								onPointerUp: handleHudDragPointerEnd,
+								onPointerCancel: handleHudDragPointerEnd,
+							})}
 				>
 					{getIcon("drag", "text-white/30")}
 				</div>


### PR DESCRIPTION
## Summary
Fixes #140: on Linux (notably Wayland), dragging the HUD recorder bar by its 6-dot grip handle did nothing, while dragging by the bar's border worked and the grip drag threw a JS error.

**Root cause**: the grip's drag repositions the HUD via a custom pointer-capture handler that calls `BrowserWindow.setPosition()` (IPC channel `hud-overlay-move-by` in `electron/windows.ts`). Wayland compositors don't allow clients to reposition their own top-level window outside of an OS-initiated interactive move, so `setPosition()` is effectively a no-op there. The border already works because it uses native `-webkit-app-region: drag`, which goes through the compositor's own move gesture instead of `setPosition()`.

**Fix**: on Linux (`isLinuxHud`), the grip handle now uses the same native `-webkit-app-region: drag` mechanism as the border, instead of the pointer-capture/IPC path. macOS and Windows are unaffected — they keep the existing pointer-capture drag (including the drift-fix from #125).

## Test plan
- [x] `vitest run src/components/launch/LaunchWindow.test.tsx` — 14/14 pass (existing drag test pins platform to `darwin`, unaffected)
- [x] `tsc --noEmit` — only pre-existing, unrelated missing-optional-dependency errors
- [x] `biome check` — clean
- [ ] Manual verification on Linux/Wayland (can't be done from this Windows dev environment — would appreciate a check from someone with a Linux box, or via the reporter re-testing)

Fixes #140

<!-- discord-thread-id:1528878220777095321 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HUD window dragging on Linux, including Wayland environments.
  * Linux users can now move the window using the native operating system drag behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->