### PR TITLE
feat(release): add Microsoft Store (MSIX) packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,33 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+  build-windows-store:
+    name: Windows Store package
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup
+
+      - name: Cache caption assets
+        uses: actions/cache@v4
+        with:
+          path: caption-assets
+          key: caption-assets-${{ runner.os }}-${{ hashFiles('scripts/fetch-caption-model.mjs') }}
+
+      - name: Build Windows Store package
+        run: npm run build:win:store -- --publish never
+
+      - name: Upload Windows Store package
+        uses: actions/upload-artifact@v4
+        with:
+          name: openscreen-windows-store
+          path: release/**/Openscreen.Setup.*.appx
+          if-no-files-found: error
+          retention-days: 30
+
   build-macos:
     name: macOS ${{ matrix.arch }} DMG
     runs-on: macos-latest

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -102,5 +102,18 @@
   "nsis": {
     "oneClick": false,
     "allowToChangeInstallationDirectory": true
+  },
+  // Microsoft Store packaging identity, from Partner Center's "Product identity" page
+  // (Applications et jeux > OpenScreen > Product identity).
+  "appx": {
+    "identityName": "EtienneLescot.OpenScreen",
+    "publisher": "CN=03B0FC8C-2067-45D9-BE82-9F15CE264B4A",
+    "publisherDisplayName": "Etienne Lescot",
+    "applicationId": "Openscreen",
+    "displayName": "OpenScreen",
+    "backgroundColor": "transparent",
+    "capabilities": ["runFullTrust", "microphone", "webcam"],
+    "languages": ["en-US", "fr-FR"],
+    "showNameOnTiles": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"build:mac": "npm run build:native:mac && tsc && vite build && electron-builder --mac",
 		"build:native:win": "node scripts/build-windows-wgc-helper.mjs",
 		"build:win": "npm run build:native:win && tsc && vite build && electron-builder --win --config.npmRebuild=false",
+		"build:win:store": "npm run build:native:win && tsc && vite build && electron-builder --win appx --config.npmRebuild=false",
 		"build:linux": "tsc && vite build && electron-builder --linux AppImage deb pacman --config.npmRebuild=false",
 		"test": "vitest --run",
 		"test:watch": "vitest",


### PR DESCRIPTION
## Summary
- Add an `appx` target to electron-builder alongside the existing NSIS installer, with the Microsoft Store package identity (`EtienneLescot.OpenScreen`) reserved in Partner Center and `microphone`/`webcam` capabilities declared
- Add a `build:win:store` npm script
- Add a `build-windows-store` CI job to `build.yml` that produces the `.appx` artifact on every tag build

## Context
First step toward publishing OpenScreen on the Microsoft Store. NSIS remains the default/primary Windows distribution channel — this is purely additive. Store submission itself (Partner Center listing, screenshots, age rating) is handled outside this repo and is in progress separately.

## Test plan
- [x] Local build verified: `npm run build:win:store` produces a valid signed-for-testing `.appx` that installs and runs (screen/mic/webcam capture confirmed working from the packaged app)
- [x] Manifest capabilities (`runFullTrust`, `microphone`, `webcam`) verified present in the built package
- [ ] CI job not yet exercised on a real tag push (will run automatically on the next release tag)

<!-- discord-thread-id:1528903295265931356 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building a Windows Store package.
  * Configured Microsoft Store identity, display information, supported capabilities, and languages.
  * Windows Store installer artifacts are now generated and available through the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->