### PR TITLE
fix: add test IDs to Import Video and Load Project buttons

### DIFF
--- a/src/components/video-editor/EditorEmptyState.tsx
+++ b/src/components/video-editor/EditorEmptyState.tsx
@@ -180,6 +180,7 @@ export function EditorEmptyState({ onVideoImported, onProjectOpened }: EditorEmp
 				<div className="flex flex-col gap-3 w-full max-w-xs">
 					<button
 						type="button"
+						data-testid="launch-open-video-button"
 						onClick={handleImportVideo}
 						className="flex items-center justify-center gap-2.5 w-full px-4 py-3 rounded-xl bg-[#34B27B] hover:bg-[#2d9e6c] active:bg-[#27885c] text-white font-medium text-sm transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#34B27B] focus-visible:ring-offset-2 focus-visible:ring-offset-[#09090b]"
 					>
@@ -188,6 +189,7 @@ export function EditorEmptyState({ onVideoImported, onProjectOpened }: EditorEmp
 					</button>
 					<button
 						type="button"
+						data-testid="launch-open-project-button"
 						onClick={handleLoadProject}
 						className="flex items-center justify-center gap-2.5 w-full px-4 py-3 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-slate-300 font-medium text-sm transition-colors outline-none focus-visible:ring-2 focus-visible:ring-white/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[#09090b]"
 					>


### PR DESCRIPTION
# fix: add test IDs to Import Video and Load Project buttons

## Summary

Add data-testid attributes to Import Video File and Load Project buttons in EditorEmptyState to fix e2e test selectors.

Fixes #130

## Changes

- Added data-testid="launch-open-video-button" to the Import Video File button
- Added data-testid="launch-open-project-button" to the Load Project button

## Testing

Verified the attributes are present in the rendered component; ran type checking and linting via sandbox (no errors). The changes are minimal and do not affect functionality.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.

<!-- discord-thread-id:1530311606335181001 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test identifiers to the “Import video” and “Load project” buttons for more reliable automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->