### PR TITLE
fix(compositor): PR #170's asset-path fix was a no-op in the packaged app — bypass asar-transparent fs

### DIFF
--- a/electron/native-bridge/services/compositorViewService.ts
+++ b/electron/native-bridge/services/compositorViewService.ts
@@ -24,15 +24,30 @@ import type {
 const localRequire: NodeRequire = createRequire(import.meta.url) as unknown as NodeRequire;
 
 /**
- * The native compositor is a separate process and can only read absolute
- * filesystem paths — it can't resolve renderer-relative asset URLs like
- * `/wallpapers/wallpaper1.jpg` or fetch `http(s)://`/`data:` URLs. Bundled
- * wallpapers live under `process.env.VITE_PUBLIC` (dev: `<root>/public`,
- * packaged: the renderer dist), so rewrite an image background's root-relative
- * path to that absolute location before handing the scene to the addon. Other
- * schemes (data:, http:) are left as-is; the native side falls back to a flat
- * colour when it can't load them. Malformed JSON passes through untouched.
+ * `existsSync` that answers for the REAL filesystem, not Electron's asar-transparent view of it.
+ *
+ * Electron patches `fs` so JS can read `.../app.asar/dist/wallpapers/x.jpg` as if it were a plain
+ * file — that's the entire point of asar. But `existsSync` inherits the same patch: called on an
+ * asar-internal path it returns `true`, even though nothing outside Electron's own patched `fs`
+ * can ever open that path — the Rust addon calls the raw OS `fopen`/`CreateFile`, which has no
+ * concept of asar and gets ENOENT. A candidate-probe loop built on the patched `fs.existsSync`
+ * therefore locks onto the WRONG candidate (VITE_PUBLIC, pointing into the asar) before ever
+ * trying the right one (`resourcesPath`, real files on disk) — confirmed by running this exact
+ * check inside the packaged binary: patched `existsSync` on the asar path answered `true`.
+ *
+ * `original-fs` is Electron's escape hatch for precisely this: the same API, unpatched. It only
+ * exists inside Electron, so fall back to plain `node:fs` where it doesn't — under plain Node
+ * (tests) there is no asar patch to route around in the first place, so plain `fs` already tells
+ * the truth there.
  */
+function realExistsSync(candidate: string): boolean {
+	try {
+		return (localRequire("original-fs") as typeof fs).existsSync(candidate);
+	} catch {
+		return fs.existsSync(candidate);
+	}
+}
+
 /**
  * Bases holding the `wallpapers/` and `cursors/` trees, most specific first.
  *
@@ -64,7 +79,7 @@ function sceneAssetBaseDirs(): string[] {
 export function resolveSceneAssetPath(relativePath: string): string | null {
 	for (const base of sceneAssetBaseDirs()) {
 		const candidate = path.join(base, relativePath);
-		if (fs.existsSync(candidate)) {
+		if (realExistsSync(candidate)) {
 			return candidate;
 		}
 	}


### PR DESCRIPTION
Fast-follow on #170 (already merged). Rebuilt and relaunched the packaged app to visually confirm that fix, and the exact same bug came right back: a bundled wallpaper still rendered as a flat colour, a themed cursor still fell back to default art, and the main-process log still showed

```
[compositor] wallpaper image "...\resources\app.asar\dist\wallpapers\wallpaper5.jpg" : ... Le chemin d'accès spécifié est introuvable. (os error 3)
```

— the exact path #170 was supposed to stop sending.

## Root cause

`resolveSceneAssetPath`'s candidate-probe loop used plain `fs.existsSync`. Electron patches `fs` to read *through* an asar archive transparently — from JS's point of view, `.../app.asar/dist/wallpapers/wallpaper5.jpg` "exists". So the probe locked onto the **first** candidate (`VITE_PUBLIC`, pointing into the asar) on every single call and never reached the second, real one (`resourcesPath`). #170's fix compiled correctly, shipped correctly, and never actually resolved anything, because the existence check itself was lying.

Confirmed the mechanism directly rather than guessing: ran a probe script inside the packaged binary via `ELECTRON_RUN_AS_NODE=1`.

```
patched fs.existsSync (asar-transparent) on asar path: true
original-fs.existsSync on asar path:                   false
original-fs.existsSync on real resourcesPath:           true
```

The native addon calls raw `fopen`/`CreateFile` with no concept of asar, so it agrees with `original-fs`, not with patched `fs` — which is exactly why the wrong candidate kept winning.

## Fix

`original-fs` is Electron's own escape hatch for precisely this: same API, unpatched. Route the existence check through it, falling back to plain `fs` where `original-fs` doesn't exist — outside Electron, i.e. the vitest suite, where plain Node's `fs` was never patched in the first place, so no fallback behavior changes.

```ts
function realExistsSync(candidate: string): boolean {
	try {
		return (localRequire("original-fs") as typeof fs).existsSync(candidate);
	} catch {
		return fs.existsSync(candidate);
	}
}
```

## Verification

- Rebuilt (`tsc && vite build && electron-builder`, native addon unchanged), grepped the packaged `app.asar` bytes directly to confirm `realExistsSync`/`original-fs` actually compiled in.
- Relaunched the packaged app against the **same** project that reproduced the original bug report. Confirmed live:
  - The bundled wallpaper now renders (padding/roundness/shadow all visible around it) instead of falling back to a flat colour.
  - Switching cursor themes now visibly changes the rendered sprite on the recording.
  - The `[compositor] wallpaper image ... introuvable` log line is gone.
- `tsc --noEmit` clean, biome clean, existing 15 tests in `compositorViewService.test.ts` still pass (they run under plain Node, so they exercise the `fs` fallback branch, not the asar-bypass itself — that half is Electron-runtime-specific and is what the live verification above covers).

## Note for review

I did not add a mocked unit test simulating Electron's asar-fs patching — a test that only asserts `localRequire("original-fs")` gets called would be closer to tautological than to a real regression guard, since the actual failure mode (patched `fs.existsSync` lying about an asar-internal path) can't be faithfully reproduced outside a real Electron + real asar. The live verification above is the real check for this one.

<!-- discord-thread-id:1531202895809220799 -->