### PR TITLE
perf(transport): parité de fluidité entre scrub barre et scrub timeline

### DIFF
--- a/src/components/ai-edition/TransportBar.test.tsx
+++ b/src/components/ai-edition/TransportBar.test.tsx
@@ -112,7 +112,9 @@ describe("le drag de la barre de progression est coalescé en rAF", () => {
 			pending.push(cb);
 			return pending.length;
 		});
-		vi.stubGlobal("cancelAnimationFrame", () => {});
+		vi.stubGlobal("cancelAnimationFrame", () => {
+			// rien à annuler : `flush()` ne rejoue que ce qui reste en attente
+		});
 		return () => {
 			const due = pending.splice(0, pending.length);
 			for (const cb of due) cb(0);
@@ -212,5 +214,45 @@ describe("le drag de la barre de progression est coalescé en rAF", () => {
 		});
 		expect(onSeek).toHaveBeenCalledTimes(1);
 		expect(onSeek).toHaveBeenCalledWith(3);
+	});
+
+	// Le remplissage et le curseur étaient positionnés uniquement par React depuis le store,
+	// donc en retard d'un commit à chaque mouvement — alors que la tête de lecture de la
+	// timeline, elle, est écrite directement dans le DOM et colle au pointeur. Ce test
+	// verrouille la parité : le visuel bouge AVANT le rAF, donc sans attendre React.
+	it("déplace le curseur dans le DOM avant tout rendu React", () => {
+		stubRaf();
+		const onSeek = vi.fn();
+		const { container } = render(
+			<I18nProvider>
+				<TransportBar
+					playing={false}
+					overrideTimeSec={null}
+					clips={clips}
+					onTogglePlay={noop}
+					onPrevClip={noop}
+					onNextClip={noop}
+					onSeek={onSeek}
+				/>
+			</I18nProvider>,
+		);
+		const input = screen.getByLabelText(/seek/i) as HTMLInputElement;
+		// Les deux éléments décorés : le remplissage (largeur) et le curseur (position).
+		const styled = Array.from(container.querySelectorAll("div")).filter(
+			(el) => el.style.width !== "" || el.style.left !== "",
+		);
+		expect(styled.length).toBeGreaterThanOrEqual(2);
+
+		act(() => {
+			fireEvent.pointerDown(input);
+			// La moitié de la durée (clip de 30 s) → 50 %.
+			fireEvent.change(input, { target: { value: "15" } });
+		});
+
+		// Aucun rAF n'a été vidé, donc aucune écriture au store et aucun rendu React : ce qui
+		// a bougé ne peut venir que de l'écriture DOM directe.
+		expect(onSeek).not.toHaveBeenCalled();
+		const moved = styled.filter((el) => el.style.width === "50%" || el.style.left === "50%");
+		expect(moved.length).toBeGreaterThanOrEqual(2);
 	});
 });

--- a/src/components/ai-edition/TransportBar.test.tsx
+++ b/src/components/ai-edition/TransportBar.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { I18nProvider } from "@/contexts/I18nContext";
 import { useProjectStore } from "@/lib/ai-edition/store/projectStore";
@@ -90,5 +90,127 @@ describe("TransportBar reads the playhead from the store", () => {
 			</I18nProvider>,
 		);
 		expect(screen.getByText("0:04.5")).toBeInTheDocument();
+	});
+});
+
+describe("le drag de la barre de progression est coalescé en rAF", () => {
+	beforeEach(() => {
+		useProjectStore.setState({ currentTimeSec: 0 });
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+		vi.unstubAllGlobals();
+	});
+
+	/** rAF piloté à la main : les callbacks ne partent que sur `flush()`, ce qui permet de
+	 *  compter ce qui se passe DANS une frame — impossible avec le vrai rAF en test. */
+	function stubRaf() {
+		const pending: FrameRequestCallback[] = [];
+		vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+			pending.push(cb);
+			return pending.length;
+		});
+		vi.stubGlobal("cancelAnimationFrame", () => {});
+		return () => {
+			const due = pending.splice(0, pending.length);
+			for (const cb of due) cb(0);
+		};
+	}
+
+	// C'est LE défaut que ce chemin avait : `onChange` d'un `<input type="range">` se
+	// déclenche à la cadence du pointeur (jusqu'à 1000 Hz) et appelait `onSeek` à chaque
+	// fois. Or `onSeek` repose un `seekTarget` dans l'état de la racine de l'éditeur, donc
+	// re-rend tout et fait poser `<video>.currentTime`. La timeline fait les mêmes appels
+	// mais une fois par frame ; ce test verrouille cette parité.
+	it("n'émet qu'un seul seek par frame, quel que soit le nombre d'événements", () => {
+		const flush = stubRaf();
+		const onSeek = vi.fn();
+		render(
+			<I18nProvider>
+				<TransportBar
+					playing={false}
+					overrideTimeSec={null}
+					clips={clips}
+					onTogglePlay={noop}
+					onPrevClip={noop}
+					onNextClip={noop}
+					onSeek={onSeek}
+				/>
+			</I18nProvider>,
+		);
+		const input = screen.getByLabelText(/seek/i) as HTMLInputElement;
+
+		act(() => {
+			fireEvent.pointerDown(input);
+		});
+		// Dix mouvements dans la même frame : un seul seek doit en sortir, et c'est le
+		// DERNIER qui compte — sans quoi la tête accuserait un retard permanent.
+		act(() => {
+			for (const value of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) {
+				fireEvent.change(input, { target: { value: String(value) } });
+			}
+		});
+		expect(onSeek).not.toHaveBeenCalled();
+
+		act(() => flush());
+		expect(onSeek).toHaveBeenCalledTimes(1);
+		expect(onSeek).toHaveBeenLastCalledWith(10);
+	});
+
+	// Le mouvement compris entre le dernier rAF et le relâchement serait perdu sans commit
+	// final : la tête s'arrêterait un cran avant le doigt.
+	it("pose la dernière position au relâchement", () => {
+		stubRaf();
+		const onSeek = vi.fn();
+		render(
+			<I18nProvider>
+				<TransportBar
+					playing={false}
+					overrideTimeSec={null}
+					clips={clips}
+					onTogglePlay={noop}
+					onPrevClip={noop}
+					onNextClip={noop}
+					onSeek={onSeek}
+				/>
+			</I18nProvider>,
+		);
+		const input = screen.getByLabelText(/seek/i) as HTMLInputElement;
+
+		act(() => {
+			fireEvent.pointerDown(input);
+			fireEvent.change(input, { target: { value: "7" } });
+			fireEvent.pointerUp(input);
+		});
+		expect(onSeek).toHaveBeenCalledWith(7);
+	});
+
+	// Hors drag il n'y a rien à coalescer : une flèche du clavier est un saut unique et
+	// doit prendre effet immédiatement, sans attendre une frame.
+	it("applique immédiatement un changement hors drag", () => {
+		stubRaf();
+		const onSeek = vi.fn();
+		render(
+			<I18nProvider>
+				<TransportBar
+					playing={false}
+					overrideTimeSec={null}
+					clips={clips}
+					onTogglePlay={noop}
+					onPrevClip={noop}
+					onNextClip={noop}
+					onSeek={onSeek}
+				/>
+			</I18nProvider>,
+		);
+		const input = screen.getByLabelText(/seek/i) as HTMLInputElement;
+
+		act(() => {
+			fireEvent.change(input, { target: { value: "3" } });
+		});
+		expect(onSeek).toHaveBeenCalledTimes(1);
+		expect(onSeek).toHaveBeenCalledWith(3);
 	});
 });

--- a/src/components/ai-edition/TransportBar.tsx
+++ b/src/components/ai-edition/TransportBar.tsx
@@ -1,5 +1,5 @@
 import { Pause, Play, SkipBack, SkipForward } from "lucide-react";
-import { memo } from "react";
+import { memo, useCallback, useEffect, useRef } from "react";
 import { useScopedT } from "@/contexts/I18nContext";
 import { setUiProbeScrubbing } from "@/lib/ai-edition/perf/uiFrameProbe";
 import type { AxcutClip } from "@/lib/ai-edition/schema";
@@ -48,6 +48,77 @@ export const TransportBar = memo(function TransportBar({
 	);
 	// ponytail: mirrors Preview's old clamp so the CSS thumb and the native
 	// range thumb stay in sync when there's no clip yet.
+	// ── Drag de la barre : même cadence que le drag de la timeline ──────────────────
+	//
+	// L'`onChange` d'un `<input type="range">` se déclenche à la cadence du POINTEUR — 125 à
+	// 1000 Hz selon la souris — et appelait `onSeek` à chacun. Or `onSeek` est `handleSeek`,
+	// qui écrit au store ET repose un `seekTarget` neuf dans l'état de `NewEditorShell`, la
+	// racine : chaque appel re-rend tout l'éditeur et fait poser `<video>.currentTime`, un
+	// vrai seek média.
+	//
+	// La timeline fait exactement les mêmes appels, mais les coalesce en rAF — donc ~60 fois
+	// par seconde au lieu de jusqu'à 1000. C'est cette seule différence de cadence qui
+	// sépare les deux chemins, et elle explique l'écart de fluidité remonté en usage.
+	//
+	// On ne fait donc rien de plus que rétablir la parité : même travail, cadence d'écran.
+	// Délibérément PAS « ne poser le seekTarget qu'au relâchement » — ce serait un
+	// comportement différent de la timeline, où le `<video>` suit pendant le drag, et
+	// divergence entre deux chemins censés faire la même chose est précisément ce qui a
+	// produit les bugs de cette zone.
+	const rafRef = useRef(0);
+	const pendingRef = useRef<number | null>(null);
+	const draggingRef = useRef(false);
+
+	useEffect(() => {
+		return () => {
+			if (rafRef.current !== 0) {
+				cancelAnimationFrame(rafRef.current);
+			}
+		};
+	}, []);
+
+	const handleInputChange = useCallback(
+		(value: number) => {
+			// Hors drag (flèches du clavier, clic simple sur la piste) : rien à coalescer,
+			// c'est un saut unique et il doit prendre effet tout de suite.
+			if (!draggingRef.current) {
+				onSeek(value);
+				return;
+			}
+			pendingRef.current = value;
+			if (rafRef.current !== 0) {
+				return;
+			}
+			rafRef.current = requestAnimationFrame(() => {
+				rafRef.current = 0;
+				const pending = pendingRef.current;
+				if (pending !== null) {
+					onSeek(pending);
+				}
+			});
+		},
+		[onSeek],
+	);
+
+	const endDrag = useCallback(() => {
+		if (!draggingRef.current) {
+			return;
+		}
+		draggingRef.current = false;
+		setUiProbeScrubbing(false, "bar");
+		if (rafRef.current !== 0) {
+			cancelAnimationFrame(rafRef.current);
+			rafRef.current = 0;
+		}
+		// Pose la dernière position : sans ce commit, le mouvement compris entre le dernier
+		// rAF et le relâchement serait perdu et la tête s'arrêterait un cran avant le doigt.
+		const pending = pendingRef.current;
+		if (pending !== null) {
+			pendingRef.current = null;
+			onSeek(pending);
+		}
+	}, [onSeek]);
+
 	const inputMax = virtualDurationSec || 1;
 	const inputValue = Math.min(Math.max(currentTimeSec, 0), inputMax);
 	const progress = (inputValue / inputMax) * 100;
@@ -97,13 +168,20 @@ export const TransportBar = memo(function TransportBar({
 					max={inputMax}
 					step={0.01}
 					value={inputValue}
-					onChange={(e) => onSeek(Number(e.target.value))}
-					// Sonde de fluidité (diagnostic) : marque la fenêtre de drag comme
-					// venant de la BARRE, pour ne pas la confondre avec un drag de timeline —
-					// les deux empruntent des chemins de code différents.
-					onPointerDown={() => setUiProbeScrubbing(true, "bar")}
-					onPointerUp={() => setUiProbeScrubbing(false, "bar")}
-					onPointerCancel={() => setUiProbeScrubbing(false, "bar")}
+					onChange={(e) => handleInputChange(Number(e.target.value))}
+					onPointerDown={() => {
+						draggingRef.current = true;
+						// Sonde de fluidité (diagnostic) : marque la fenêtre de drag comme
+						// venant de la BARRE, pour ne pas la confondre avec un drag de
+						// timeline — les deux empruntent des chemins de code différents.
+						setUiProbeScrubbing(true, "bar");
+					}}
+					onPointerUp={endDrag}
+					// `pointercancel` et `blur` ferment aussi le drag : un pointeur capturé
+					// puis interrompu (geste système, perte de focus) ne produit pas de
+					// `pointerup`, et la dernière position resterait alors non confirmée.
+					onPointerCancel={endDrag}
+					onBlur={endDrag}
 					className={styles.scrubInput}
 					aria-label={te("transport.seekVideo")}
 				/>

--- a/src/components/ai-edition/TransportBar.tsx
+++ b/src/components/ai-edition/TransportBar.tsx
@@ -48,6 +48,10 @@ export const TransportBar = memo(function TransportBar({
 	);
 	// ponytail: mirrors Preview's old clamp so the CSS thumb and the native
 	// range thumb stay in sync when there's no clip yet.
+	const inputMax = virtualDurationSec || 1;
+	const inputValue = Math.min(Math.max(currentTimeSec, 0), inputMax);
+	const progress = (inputValue / inputMax) * 100;
+
 	// ── Drag de la barre : même cadence que le drag de la timeline ──────────────────
 	//
 	// L'`onChange` d'un `<input type="range">` se déclenche à la cadence du POINTEUR — 125 à
@@ -68,6 +72,20 @@ export const TransportBar = memo(function TransportBar({
 	const rafRef = useRef(0);
 	const pendingRef = useRef<number | null>(null);
 	const draggingRef = useRef(false);
+	// Remplissage et curseur de la barre, écrits DIRECTEMENT pendant un drag.
+	//
+	// Même patron que `playheadElRef` dans V4Timeline, et pour la même raison : la position
+	// que l'utilisateur voit ne doit pas attendre un rendu React. Ces deux éléments étaient
+	// positionnés uniquement depuis `progress`, dérivé du store — donc en retard d'un commit
+	// à chaque mouvement, alors que la tête de lecture de la timeline, elle, colle au
+	// pointeur. C'est la dernière différence de parité entre les deux chemins que j'aie pu
+	// identifier dans le code.
+	//
+	// React continue de les positionner hors drag (et au rendu suivant pendant le drag, avec
+	// une valeur au pire vieille d'une frame puisque le rAF écrit au store à 60 Hz) : les
+	// deux écritures convergent au lieu de se contredire.
+	const progressElRef = useRef<HTMLDivElement | null>(null);
+	const thumbElRef = useRef<HTMLDivElement | null>(null);
 
 	useEffect(() => {
 		return () => {
@@ -86,6 +104,15 @@ export const TransportBar = memo(function TransportBar({
 				return;
 			}
 			pendingRef.current = value;
+			// Visuel d'abord, sans passer par React : latence nulle, comme la tête de lecture
+			// de la timeline. `inputMax` est déjà borné à 1 minimum, pas de division par zéro.
+			const pct = Math.min(100, Math.max(0, (value / inputMax) * 100));
+			if (progressElRef.current) {
+				progressElRef.current.style.width = `${pct}%`;
+			}
+			if (thumbElRef.current) {
+				thumbElRef.current.style.left = `${pct}%`;
+			}
 			if (rafRef.current !== 0) {
 				return;
 			}
@@ -97,7 +124,7 @@ export const TransportBar = memo(function TransportBar({
 				}
 			});
 		},
-		[onSeek],
+		[onSeek, inputMax],
 	);
 
 	const endDrag = useCallback(() => {
@@ -118,10 +145,6 @@ export const TransportBar = memo(function TransportBar({
 			onSeek(pending);
 		}
 	}, [onSeek]);
-
-	const inputMax = virtualDurationSec || 1;
-	const inputValue = Math.min(Math.max(currentTimeSec, 0), inputMax);
-	const progress = (inputValue / inputMax) * 100;
 
 	return (
 		<div className={styles.transport} role="toolbar" aria-label={te("transport.playbackControls")}>
@@ -160,7 +183,11 @@ export const TransportBar = memo(function TransportBar({
 			</span>
 			<div className={styles.scrubBar}>
 				<div className={styles.scrubTrack}>
-					<div className={styles.scrubProgress} style={{ width: `${progress}%` }} />
+					<div
+						ref={progressElRef}
+						className={styles.scrubProgress}
+						style={{ width: `${progress}%` }}
+					/>
 				</div>
 				<input
 					type="range"
@@ -186,6 +213,7 @@ export const TransportBar = memo(function TransportBar({
 					aria-label={te("transport.seekVideo")}
 				/>
 				<div
+					ref={thumbElRef}
 					className={styles.scrubThumb}
 					style={{
 						left: `${progress}%`,

--- a/src/components/ai-edition/TransportBar.tsx
+++ b/src/components/ai-edition/TransportBar.tsx
@@ -1,6 +1,7 @@
 import { Pause, Play, SkipBack, SkipForward } from "lucide-react";
 import { memo } from "react";
 import { useScopedT } from "@/contexts/I18nContext";
+import { setUiProbeScrubbing } from "@/lib/ai-edition/perf/uiFrameProbe";
 import type { AxcutClip } from "@/lib/ai-edition/schema";
 import { useProjectStore } from "@/lib/ai-edition/store/projectStore";
 import styles from "./NewEditorShell.module.css";
@@ -97,6 +98,12 @@ export const TransportBar = memo(function TransportBar({
 					step={0.01}
 					value={inputValue}
 					onChange={(e) => onSeek(Number(e.target.value))}
+					// Sonde de fluidité (diagnostic) : marque la fenêtre de drag comme
+					// venant de la BARRE, pour ne pas la confondre avec un drag de timeline —
+					// les deux empruntent des chemins de code différents.
+					onPointerDown={() => setUiProbeScrubbing(true, "bar")}
+					onPointerUp={() => setUiProbeScrubbing(false, "bar")}
+					onPointerCancel={() => setUiProbeScrubbing(false, "bar")}
 					className={styles.scrubInput}
 					aria-label={te("transport.seekVideo")}
 				/>

--- a/src/lib/ai-edition/perf/uiFrameProbe.ts
+++ b/src/lib/ai-edition/perf/uiFrameProbe.ts
@@ -21,7 +21,13 @@
  * qu'on ne le demande pas — aucun coût en usage normal.
  */
 
-type BaseState = "repos" | "preview" | "scrub" | "scrub+preview";
+type BaseState =
+	| "repos"
+	| "preview"
+	| "scrub-tl"
+	| "scrub-tl+preview"
+	| "scrub-bar"
+	| "scrub-bar+preview";
 /** L'état porte le suffixe `@N` = nombre de bascules de clip déjà vues. Voir
  *  `noteUiProbeClipSwitch` : sans cette séparation, deux mesures ne sont pas comparables. */
 type ProbeState = string;
@@ -36,7 +42,19 @@ let rafHandle = 0;
 let lastTs = 0;
 /** Frames de preview peintes depuis le dernier tick — dit si la preview travaille. */
 let previewFramesSinceTick = 0;
-let scrubbing = false;
+/**
+ * D'OÙ vient le scrub en cours.
+ *
+ * Les deux chemins n'ont rien à voir : la timeline écrit la tête de lecture directement
+ * dans le DOM et coalesce son écriture au store en rAF ; la barre de progression, elle,
+ * écrit au store à chaque événement ET repose un `seekTarget` — un état de la RACINE de
+ * l'éditeur — ce qui re-render tout et déclenche un seek du `<video>` par mouvement de
+ * souris. Les mélanger sous une même étiquette `scrub` reviendrait à moyenner deux
+ * populations différentes, exactement le biais que cette sonde existe pour éviter.
+ */
+type ScrubSource = "timeline" | "bar";
+
+let scrubbing: ScrubSource | null = null;
 /** Bascules de clip vues depuis le démarrage de la sonde. Sépare les états. */
 let clipSwitches = 0;
 
@@ -48,8 +66,8 @@ export function noteUiProbePreviewFrame(): void {
 }
 
 /** Appelé par la timeline à l'entrée et à la sortie d'un drag de tête de lecture. */
-export function setUiProbeScrubbing(active: boolean): void {
-	scrubbing = active;
+export function setUiProbeScrubbing(active: boolean, source: ScrubSource = "timeline"): void {
+	scrubbing = active ? source : null;
 }
 
 /**
@@ -87,14 +105,15 @@ function bucketFor(state: ProbeState): Bucket {
 
 function currentState(): ProbeState {
 	const previewActive = previewFramesSinceTick > 0;
-	const base: BaseState =
-		scrubbing && previewActive
-			? "scrub+preview"
-			: scrubbing
-				? "scrub"
-				: previewActive
-					? "preview"
-					: "repos";
+	// La source du scrub fait partie de l'étiquette : `scrub-tl` et `scrub-bar` sont deux
+	// chemins de code distincts, les confondre masquerait précisément l'écart qu'on cherche.
+	const base: BaseState = scrubbing
+		? previewActive
+			? `scrub-${scrubbing === "timeline" ? "tl" : "bar"}+preview`
+			: `scrub-${scrubbing === "timeline" ? "tl" : "bar"}`
+		: previewActive
+			? "preview"
+			: "repos";
 	return `${base}@${clipSwitches}`;
 }
 
@@ -112,7 +131,14 @@ function summarize() {
 	// Trié par état puis par nombre de bascules, pour que « avant / après le 1er
 	// changement de clip » se lisent l'un sous l'autre.
 	const states = [...buckets.keys()].sort((a, b) => {
-		const order = ["repos", "preview", "scrub", "scrub+preview"];
+		const order = [
+			"repos",
+			"preview",
+			"scrub-tl",
+			"scrub-tl+preview",
+			"scrub-bar",
+			"scrub-bar+preview",
+		];
 		const [ba, na] = a.split("@");
 		const [bb, nb] = b.split("@");
 		return order.indexOf(ba) - order.indexOf(bb) || Number(na) - Number(nb);


### PR DESCRIPTION
## Contexte

Suite de la série « fluidité du scrub », après #206 et #207 mergées. Le point de départ : **scruber via la barre de progression du playback semble moins fluide que scruber via la timeline**, alors que les deux font conceptuellement la même chose (poser une position). Cette PR referme l'écart en rétablissant la parité entre les deux chemins.

## Ce que fait chaque commit

1. **`b2dbd890`** — la sonde de fluidité distingue désormais `scrub-tl` (timeline) de `scrub-bar` (barre). Neutre en comportement ; c'est l'instrument qui rend l'écart mesurable au lieu de « ressenti ».
2. **`6eff6b97`** — coalescence du drag de la barre en rAF. L'`onChange` d'un `<input type="range">` se déclenche à la cadence du **pointeur** (jusqu'à 1000 Hz) et appelait `onSeek` à chaque fois — donc jusqu'à 1000 re-rendus de tout l'éditeur + autant de `<video>.currentTime` par seconde. La timeline, elle, coalesce déjà en rAF (~60 Hz). On rétablit exactement cette parité, plus un `onSeek` final au relâchement (`pointerup`/`pointercancel`/`blur`) pour ne pas perdre le dernier mouvement.
3. **`a29458d3`** — écriture DIRECTE du remplissage et du curseur dans le DOM pendant un drag, comme `playheadElRef` dans la timeline. Le visuel ne passe plus par un commit React : latence nulle.

## Mesures (sonde intégrée)

| arme | > 25 ms (pondéré n) | p50 |
|---|---|---|
| `scrub-tl` | ≈ 7,5 % | 16,7 ms |
| `scrub-bar` (cette PR) | ≈ 10,4 % | 16,7 ms |
| `scrub-bar` (avant la série) | ≈ 12,6 % | — |

**Honnêteté sur les chiffres** — la comparaison `scrub-tl` vs `scrub-bar` ci-dessus est **biaisée** : les deux bras n'ont pas été entrelacés, et entre les deux la ligne de base au repos avait dérivé (`repos` de 0 % à 22 % de frames > 25 ms sur la session). `scrub-bar` a donc été mesuré dans un régime plus dégradé que `scrub-tl`. Le fait propre et interne à la session : **pendant tout le `scrub-bar`, le p50 est resté à 16,7 ms (60 fps)** alors qu'au repos il avait dérivé à 25,0 ms — scruber est devenu plus sain que ne rien faire. Le gain du commit `6eff6b97` est net au ressenti et cohérent avec la mesure ; le gain marginal de `a29458d3` par-dessus n'est **pas** isolé proprement (pas d'A/B contrôlé).

## Hors périmètre

La **dérive au repos** (`repos` 0 % → 22 %, p50 se verrouillant à 25,0 ms, monotone avec le nombre de bascules de clip, `2 <video>` stables) est le vrai signal restant. Elle survit à cette PR comme aux précédentes et sent la fuite par bascule de clip côté transport/`<video>`, pas côté React. Elle fera l'objet d'une investigation séparée.

## Vérification

- `tsc --noEmit` propre.
- 70/70 tests sur `src/components/ai-edition`, dont 4 nouveaux sur `TransportBar` (un seek/frame, position finale au relâchement, saut immédiat hors drag, et le visuel qui bouge avant tout rAF — vérifié qu'il échoue sans le correctif).

<!-- discord-thread-id:1532314141266546710 -->