### PR TITLE
fix(preview): seek_to retombe sur un seek complet quand le décode-avant bute sur l'EOF

### DIFF
--- a/crates/compositor/src/pipeline_macos.rs
+++ b/crates/compositor/src/pipeline_macos.rs
@@ -250,7 +250,13 @@ impl Decoder {
                 // 2) La cible est DEVANT et à portée : dérouler depuis ici plutôt que de
                 //    repartir d'une image clé (cf. `pipeline_windows::SEEK_FORWARD_MAX_SEC`).
                 if cur < seconds && seconds - cur <= SEEK_FORWARD_MAX_SEC {
-                    return self.decode_forward_to(seconds, tb_sec);
+                    let f = self.decode_forward_to(seconds, tb_sec)?;
+                    if !f.is_null() {
+                        return Ok(f);
+                    }
+                    // EOF atteint avant la cible (décodeur réactivé depuis le pool, laissé en fin
+                    // de flux) : on retombe sur le seek keyframe complet au lieu de rendre `null`
+                    // — qui forçait une réouverture complète. Voir `pipeline_windows::seek_to`.
                 }
             }
         }

--- a/crates/compositor/src/pipeline_windows.rs
+++ b/crates/compositor/src/pipeline_windows.rs
@@ -619,7 +619,18 @@ impl Decoder {
                 //    repartir d'une image clé redevient moins cher — un seek coûte en moyenne
                 //    un demi-GOP, soit ~0,5 s sur nos captures.
                 if cur < seconds && seconds - cur <= SEEK_FORWARD_MAX_SEC {
-                    return self.decode_forward_to(seconds, tb_sec);
+                    let f = self.decode_forward_to(seconds, tb_sec)?;
+                    if !f.is_null() {
+                        return Ok(f);
+                    }
+                    // `decode_forward_to` a atteint l'EOF avant la cible — typiquement un
+                    // décodeur réactivé depuis le pool (`live::swap_clip_pooled`), laissé en fin
+                    // de flux (`sent_eof`), qui ne peut plus avancer. On NE rend PAS `null` : ça
+                    // forçait l'appelant à tout ROUVRIR (~190 ms mesurés), le pire à-coup ressenti
+                    // au franchissement. On retombe sur le seek keyframe complet ci-dessous, qui
+                    // rembobine + réarme le décodeur et repart proprement. Si la cible est
+                    // réellement au-delà de l'EOF, ce seek complet rendra `null` lui aussi :
+                    // comportement inchangé pour ce cas.
                 }
             }
         }

--- a/src/components/ai-edition/VirtualPreview.tsx
+++ b/src/components/ai-edition/VirtualPreview.tsx
@@ -619,10 +619,13 @@ export function VirtualPreview({
 							// handles clip-end advancement, so dropping the event
 							// handler here is safe.
 						/>
-						{loadState !== "ready" && (
-							<div className={styles.overlay}>
-								{loadState === "error" ? "Video preview could not be loaded." : "Loading preview…"}
-							</div>
+						{/* Plus d'overlay « Loading preview… » : il reflétait l'état du <video>
+						    CACHÉ (source horloge/audio), pas la preview RÉELLE — le canvas natif,
+						    qui montre déjà une image valide pendant que le <video> re-seek. Il
+						    recouvrait donc une bonne image à chaque scrub, pour rien. On garde
+						    seulement l'erreur, qui, elle, signale un vrai échec de chargement. */}
+						{loadState === "error" && (
+							<div className={styles.overlay}>Video preview could not be loaded.</div>
 						)}
 					</div>
 					{/* The native D3D canvas already draws the recorded-cursor sprite as part


### PR DESCRIPTION
Suite du pool de décodeurs (#209).

## Le défaut

Dans un scrub réel (logs `OPENSCREEN_CLIPSWITCH_TIMING`), **~13 % des franchissements** restaient à **~190 ms** au lieu du POOL_HIT attendu. Cause : un décodeur réactivé depuis le pool est souvent laissé en **fin de flux** (on venait d'y scruber près de la fin avant de le quitter). Quand on y revient et qu'on le repositionne un peu plus loin, le chemin rapide `decode_forward_to` bute sur l'EOF et rendait `null` → `swap_clip_pooled` jetait la paire poolée et **rouvrait tout à neuf** (~190 ms). Ce sont les **pires à-coups ressentis** au franchissement.

## Le correctif

Dans `seek_to` (donc utile aussi à `seek_active`, pas seulement au pool) : quand le décode-avant atteint l'EOF avant la cible, on ne rend plus `null` — on **retombe sur le seek keyframe complet** juste en dessous, qui rembobine + réarme le décodeur et repart proprement. Si la cible est réellement au-delà de l'EOF, le seek complet rend `null` lui aussi : **comportement inchangé** pour ce cas. Appliqué aux deux backends (`pipeline_windows` + `pipeline_macos`).

## Mesures (headless, GPU au repos)

Les reseeks près de l'EOF passent de **OPEN ~190 ms → POOL_HIT ~50-80 ms**. Jamais pire que l'état d'avant (le pire cas reste le même repli sur ouverture).

## Sûreté

La classe « frame sans texture → preview noire » a déjà mordu dans ce fichier. Vérifié avec un harnais qui **lit les pixels** (pas seulement le compteur de générations) : sur **46 franchissements** — sauts, retours locaux, éviction LRU 5 assets, **et près de l'EOF** — **0 preview noire, 0 frame stale**, chaque franchissement produit une frame fraîche valide.

(Un premier jet signalait des « frames absentes » : c'étaient des faux positifs d'un `pump` trop court qui expirait avant qu'un seek keyframe près de l'EOF, GPU alors chargé par l'app de test, ait fini. GPU au repos + fenêtre large → 0.)

`cargo check` OK (Windows) ; le backend macOS est identique, validé par la CI Rust.

## Portée honnête

C'est une **robustesse marginale** au-dessus de #209 : elle supprime les pires spikes (les ~190 ms), pas une transformation ressentie — le scrub reste dominé par le seek keyframe (~30-90 ms, quasi incompressible en H.264 sans proxy).

<!-- discord-thread-id:1532374569237741800 -->