### PR TITLE
fix(ci): re-piner le build ffmpeg BtbN, dont la release a été purgée

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -26,11 +26,11 @@ distributed by their own registries, not redistributed inside our binaries.
   verifies this before vendoring — it reads `ffmpeg -L`, `-buildconf` and
   `-encoders` and refuses any binary that reports otherwise.
 - **Upstream binaries**: BtbN/FFmpeg-Builds, release
-  `autobuild-2026-07-15-14-01`, the `*-lgpl-shared-8.1` assets. Pinned by
+  `autobuild-2026-07-30-13-32`, the `*-lgpl-shared-8.1` assets. Pinned by
   SHA-256 in `scripts/fetch-ffmpeg.mjs`; the digests there identify the exact
   artifacts we ship.
-  <https://github.com/BtbN/FFmpeg-Builds/releases/tag/autobuild-2026-07-15-14-01>
-- **Corresponding source**: FFmpeg n8.1.2, commit `94138f6973`, from
+  <https://github.com/BtbN/FFmpeg-Builds/releases/tag/autobuild-2026-07-30-13-32>
+- **Corresponding source**: FFmpeg n8.1.2, commit `cfa62de001`, from
   <https://github.com/FFmpeg/FFmpeg>. The build configuration and scripts that
   produced these exact binaries are published at
   <https://github.com/BtbN/FFmpeg-Builds>.

--- a/crates/.cargo/config.toml
+++ b/crates/.cargo/config.toml
@@ -2,8 +2,8 @@
 # ffmpeg LGPL-shared (voir README). LIBCLANG_PATH = install LLVM locale (bindgen).
 # Ces valeurs cèdent à une vraie variable d'environnement (force=false par défaut).
 #
-# Pinné sur le MÊME build release-branch (n8.1.2-22-g94138f6973, tag BtbN
-# autobuild-2026-07-15-14-01) que scripts/fetch-ffmpeg.mjs vendorise dans
+# Pinné sur le MÊME build release-branch (n8.1.2-32-gcfa62de001, tag BtbN
+# autobuild-2026-07-30-13-32) que scripts/fetch-ffmpeg.mjs vendorise dans
 # electron/native/bin/<tag>/ pour le packaging — pas un snapshot "master-latest"
 # flottant. L'addon (compositor-view-napi) doit être lié à la même version de
 # ffmpeg que celle shippée, sinon les DLLs vendorisées ne matchent pas les

--- a/scripts/fetch-ffmpeg.mjs
+++ b/scripts/fetch-ffmpeg.mjs
@@ -66,47 +66,47 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, "..");
 
 /** Immutable dated tag. `latest` is an alias that moves — do not use it here. */
-const RELEASE_TAG = "autobuild-2026-07-15-14-01";
+const RELEASE_TAG = "autobuild-2026-07-30-13-32";
 const BASE = `https://github.com/BtbN/FFmpeg-Builds/releases/download/${RELEASE_TAG}`;
 
 /** Tag, asset and digest move together. Re-pin all three or none. */
 const PINNED = {
 	"win32-x64": {
-		asset: "ffmpeg-n8.1.2-22-g94138f6973-win64-lgpl-8.1.zip",
-		sha256: "6bd644cb9476a72d905ba22c807eaef1c47a224c8f194c0771da9f3e9a765c35",
+		asset: "ffmpeg-n8.1.2-32-gcfa62de001-win64-lgpl-8.1.zip",
+		sha256: "c5a091e6a0e446f737f5ae78f9ed38dc02081c014156097468c196b606c4717f",
 		exe: "ffmpeg.exe",
 	},
 	"win32-arm64": {
-		asset: "ffmpeg-n8.1.2-22-g94138f6973-winarm64-lgpl-8.1.zip",
-		sha256: "8f89ba5cca2c14ef8e181cdb1bd8403d7b7ee7586151027918a2ac8e42cf7c48",
+		asset: "ffmpeg-n8.1.2-32-gcfa62de001-winarm64-lgpl-8.1.zip",
+		sha256: "c5b600e5577142fe7d9d4c9788b91d09a4eaf36900abc5b7cf82b8af54663d7a",
 		exe: "ffmpeg.exe",
 	},
 	"linux-x64": {
-		asset: "ffmpeg-n8.1.2-22-g94138f6973-linux64-lgpl-8.1.tar.xz",
-		sha256: "81c8a9fd1f4bb0a888e820d8ddc825cee5116da16efe93054c761ecbc4b54fc3",
+		asset: "ffmpeg-n8.1.2-32-gcfa62de001-linux64-lgpl-8.1.tar.xz",
+		sha256: "c54903d95c31d283441bc30ad61ed5d58ed968e18d6169b606dbf175d3719c30",
 		exe: "ffmpeg",
 	},
 	"linux-arm64": {
-		asset: "ffmpeg-n8.1.2-22-g94138f6973-linuxarm64-lgpl-8.1.tar.xz",
-		sha256: "0d4777bde13dcfb61de3541d129df8a37f0e24eb0afddb0bab698fa73ec0aed4",
+		asset: "ffmpeg-n8.1.2-32-gcfa62de001-linuxarm64-lgpl-8.1.tar.xz",
+		sha256: "f7a5ffe5e8f10957ce4675e0fab8d8a739a33abcf626721a9cfc7fcae40afb3d",
 		exe: "ffmpeg",
 	},
 };
 
 /**
  * The "-shared" sibling of PINNED, from the *same* release tag and source
- * commit (n8.1.2-22-g94138f6973) — same ffmpeg, just built with DLLs instead
+ * commit (n8.1.2-32-gcfa62de001) — same ffmpeg, just built with DLLs instead
  * of static linking. Only the compositor addon needs this, and it's
  * Windows-only (D3D11), so there's no linux/darwin entry here.
  */
 const SHARED_PINNED = {
 	"win32-x64": {
-		asset: "ffmpeg-n8.1.2-22-g94138f6973-win64-lgpl-shared-8.1.zip",
-		sha256: "8bf72607f421282b64f02c6af8683c480e2d299c6b21349ab0f9b5e27c74e223",
+		asset: "ffmpeg-n8.1.2-32-gcfa62de001-win64-lgpl-shared-8.1.zip",
+		sha256: "23429f940316ea92e376f6946c0a1f1b9043c930f3bc068228461d65ae24f8b8",
 	},
 	"win32-arm64": {
-		asset: "ffmpeg-n8.1.2-22-g94138f6973-winarm64-lgpl-shared-8.1.zip",
-		sha256: "8ee2c32da356883297bac055ccf14e0b6eb1fbb2e5f92f24c569a171207da852",
+		asset: "ffmpeg-n8.1.2-32-gcfa62de001-winarm64-lgpl-shared-8.1.zip",
+		sha256: "7e8ede09fb48087478a272c57dab1a11eaba6688ee7a3d82728fd365425a1b6e",
 	},
 };
 

--- a/technical-documentation/architecture/native-compositor.md
+++ b/technical-documentation/architecture/native-compositor.md
@@ -232,8 +232,8 @@ LIBCLANG_PATH = "C:\\Program Files\\LLVM\\bin"
 ```
 
 So the thirdparty ffmpeg is **`crates/thirdparty/ffmpeg-n8.1.2-win64-lgpl-shared`**
-(the BtbN LGPL-shared build of ffmpeg-n8.1.2-22-g94138f6973, tag
-`autobuild-2026-07-15-14-01`). It must be the **same build** that
+(the BtbN LGPL-shared build of ffmpeg-n8.1.2-32-gcfa62de001, tag
+`autobuild-2026-07-30-13-32`). It must be the **same build** that
 `scripts/fetch-ffmpeg.mjs` vendorises into
 `electron/native/bin/<tag>/` for packaging. The addon's `require()` loads
 `avcodec-NN.dll` / `avformat-NN.dll` / etc. against the vendorised tree at


### PR DESCRIPTION
Le CI du dépôt est rouge sur toutes les branches depuis aujourd'hui ~13h28 UTC. L'étape « Vendor the pinned ffmpeg » échoue avant que cargo ne démarre :

```
> node scripts/fetch-ffmpeg.mjs
Downloading ffmpeg-n8.1.2-22-g94138f6973-win64-lgpl-8.1.zip
  from autobuild-2026-07-15-14-01
Download failed: 404 Not Found
```

BtbN ne conserve ses autobuilds qu'une quinzaine de jours. Le pin datait du 15 juillet et le tag a été purgé en cours de journée : les runs d'avant 13h23 passent, tous ceux d'après échouent — `release/v1.8.0` comprise, donc ce n'est le code de personne.

Re-pinné sur `autobuild-2026-07-30-13-32`, assets `n8.1.2-32-gcfa62de001` : **même ffmpeg 8.1.2**, dix commits plus loin sur la branche 8.1.

## Six entrées, pas quatre

Le fichier prévient — « Tag, asset and digest move together. Re-pin all three or none. » — et il y a **deux** tables : `PINNED` (les binaires vendorisés, 4 plateformes) et `SHARED_PINNED` (le SDK auquel le crate compositeur se lie, 2 plateformes). Les six sont déplacées ensemble.

Le commit source est aussi cité en clair ailleurs, mis à jour pour ne pas désigner un artefact qui n'existe plus :

- **`THIRD-PARTY-NOTICES.md`** — le point qui compte : c'est la conformité LGPL, la « corresponding source » doit désigner ce qui est réellement distribué ;
- `crates/.cargo/config.toml` et `technical-documentation/architecture/native-compositor.md`, qui rappellent tous deux que l'addon doit être lié au build exact qui est shippé.

Après le commit, plus aucune occurrence de `94138f6973` ni de `autobuild-2026-07-15` dans l'arbre.

## Vérification

Les six URL renvoient 200, et le sha256 de chaque archive **effectivement téléchargée** correspond au digest posé dans le fichier — calculés sur les octets servis, jamais recopiés d'ailleurs.

`npm run fetch:ffmpeg` ne peut pas servir de contrôle ici : il sort en erreur sur darwin, BtbN ne publiant pas de build macOS. La licence a donc été vérifiée sur le binaire Linux, le seul inspectable depuis un Mac : ligne de configure sans `--enable-gpl`, sans `--enable-nonfree` et sans `--enable-libx264/libx265/libxvid`, et le binaire se déclare « GNU Lesser General Public License ». Le contrôle `ffmpeg -L` / `-buildconf` / `-encoders` du script rejoue de toute façon sur la plateforme cible en CI — c'est le job Windows de cette PR qui l'exercera pour de vrai.

## Ça va recommencer

Le nouveau pin se re-périmera dans ~deux semaines, par construction : la source est une release purgée en continu. C'est un sursis, pas une solution. Les vraies sorties seraient de miroiter les archives quelque part de stable (release GitHub du dépôt, artefact, cache) ou de basculer sur une source qui ne purge pas. Hors périmètre de ce correctif, mais ça reviendra.

<!-- discord-thread-id:1532418626530054317 -->