### PR TITLE
fix(export): stop counting letterbox rows as an upscale

### DIFF
--- a/src/components/ai-edition/ExportDialog.tsx
+++ b/src/components/ai-edition/ExportDialog.tsx
@@ -31,7 +31,7 @@ import {
 	type GifFrameRate,
 	type GifSizePreset,
 } from "@/lib/exporter";
-import { calculateMp4ExportSettings } from "@/lib/exporter/mp4ExportSettings";
+import { calculateMp4ExportSettings, wouldUpscale } from "@/lib/exporter/mp4ExportSettings";
 import { exportGifNative, exportMultiNative, useIsCpuCompositor } from "@/native";
 import type { CompositorClipInput } from "@/native/contracts";
 import { buildSceneDescription, resolveVisibleClips } from "@/native/sceneDescription";
@@ -86,20 +86,12 @@ function buildNativeClipList(document: AxcutDocument): CompositorClipInput[] {
 	});
 }
 
-// Target short side (px) for the two fixed quality tiers -- mirrors the legacy
-// editor's SettingsPanel (MP4_EXPORT_SHORT_SIDES), used only to decide whether
-// picking that tier would upscale past the source's actual resolution.
-const MEDIUM_SHORT_SIDE = 720;
-const HIGH_SHORT_SIDE = 1080;
-
 const QUALITY_OPTIONS: Array<{
 	value: ExportQuality;
 	labelKey: string;
-	/** Target short side for the upscale check; undefined for "source" (no fixed target). */
-	targetShortSide?: number;
 }> = [
-	{ value: "medium", labelKey: "exportQuality.low", targetShortSide: MEDIUM_SHORT_SIDE },
-	{ value: "good", labelKey: "exportQuality.medium", targetShortSide: HIGH_SHORT_SIDE },
+	{ value: "medium", labelKey: "exportQuality.low" },
+	{ value: "good", labelKey: "exportQuality.medium" },
 	{ value: "source", labelKey: "exportQuality.high" },
 ];
 
@@ -162,17 +154,12 @@ export function ExportDialog({ open, onClose, document }: ExportDialogProps) {
 	// Smallest clip's true (cropped) footprint on the timeline — a multiclip timeline can mix
 	// crops/resolutions, so this is what "Source" quality actually targets: sizing to the
 	// SMALLEST clip's own resolution means no clip on the timeline is ever upscaled past its
-	// true footprint by picking Source, which is why Source shows no upscale/downscale badge
-	// at all any more (see the tier badges below) — it's upscale-proof by construction. The
-	// fixed 720p/1080p tiers don't have that property (they can still upscale a small clip),
-	// so `smallestShortSide` below still feeds their upscale badge.
+	// true footprint by picking Source. It also feeds the upscale badge on the fixed
+	// 720p/1080p tiers, which can still genuinely upscale a small clip.
 	const smallestSource = useMemo(
 		() => pickExtremeDims(effectiveClipDims, "smallest"),
 		[effectiveClipDims],
 	);
-	const smallestShortSide = smallestSource
-		? Math.min(smallestSource.width, smallestSource.height)
-		: null;
 
 	// Aspect the export normalizes to: the timeline's selected ratio (mirrors documentExporter),
 	// so the sizes shown match what the export produces. Read through `getEditorSettings` — the
@@ -419,16 +406,15 @@ export function ExportDialog({ open, onClose, document }: ExportDialogProps) {
 										const dims = tierOutputDims(q.value);
 										if (!dims) return null;
 										// Downscale badge removed everywhere — restated what picking a lower
-										// tier already means, not actionable. Upscale badge removed only for
-										// "Source": it's upscale-proof by construction now (targets the
-										// smallest clip), so the warning never meant anything there. The fixed
-										// 720p/1080p tiers can still genuinely upscale a small clip, so that
-										// badge stays relevant for them.
-										const outShortSide = Math.min(dims.width, dims.height);
-										const isUpscale =
-											q.value !== "source" &&
-											smallestShortSide !== null &&
-											outShortSide > smallestShortSide;
+										// tier already means, not actionable. The upscale badge asks whether
+										// the clip has to be STRETCHED to fill this frame (`wouldUpscale`),
+										// which is a contain-fit question: a short-side compare read the
+										// letterbox rows a non-16:9 source gets in a 16:9 project as if they
+										// were stretched pixels, and flagged "1080p" on the very frame
+										// "Source" produced unflagged. No "Source" special case any more —
+										// its frame is the source's long side at the project ratio, so its
+										// contain scale is never above 1 and the general test covers it.
+										const isUpscale = smallestSource !== null && wouldUpscale(dims, smallestSource);
 										return (
 											<span
 												style={{

--- a/src/lib/exporter/mp4ExportSettings.test.ts
+++ b/src/lib/exporter/mp4ExportSettings.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	calculateEffectiveSourceDimensions,
 	calculateMp4ExportSettings,
+	wouldUpscale,
 } from "./mp4ExportSettings";
 
 describe("calculateMp4ExportSettings", () => {
@@ -106,6 +107,40 @@ describe("calculateMp4ExportSettings", () => {
 			height: 1920,
 			bitrate: 20_000_000,
 		});
+	});
+
+	it("does not call letterbox rows an upscale (1920x1032 window capture, 16:9 project)", () => {
+		const source = { width: 1920, height: 1032 };
+		const tier = (quality: "medium" | "good" | "source") =>
+			calculateMp4ExportSettings({
+				quality,
+				sourceWidth: source.width,
+				sourceHeight: source.height,
+				aspectRatioValue: 16 / 9,
+			});
+
+		// The reported bug: both tiers resolve to the exact same 1920x1080 frame, so they must
+		// carry the same badge. The old short-side test flagged only one of them.
+		expect(tier("good")).toMatchObject({ width: 1920, height: 1080 });
+		expect(tier("source")).toMatchObject({ width: 1920, height: 1080 });
+		expect(wouldUpscale(tier("good"), source)).toBe(false);
+		expect(wouldUpscale(tier("source"), source)).toBe(false);
+		expect(wouldUpscale(tier("medium"), source)).toBe(false);
+	});
+
+	it("still flags a tier that genuinely stretches the source", () => {
+		const source = { width: 1280, height: 720 };
+		expect(
+			wouldUpscale(
+				calculateMp4ExportSettings({
+					quality: "good",
+					sourceWidth: source.width,
+					sourceHeight: source.height,
+					aspectRatioValue: 16 / 9,
+				}),
+				source,
+			),
+		).toBe(true);
 	});
 
 	it("uses the cropped area as the effective source size", () => {

--- a/src/lib/exporter/mp4ExportSettings.ts
+++ b/src/lib/exporter/mp4ExportSettings.ts
@@ -11,6 +11,25 @@ interface SourceCropRegion {
 	height: number;
 }
 
+interface Dims {
+	width: number;
+	height: number;
+}
+
+/**
+ * Would rendering a `source`-sized clip into an `output`-sized frame stretch it past its own
+ * resolution?
+ *
+ * The clip is CONTAIN-fitted into the output frame, so the answer is that fit scale — not a
+ * comparison of short sides, which counts letterbox rows as if they were stretched pixels. A
+ * 1920x1032 window capture in a 16:9 project gives a 1920x1080 frame whose 48 extra rows are
+ * wallpaper, at scale 1.0: nothing is upscaled. The short-side test called that frame an
+ * upscale under the "1080p" tier while "Source" produced the exact same frame unflagged.
+ */
+export function wouldUpscale(output: Dims, source: Dims): boolean {
+	return Math.min(output.width / source.width, output.height / source.height) > 1;
+}
+
 const MEDIUM_SHORT_SIDE = 720;
 const HIGH_SHORT_SIDE = 1080;
 


### PR DESCRIPTION
Reported from the export dialog: with a 1920x1032 window capture on the timeline, the **Source** tile reads `1920 × 1080`.

That number is right — it is the output frame, and the smallest 16:9 frame holding a 1920-wide source without shrinking it *is* 1920x1080. The source's real 1032 was never lost either: it is what makes the 720p tile read as a downscale. So the size SSOT is fine.

What was wrong is next to it: **1080p and Source resolve to the exact same 1920x1080 frame, and only one of them carries the "Upscale" warning.**

| | before | after |
|---|---|---|
| 720p | `1280 × 720` | `1280 × 720` |
| 1080p | `1920 × 1080 · Upscale` | `1920 × 1080` |
| Source | `1920 × 1080` | `1920 × 1080` |

The badge compared short sides (`1080 > 1032`), which counts the letterbox rows a non-16:9 source gets in a 16:9 project as if they were stretched pixels. Those 48 rows are wallpaper; the clip is contain-fitted and still renders at 1:1.

`wouldUpscale()` now asks the contain-fit question the compositor actually answers:

```ts
min(out.w / src.w, out.h / src.h) > 1
```

A source whose shape matches the project ratio is unaffected — which is why a full-screen capture never showed this and a window capture did. A tier that genuinely stretches the source (1280x720 → 1080p, scale 1.5) is still flagged.

The `q.value !== "source"` exemption is gone: Source's frame is the source's long side at the project ratio, so its contain scale is never above 1 and the general test covers it. The `MEDIUM_SHORT_SIDE`/`HIGH_SHORT_SIDE` constants (duplicated from `mp4ExportSettings.ts`) and the write-only `targetShortSide` field they fed go with it.

### Verification

- `src/lib/exporter/mp4ExportSettings.test.ts` — 8/8, two new cases: the reported 1920x1032 @ 16:9 (all three tiers unflagged) and a real stretch that must stay flagged.
- `src/components/ai-edition/ExportDialog.test.ts` — 8/8.
- `biome check` clean on the three files (also via the pre-commit hook).
- Not exercised in the running app: it needs a real 1920x1032 window recording loaded in the editor. The unit test replays that exact case.

`tsc --noEmit` reports one pre-existing unrelated error, `src/i18n/loader.ts: Cannot find module 'i18next'` — the local `node_modules` predates that dependency and needs an `npm install`.

<!-- discord-thread-id:1533720253970780222 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export quality warnings by accurately accounting for letterboxed video dimensions.
  * Prevented false upscale warnings when source footage fits within the selected output without enlargement.
  * Continued warning users when genuinely smaller source footage would be enlarged during export.
  * Updated quality handling consistently across medium, good, and source export options.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->