### PR TITLE
ci(nix): fix the bump workflow's PR creation, and catch npmDepsHash drift

### DIFF
--- a/.github/workflows/bump-nix-package.yml
+++ b/.github/workflows/bump-nix-package.yml
@@ -10,9 +10,10 @@ on:
         required: true
         type: string
 
+# GITHUB_TOKEN only pushes the branch here — the PR itself is opened with the
+# PAT below, so no `pull-requests: write` is needed (and it never worked).
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   bump:

--- a/.github/workflows/bump-nix-package.yml
+++ b/.github/workflows/bump-nix-package.yml
@@ -78,7 +78,13 @@ jobs:
 
       - name: Create PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # NOT GITHUB_TOKEN: the repo has "Allow GitHub Actions to create and
+          # approve pull requests" turned off, so `gh pr create` dies with
+          # "GitHub Actions is not permitted to create or approve pull requests"
+          # — it did exactly that on v1.7.0, after pushing the branch, and #136
+          # had to be opened by hand. The PAT every other release workflow
+          # already uses has no such restriction, and its PRs trigger CI.
+          GH_TOKEN: ${{ secrets.OPENSCREEN_RELEASE_TOKEN }}
           VERSION: ${{ steps.meta.outputs.version }}
           HASH: ${{ steps.hash.outputs.hash }}
           BRANCH: ${{ steps.meta.outputs.branch }}
@@ -112,7 +118,5 @@ jobs:
           - \`npmDepsHash\` → \`${HASH}\` (computed via \`prefetch-npm-deps package-lock.json\`)
 
           Merge this so Nix users (NixOS, Home Manager, \`nix run github:${{ github.repository }}\`) pick up the new release.
-
-          > Note: PRs opened by \`GITHUB_TOKEN\` don't auto-trigger CI. The diff is two lines — review the change here, then merge. If you want CI to run, push an empty commit to this branch or close-and-reopen the PR.
           EOF
           )"

--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -1,0 +1,60 @@
+name: Nix
+
+# nix/package.nix records `npmDepsHash`, a hash of the npm dependency set that
+# package-lock.json resolves to. The two have to agree or `nix build` fails
+# outright, and nothing here ever checked that they did.
+#
+# The only thing that refreshed the hash was bump-nix-package.yml, which fires
+# on stable releases. `src` is this repo's own tree, not a fetched tarball, so
+# every lockfile change landing between two releases left main's hash pointing
+# at dependencies that no longer existed. It last matched on 2026-07-05 (v1.6.0)
+# while package-lock.json moved ten more times, so `nix run github:…` was broken
+# for four weeks with nothing reporting it.
+#
+# Release-time bumps can't fix that — the drift starts the moment a lockfile PR
+# merges. This runs on the PR that causes it and prints the hash to paste.
+on:
+  pull_request:
+    paths:
+      - package-lock.json
+      - nix/**
+      - .github/workflows/nix-check.yml
+  push:
+    branches: [main]
+    paths:
+      - package-lock.json
+      - nix/**
+
+jobs:
+  npm-deps-hash:
+    name: npmDepsHash matches package-lock.json
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Compare recorded hash against the lockfile
+        run: |
+          set -euo pipefail
+          EXPECTED=$(nix run nixpkgs#prefetch-npm-deps -- package-lock.json)
+          RECORDED=$(sed -nE 's|^[[:space:]]*npmDepsHash[[:space:]]*=[[:space:]]*"([^"]*)";|\1|p' nix/package.nix)
+
+          echo "recorded in nix/package.nix: ${RECORDED:-<none>}"
+          echo "expected from package-lock.json: $EXPECTED"
+
+          if [[ -z "$EXPECTED" ]]; then
+            echo "::error::prefetch-npm-deps returned an empty hash"
+            exit 1
+          fi
+
+          if [[ "$EXPECTED" != "$RECORDED" ]]; then
+            echo "::error file=nix/package.nix::npmDepsHash is stale — set it to $EXPECTED"
+            exit 1
+          fi
+
+          echo "In sync."

--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -19,8 +19,13 @@ on:
       - package-lock.json
       - nix/**
       - .github/workflows/nix-check.yml
+  # Same branch list as ci.yml, and for the reason its own comment gives: a
+  # release branch is the last place to skip a check. PRs need no filter here —
+  # the trigger above has none, so they are covered wherever they land — but a
+  # direct push or a rebase force-push onto a long-lived branch is not a PR and
+  # would otherwise go unchecked.
   push:
-    branches: [main]
+    branches: [main, feat/ai-edition, "release/**"]
     paths:
       - package-lock.json
       - nix/**

--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -29,6 +29,13 @@ on:
     paths:
       - package-lock.json
       - nix/**
+      - .github/workflows/nix-check.yml
+
+# Read-only, and stated rather than inherited: the repo default happens to be
+# `read` today, which is exactly the kind of repo-level setting that silently
+# changed this workflow's sibling out from under it.
+permissions:
+  contents: read
 
 jobs:
   npm-deps-hash:

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -33,7 +33,7 @@ buildNpmPackage {
       );
     };
 
-  npmDepsHash = "sha256-IZypOLWlDShIjCKWxlJcrdtIkMu0P/DuXaq4c0HW3FY=";
+  npmDepsHash = "sha256-SggSPoDnKzmvgXpIGP11y6h390SkoZszeMjFTaokRjQ=";
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -11,7 +11,7 @@
 buildNpmPackage {
   nodejs = nodejs_22;
   pname = "openscreen";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src =
     let


### PR DESCRIPTION
Supersedes #136.

### The visible break

`gh pr create` in `bump-nix-package.yml` ran under `GITHUB_TOKEN`, but the repo has *Allow GitHub Actions to create and approve pull requests* off:

```
{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}
```

So the v1.7.0 run pushed its branch and then died on the API call — [run 29707554857](https://github.com/getopenscreen/openscreen/actions/runs/29707554857):

> `pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests`

That is why #136 was opened by hand, and v1.8.0 would have hit it again. Switched to `OPENSCREEN_RELEASE_TOKEN`, which every other release workflow already uses — it isn't subject to that restriction, and its PRs trigger CI, so the "push an empty commit if you want CI" note in the generated body is gone.

Preferred over flipping the repo setting, which would loosen PR creation repo-wide for one workflow.

### The quiet one

`src` is this repo's own tree (a `fileset`, not a fetched tarball), so `npmDepsHash` has to agree with the `package-lock.json` sitting beside it. The only thing that ever refreshed that hash was this release-time workflow.

- `nix/package.nix` last changed **2026-07-05** (`bump nix package to v1.6.0`)
- `package-lock.json` last changed **2026-07-29**, after **10** commits touching it

So `nix run github:getopenscreen/openscreen` had been failing on main for about four weeks, and nothing reported it — no workflow ran `nix build` or otherwise looked at the hash.

A release-time bump structurally cannot cover this: the drift starts the moment a lockfile PR merges, not at the next release. `nix-check.yml` runs on PRs touching `package-lock.json` or `nix/**`, compares the recorded hash against `prefetch-npm-deps package-lock.json`, and fails with the value to paste. Same command the bump workflow already uses, so no new tooling.

### The guard proved itself on this PR

First push kept the stale hash deliberately. [Run 30789853182](https://github.com/getopenscreen/openscreen/actions/runs/30789853182) — **failed**, as it should have:

```
recorded in nix/package.nix:     sha256-IZypOLWlDShIjCKWxlJcrdtIkMu0P/DuXaq4c0HW3FY=
expected from package-lock.json: sha256-SggSPoDnKzmvgXpIGP11y6h390SkoZszeMjFTaokRjQ=
Error: npmDepsHash is stale — set it to sha256-SggSPoDnKzmvgXpIGP11y6h390SkoZszeMjFTaokRjQ=
```

Pasted that value, [run 30789963366](https://github.com/getopenscreen/openscreen/actions/runs/30789963366) — **green**, `In sync.`

Worth noting: #136 carried `sha256-cb8loUzQs4fz3um0xbYgtjQdcRZh/Ptk2YPgv3FHP/s=`, computed from main as it stood on 2026-07-19. That is neither of the two values above — it was stale for the same reason, so merging #136 would not have fixed the build either.

`version` also goes to `1.7.0`, which is all #136 carried.

### Not covered here

No `required_status_checks` rule exists in the `main-protection` ruleset, so this check reports but does not block a merge. Making it blocking is a separate call — there are currently no required checks at all on this repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Nix package to version 1.7.0.
  * Improved automated release pull requests.
  * Added automated checks to verify dependency hashes remain synchronized with the package lockfile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->