### PR TITLE
fix(nix): make the v1.8.0 tag buildable

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -11,7 +11,7 @@
 buildNpmPackage {
   nodejs = nodejs_22;
   pname = "openscreen";
-  version = "1.6.0";
+  version = "1.8.0";
 
   src =
     let
@@ -33,7 +33,7 @@ buildNpmPackage {
       );
     };
 
-  npmDepsHash = "sha256-IZypOLWlDShIjCKWxlJcrdtIkMu0P/DuXaq4c0HW3FY=";
+  npmDepsHash = "sha256-SggSPoDnKzmvgXpIGP11y6h390SkoZszeMjFTaokRjQ=";
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 


### PR DESCRIPTION
Targets `release/v1.8.0`, **not** main — nothing from main comes along.

### Why the fix on main isn't enough

`src` in `nix/package.nix` is this repo's own tree, not a tarball fetched at a tag. So what a Nix user builds depends on the ref they point at:

| Command | Builds |
|---|---|
| `nix run github:getopenscreen/openscreen` | main |
| `nix run github:getopenscreen/openscreen/v1.8.0` | **this branch's tip** |

And `promote.yml` pushes the stable tag on the release branch tip:

> https://github.com/getopenscreen/openscreen/blob/main/.github/workflows/promote.yml#L84 — *Push stable tag on the release branch tip*

So `v1.8.0` would ship the `nix/package.nix` this branch currently carries, untouched since 2026-07-05:

```
version     = "1.6.0"
npmDepsHash = "sha256-IZypOLWlDShIjCKWxlJcrdtIkMu0P/DuXaq4c0HW3FY="
```

`bump-nix-package.yml` structurally cannot repair that. It fires on `release: published`, checks out **main**, and opens its PR against **main**. The tag is never on its path — it has never once touched a tag.

### The value is already proven, not guessed

`package-lock.json` is byte-identical between this branch and main:

```
git diff --quiet origin/main origin/release/v1.8.0 -- package-lock.json   # clean
```

So the correct hash is exactly what CI computed on main in [run 30789963366](https://github.com/getopenscreen/openscreen/actions/runs/30789963366):

```
sha256-SggSPoDnKzmvgXpIGP11y6h390SkoZszeMjFTaokRjQ=
```

### Version

Straight to `1.8.0`. `promote.yml` rewrites `package.json` at tag time but never touches `nix/package.nix`.

With both lines correct here, `bump-nix-package.yml` hits its `git diff --quiet` early-exit after the release and no-ops — the workflow becomes a safety net rather than the thing doing the repair after the fact.

### Merging this back into main is safe

`promote.yml` rebase-merges this branch into main afterwards. No commit on this branch touches `nix/` other than this one:

```
git log origin/main..origin/release/v1.8.0 -- nix/    # empty before this PR
```

So main keeps whatever #230 leaves it with, and this lands on top with the same hash.

### Depends on nothing

Independent of #230. #230 fixes main and stops the drift recurring; this makes the v1.8.0 tag buildable. Both are wanted, in either order.

<!-- discord-thread-id:1533738284717572169 -->