### PR TITLE
fix(timeline): prefer exact segment clip matches

### DIFF
--- a/src/lib/ai-edition/timeline/virtual-preview.test.ts
+++ b/src/lib/ai-edition/timeline/virtual-preview.test.ts
@@ -5,6 +5,7 @@ import { formatSeconds } from "./format";
 import {
 	clampVirtualTime,
 	findNextKeptSegment,
+	findRawClipForSegment,
 	getRawVirtualStartTime,
 	keptWordIdSet,
 	locateKeptSegment,
@@ -369,6 +370,23 @@ describe("virtual-preview pure functions", () => {
 
 		expect(getRawVirtualStartTime(segClip1Part2, rawClips)).toBe(6);
 		expect(getRawVirtualStartTime(segClip2Part1, rawClips)).toBe(13.2);
+	});
+
+	it("findRawClipForSegment prefers an exact raw id over an earlier prefix match", () => {
+		const rawClips: AxcutClip[] = [
+			{ ...clips[0], id: "clip" },
+			{
+				...clips[1],
+				id: "clip_seg1",
+			},
+		];
+		const segment = { ...rawClips[1] };
+
+		expect(findRawClipForSegment(segment, rawClips)?.id).toBe("clip_seg1");
+		expect(getRawVirtualStartTime(segment, rawClips)).toBe(10);
+		expect(findRawClipForSegment({ ...segment, id: "clip_seg1_seg2" }, rawClips)?.id).toBe(
+			"clip_seg1",
+		);
 	});
 
 	it("findNextKeptSegment finds next kept segment across multi-clip trim boundary", () => {

--- a/src/lib/ai-edition/timeline/virtual-preview.ts
+++ b/src/lib/ai-edition/timeline/virtual-preview.ts
@@ -59,9 +59,10 @@ export function findRawClipForSegment(
 ): AxcutClip | undefined {
 	return (
 		rawClips.find((clip) => clip.id === segment.id) ??
-		[...rawClips]
-			.sort((a, b) => b.id.length - a.id.length)
-			.find((clip) => segment.id.startsWith(`${clip.id}_seg`)) ??
+		rawClips.reduce<AxcutClip | undefined>((longest, clip) => {
+			if (!segment.id.startsWith(`${clip.id}_seg`)) return longest;
+			return !longest || clip.id.length > longest.id.length ? clip : longest;
+		}, undefined) ??
 		rawClips.find(
 			(c) =>
 				c.assetId === segment.assetId &&

--- a/src/lib/ai-edition/timeline/virtual-preview.ts
+++ b/src/lib/ai-edition/timeline/virtual-preview.ts
@@ -58,7 +58,10 @@ export function findRawClipForSegment(
 	rawClips: AxcutClip[],
 ): AxcutClip | undefined {
 	return (
-		rawClips.find((c) => c.id === segment.id || segment.id.startsWith(`${c.id}_seg`)) ??
+		rawClips.find((clip) => clip.id === segment.id) ??
+		[...rawClips]
+			.sort((a, b) => b.id.length - a.id.length)
+			.find((clip) => segment.id.startsWith(`${clip.id}_seg`)) ??
 		rawClips.find(
 			(c) =>
 				c.assetId === segment.assetId &&


### PR DESCRIPTION
## Summary

- resolve an exact raw clip ID before considering generated segment-prefix matches
- use the longest matching raw ID for generated segments so nested `_seg`-like IDs remain unambiguous
- add regression coverage for both exact and generated collision cases

## Related issue

No linked issue; found while auditing segment-to-source identity handling.

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [x] Patch
- [ ] Minor
- [ ] Major / breaking change
- [ ] No release note needed

## Desktop impact
- [ ] Windows
- [ ] macOS
- [ ] Linux
- [ ] Installer / packaging
- [x] Not platform-specific

## Screenshots / video

Not applicable; this fixes internal timeline identity resolution.

## Testing

- `npm exec -- vitest run src/lib/ai-edition/timeline/virtual-preview.test.ts`
- `npm exec -- biome check src/lib/ai-edition/timeline/virtual-preview.ts src/lib/ai-edition/timeline/virtual-preview.test.ts`
- `npm run build-vite`
- `npm run wb:typecheck`

<!-- discord-thread-id:1533991779651555450 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeline segment matching to select exact clip matches before partial matches.
  * Ensured split segments resolve to the most specific source clip.
  * Corrected virtual timeline start offsets for exact clip matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->