### PR TITLE
fix(ci): sign the macOS .app ad-hoc when no certificate is available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -260,9 +260,52 @@ jobs:
             exit 1
           fi
 
+      # electron-builder used to do this itself. Its macPackager carried a
+      # `noIdentity && fallBackToAdhoc` branch that handed back `Identity("-")`
+      # whenever no certificate was found — mandatory on arm64, where an unsigned
+      # binary will not launch at all. 26.15.3 replaced that path with
+      # `findSigningIdentity`, which returns null instead, and `sign()` leaves on
+      # `return false`. Nothing signs the bundle, and what ships is the bare
+      # linker signature on the Electron binary: `Identifier=Electron`,
+      # `Sealed Resources=none`.
+      #
+      # That is not cosmetic. macOS keys TCC grants to an app's code signature,
+      # so a bundle signed as "Electron" cannot hold one. v1.9.0-rc.1 asked for
+      # Accessibility, the user granted it, `AXIsProcessTrusted()` still returned
+      # false, and the editable-cursor preflight in useScreenRecorder re-opened
+      # the same dialog on every press of record — recording was impossible.
+      #
+      # Signed with the same runtime and entitlements electron-builder applies,
+      # so a locally signed build and a certificate-signed one differ only in the
+      # identity. Both arches on purpose: 26.8.1 only fell back on arm64, which
+      # left Intel DMGs unsigned for their whole existence.
+      - name: Ad-hoc sign the .app
+        if: steps.signing.outputs.enabled != 'true'
+        run: |
+          codesign --force --deep --sign - \
+            --options runtime \
+            --entitlements macos.entitlements \
+            "${{ steps.find_app.outputs.app_bundle }}"
+
+      # UNCONDITIONAL. Gated on `enabled == 'true'`, this step never ran for the
+      # RC builds — the only ones that could be unsigned — so the regression
+      # above shipped with every macOS check in this job green.
       - name: Verify .app code signature
-        if: steps.signing.outputs.enabled == 'true'
-        run: codesign --verify --deep --strict "${{ steps.find_app.outputs.app_bundle }}"
+        run: |
+          APP="${{ steps.find_app.outputs.app_bundle }}"
+          codesign --verify --deep --strict "$APP"
+
+          # The identifier, not just the structure: `--verify` passes on the bare
+          # linker signature too, so it alone would not have caught this. What
+          # distinguishes a bundle macOS can attach permissions to is that its
+          # signing identifier matches the bundle id.
+          EXPECTED="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$APP/Contents/Info.plist")"
+          ACTUAL="$(codesign -dv --verbose=2 "$APP" 2>&1 | sed -n 's/^Identifier=//p')"
+          echo "signature identifier=${ACTUAL}  expected=${EXPECTED}"
+          if [[ "$ACTUAL" != "$EXPECTED" ]]; then
+            echo "::error::The .app is signed as '${ACTUAL}', not '${EXPECTED}' — macOS cannot attach Accessibility or Screen Recording permissions to a bundle whose signature does not carry its own identifier"
+            exit 1
+          fi
 
       - name: Create DMG
         id: dmg


### PR DESCRIPTION
## Summary

**v1.9.0-rc.1 cannot record on macOS.** The app asks for Accessibility, the user grants it, and it asks again — forever. The permission code is not at fault: the `.app` in the published DMG is not signed at all, and macOS keys TCC grants to an app's code signature, so the grant has nothing to attach to.

Compare the DMGs:

| Release | `Identifier` | `Sealed Resources` |
|---|---|---|
| v1.7.0 | `com.etiennelescot.openscreen` | v2, 796 files |
| v1.8.0-rc.7 / rc.8 / rc.9 | `com.etiennelescot.openscreen` | v2, 128 files |
| **v1.9.0-rc.1** | **`Electron`** | **none** |

`Identifier=Electron` with no sealed resources is the raw linker signature on the Electron binary. electron-builder never re-signed the bundle.

### Root cause

The `electron-builder ^26.8.1 → ^26.15.3` bump in `package.json`. CI sets `CSC_IDENTITY_AUTO_DISCOVERY=false` when the signing secrets are absent, which is every RC. In 26.8.1, `macPackager.sign()` ended at:

```js
else if (noIdentity && fallBackToAdhoc) {
  log.warn(null, "falling back to ad-hoc signature for macOS application code signing")
  identity = new Identity("-", undefined)
}
```

26.15.3 replaced that whole block with `findSigningIdentity`, which returns null, and `sign()` leaves on `return false`. There is no ad-hoc fallback anywhere in 26.15.3's `out/`. No config changed between the two tags — the version bump is the only variable.

### Why the symptom is total

`requestMacCursorAccessibilityAccess` reads `accessibilityTrusted` from the cursor helper, which is `AXIsProcessTrusted()`. That stays false however many times the box is ticked. The preflight in `useScreenRecorder.ts` returns before the countdown, and `handlers.ts` re-opens the deep-link dialog. With the HUD in its default `editable-overlay` cursor mode there is no way through.

### Why nothing caught it

`Verify .app code signature` is gated on `steps.signing.outputs.enabled == 'true'` — so it never ran on the only builds that could be unsigned. Every macOS check in the job was green.

## Changes

- **Ad-hoc sign the `.app`** when no certificate is available, with the same `--options runtime` and `macos.entitlements` electron-builder would have applied. Both arches: 26.8.1 only fell back on arm64, so Intel DMGs were never signed at all.
- **Make signature verification unconditional**, and assert the signing identifier against `CFBundleIdentifier`. `codesign --verify --deep --strict` passes on the bare linker signature too, so structure alone would not have caught this; the identifier is what separates a bundle macOS can attach permissions to from one it cannot.

## Related issue

Refs #

## Type of change
- [x] Bug fix

## Release impact
- [x] Patch

## Desktop impact
- [x] macOS
- [x] Installer / packaging

## Testing

Verified against the three real bundles on an M-series Mac, since the failure is only observable in a packaged `.app`:

```
$ codesign --force --deep --sign - --options runtime \
    --entitlements macos.entitlements Openscreen.app     # copy of the rc.1 DMG
$ codesign --verify --deep --strict Openscreen.app       # passes
$ codesign -dv --verbose=2 Openscreen.app
Identifier=com.etiennelescot.openscreen
Sealed Resources version=2 rules=13 files=128
```

which is byte-for-byte the shape of the working v1.8.0-rc.9 bundle.

The new guard, run against all three:

```
v1.9.0-rc.1 (as published)   expected=com.etiennelescot.openscreen  actual=Electron                       -> rejected
v1.9.0-rc.1 (ad-hoc signed)  expected=com.etiennelescot.openscreen  actual=com.etiennelescot.openscreen   -> passes
v1.8.0-rc.9 (known good)     expected=com.etiennelescot.openscreen  actual=com.etiennelescot.openscreen   -> passes
```

Workflow YAML parses (`js-yaml`); `npm run docs:check` is OK.

Users already on rc.1 can unstick themselves without waiting for rc.2 — quit the app, re-sign it with the `codesign` line above, then `tccutil reset All com.etiennelescot.openscreen` to drop the orphaned entries.

## Note

`npm run build:mac` has the same hole for anyone building locally without a certificate. Left out of this PR to keep it to the published-artifact path.

<!-- discord-thread-id:1534270706622140498 -->