### PR TITLE
test(recording): make the re-index suite run off Linux

### DIFF
--- a/electron/recording/webm-seek-index.test.ts
+++ b/electron/recording/webm-seek-index.test.ts
@@ -4,6 +4,9 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { reindexRecordingOnDisk } from "./webm-seek-index";
 
+/** The platforms whose native helpers already write an indexed file. */
+const NON_LINUX = ["darwin", "win32"] as const;
+
 /**
  * The property under test is not "does libavformat work" — the Rust side owns
  * that, and `crates/compositor/tests/remux_seek_index.rs` proves it. It is the
@@ -14,13 +17,26 @@ import { reindexRecordingOnDisk } from "./webm-seek-index";
 describe("recording re-index", () => {
 	let dir: string;
 	const ORIGINAL = "original recording bytes";
+	const REAL_PLATFORM = process.platform;
 
+	const setPlatform = (value: NodeJS.Platform) =>
+		Object.defineProperty(process, "platform", { value, configurable: true });
+
+	/**
+	 * Pin the platform, because the wrapper is Linux-gated and returns
+	 * `unsupported-platform` before it touches anything else. Left to the real
+	 * platform, every case below stops at that guard and asserts nothing on a
+	 * macOS or Windows checkout — where this suite read as six red tests that
+	 * were neither the contributor's fault nor a real regression.
+	 */
 	beforeEach(async () => {
+		setPlatform("linux");
 		dir = await mkdtemp(path.join(tmpdir(), "openscreen-reindex-"));
 		vi.spyOn(console, "warn").mockImplementation(() => undefined);
 	});
 
 	afterEach(async () => {
+		setPlatform(REAL_PLATFORM);
 		await rm(dir, { recursive: true, force: true });
 		vi.restoreAllMocks();
 	});
@@ -116,18 +132,17 @@ describe("recording re-index", () => {
 		expect(await readFile(filePath, "utf8")).toBe("remuxed bytes");
 	});
 
-	it("does nothing on platforms whose capture already writes indexed files", async () => {
+	// Both platforms the guard is there for, so the Linux pin above can never
+	// quietly become the only thing this suite ever exercises.
+	it.each(NON_LINUX)("does nothing on %s, which captures an index already", async (platform) => {
 		const filePath = await makeRecording();
 		const service = fakeRemux("remuxed bytes");
-		const platform = process.platform;
-		Object.defineProperty(process, "platform", { value: "win32", configurable: true });
-		try {
-			const result = await reindexRecordingOnDisk(filePath, service);
-			expect(result).toEqual({ reindexed: false, reason: "unsupported-platform" });
-			expect(service.remuxSeekable).not.toHaveBeenCalled();
-			expect(await readFile(filePath, "utf8")).toBe(ORIGINAL);
-		} finally {
-			Object.defineProperty(process, "platform", { value: platform, configurable: true });
-		}
+		setPlatform(platform);
+
+		const result = await reindexRecordingOnDisk(filePath, service);
+
+		expect(result).toEqual({ reindexed: false, reason: "unsupported-platform" });
+		expect(service.remuxSeekable).not.toHaveBeenCalled();
+		expect(await readFile(filePath, "utf8")).toBe(ORIGINAL);
 	});
 });


### PR DESCRIPTION
`npx vitest --run` currently shows **6 red tests on a clean checkout** for anyone on macOS or Windows. They are environmental, not a regression — but nothing says so, and working that out by hand costs every new contributor the same half hour.

## Cause

`reindexRecordingOnDisk` is Linux-gated by intent ([webm-seek-index.ts:62](https://github.com/getopenscreen/openscreen/blob/release/v1.9.0/electron/recording/webm-seek-index.ts#L62)) — Windows and macOS record through native helpers that already write indexed files, so re-muxing their output would be pure cost:

```ts
if (process.platform !== "linux") {
    return { reindexed: false, reason: "unsupported-platform" };
}
```

Six cases in the suite inject a fake remux service and assert the remuxed result. Off Linux they stop at that guard and fail. Worth noting they weren't just failing — they were **asserting nothing about the wrapper at all** on those platforms.

## Fix

Pin `process.platform` to `linux` in `beforeEach`, restore the real value in `afterEach`. The technique is the one the suite's own last case already used inline; hoisting it drops the per-test save/restore boilerplate and makes the restore hold even when a case throws part-way through.

The guard stays covered — now parametrised over both platforms it exists for rather than `win32` alone, so the Linux pin can't quietly become the only thing the suite ever exercises.

**No production code changes.** Test file only.

## Verification

The cases still have teeth — this is the part that mattered, since they had been passing vacuously. Removing the empty-output size check from `reindexRecordingOnDisk` fails the truncated-file case:

```
× keeps the original when the remux leaves a truncated 0-byte file
  Tests  1 failed | 7 passed (8)
```

Implementation restored byte-identical afterwards (empty diff).

Full suite on macOS, from 6 failures to none:

```
Test Files  137 passed (137)
     Tests  1626 passed | 1 skipped (1627)
```

`tsc --noEmit` clean, Biome clean (13 warnings, unchanged from baseline).

<!-- discord-thread-id:1534316623349940456 -->