### PR TITLE
fix(build): declare all 13 supported locales in the AppX package

### DIFF
--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -210,7 +210,26 @@
     "displayName": "OpenScreen",
     "backgroundColor": "transparent",
     "capabilities": ["runFullTrust", "microphone", "webcam"],
-    "languages": ["en-US", "fr-FR"],
+    // Mirrors SUPPORTED_LOCALES in src/i18n/config.ts. This list is what the Store
+    // shows as "supported languages" on the product page and what lets the listing
+    // surface in each language's Store search — declaring only en-US/fr-FR advertised
+    // 2 of the 13 languages the app actually ships. Bare tags (ar, es, ...) match every
+    // region of that language, which is what the renderer's locale resolution does too.
+    "languages": [
+      "en-US",
+      "fr-FR",
+      "ar",
+      "es",
+      "it",
+      "ja-JP",
+      "ko-KR",
+      "pt-BR",
+      "ru",
+      "tr",
+      "vi",
+      "zh-CN",
+      "zh-TW"
+    ],
     "showNameOnTiles": true
   }
 }


### PR DESCRIPTION
## Problem

`electron-builder.json5` declared `appx.languages: ["en-US", "fr-FR"]`, but the app ships 13 locales (`SUPPORTED_LOCALES` in `src/i18n/config.ts`: en, ar, es, fr, it, ja-JP, ko-KR, ru, tr, vi, pt-BR, zh-CN, zh-TW).

Two consequences on the Microsoft Store product page:

- it advertises "supported languages: English, French" for an app translated into 13;
- the listing never surfaces in Store searches run in the other 11 languages.

Found while finishing the Store submission for product `9MXQ1HQJL5G5`, where 11 additional listing languages had been added that the package itself never claimed to support.

## Change

`appx.languages` now mirrors `SUPPORTED_LOCALES`. Region-less locales use bare tags (`ar`, `es`, `it`, `ru`, `tr`, `vi`) so every region of that language matches — the same resolution the renderer's own loader does. `en-US` and `fr-FR` are left as they were, since the Store already has validated listings under those exact tags.

## Verification

Parsed the edited file with `json5` and diffed the two lists: 13/13 locales covered, none missing.

```
appx.languages (13): en-US, fr-FR, ar, es, it, ja-JP, ko-KR, pt-BR, ru, tr, vi, zh-CN, zh-TW
SUPPORTED_LOCALES (13): en, ar, es, fr, it, ja-JP, ko-KR, ru, tr, vi, pt-BR, zh-CN, zh-TW
not covered by appx: none
```

No test added: this is a declarative list, not logic. The tie to `src/i18n/config.ts` is named in a comment above the array so the next locale addition has a pointer.

## Note

Config-only — it takes effect on the next `npm run build:win:store`, **not** on the 1.8.0 appx currently sitting in the draft submission.

<!-- discord-thread-id:1534325823010640016 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded Microsoft Store language support to include all 13 available application locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->