### PR TITLE
ci(macos): reject a MAC_CSC_NAME that carries its certificate type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,29 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
         run: |
           if [[ -n "$MAC_CERTIFICATE_P12" && -n "$MAC_CERTIFICATE_PASSWORD" && -n "$MAC_CSC_NAME" && -n "$APPLE_ID" && -n "$APPLE_TEAM_ID" && -n "$APPLE_APP_SPECIFIC_PASSWORD" ]]; then
+            # `CSC_NAME` must name the identity WITHOUT its certificate type.
+            # electron-builder picks the type itself and rejects a qualified name
+            # outright:
+            #
+            #   ⨯ Please remove prefix "Developer ID Application:" from the
+            #     specified name — appropriate certificate will be chosen
+            #     automatically
+            #
+            # It does that at `Package .app bundle`, which sits after the ffmpeg
+            # build and the compositor addon — about twelve minutes in, and only
+            # on macOS. Since the same secret also feeds `codesign --sign` at
+            # `Sign DMG`, the mistake is easy to make: codesign accepts the full
+            # common name, so the qualified form looks right until electron-builder
+            # sees it. The short form satisfies both, because codesign matches on a
+            # substring of the common name.
+            case "$MAC_CSC_NAME" in
+              # Every pattern ends at the colon on purpose, so a company whose
+              # name merely starts with one of these words is not rejected.
+              "Developer ID Application:"*|"Developer ID Installer:"*|"Apple Development:"*|"Apple Distribution:"*|"3rd Party Mac Developer Application:"*|"3rd Party Mac Developer Installer:"*)
+                echo "::error::MAC_CSC_NAME carries a certificate-type prefix. Set it to the identity name alone, e.g. 'Jane Doe (AB12CD34EF)' rather than 'Developer ID Application: Jane Doe (AB12CD34EF)'. Read it from: security find-identity -v -p codesigning"
+                exit 1
+                ;;
+            esac
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Validate `MAC_CSC_NAME` in `Resolve macOS signing` and fail immediately if it carries a certificate-type prefix, instead of letting electron-builder discover it twelve minutes later.

## Why

`CSC_NAME` must name the identity *without* its type — electron-builder selects the certificate type itself and rejects a qualified name:

```
⨯ Please remove prefix "Developer ID Application:" from the specified name
  — appropriate certificate will be chosen automatically
```

It rejects at `Package .app bundle`, which sits after `Vendor LGPL ffmpeg` and `Build Metal compositor addon`. In run [30950523913](https://github.com/getopenscreen/openscreen/actions/runs/30950523913) — the first build ever to have signing enabled — that cost a full macOS job to learn that a secret had four extra words in it.

The mistake is easy to make because **the same secret feeds two different consumers**: `CSC_NAME` for electron-builder, and `codesign --sign` at `Sign DMG`. `codesign` happily accepts the full common name, so the qualified form looks correct everywhere until electron-builder sees it. The short form satisfies both, since `codesign` matches on a substring of the common name — verified locally:

```
$ codesign --sign "Etienne Lescot (M4LK7C6S84)" ...
Authority=Developer ID Application: Etienne Lescot (M4LK7C6S84)
TeamIdentifier=M4LK7C6S84
```

## Behaviour

The check runs only when signing is enabled — every other signing input is already validated in that same step — and the error names the value to use:

```
::error::MAC_CSC_NAME carries a certificate-type prefix. Set it to the identity
name alone, e.g. 'Jane Doe (AB12CD34EF)' rather than 'Developer ID Application:
Jane Doe (AB12CD34EF)'. Read it from: security find-identity -v -p codesigning
```

Covers the Developer ID, Apple Development/Distribution and 3rd Party Mac Developer prefixes. **Every pattern ends at the colon**, so an organisation whose name merely begins with one of those words is not rejected.

## Related issue

Refs #

## Type of change
- [x] Enhancement

## Release impact
- [x] No release note needed

## Desktop impact
- [x] macOS
- [x] Installer / packaging

## Testing

Shell logic exercised against the real values and the false-positive edge case:

```
REJETE   <Developer ID Application: Etienne Lescot (M4LK7C6S84)>   ← the value that broke the build
REJETE   <3rd Party Mac Developer Application: Acme (X1)>
accepte  <3rd Party Mac Developer Tools Inc (X1)>                  ← no colon, not a prefix
accepte  <Etienne Lescot (M4LK7C6S84)>                             ← the value in use now
```

Workflow YAML parses (`js-yaml`); `npm run docs:check` OK (22 files). No documentation asserts anything about `MAC_CSC_NAME`'s format, so nothing needed updating — `release-and-secrets.md` describes the secret's purpose, not its shape.

<!-- discord-thread-id:1534326590304161883 -->