### PR TITLE
fix(ci): scope RC release notes to the previous RC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -474,6 +474,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Full history + tags: the RC notes below are built from `git log` over the
+          # range since the previous RC tag, and resolving that tag needs the tags.
+          fetch-depth: 0
 
       - name: Resolve release tag
         id: release
@@ -520,6 +524,21 @@ jobs:
             NOTES_START_TAG="v${PX}.$((PY - 1)).0"
           else
             NOTES_START_TAG="v$((PX - 1)).0.0"
+          fi
+          # For an RC, compare against the PREVIOUS RC of the same line, not the previous
+          # stable. Deriving the start tag from STABLE_VERSION alone made every RC of a
+          # line span the same range, so each re-cut just repeated the last RC's notes
+          # plus its own handful, and testers could not see what the re-cut changed.
+          # Walk down from the current rc number so a skipped or failed RC doesn't break it.
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            RC_NUMBER="${VERSION##*.}"
+            for (( n = RC_NUMBER - 1; n >= 1; n-- )); do
+              CANDIDATE="v${STABLE_VERSION}-rc.${n}"
+              if git rev-parse -q --verify "refs/tags/${CANDIDATE}" >/dev/null; then
+                NOTES_START_TAG="$CANDIDATE"
+                break
+              fi
+            done
           fi
           echo "Computed notes_start_tag=${NOTES_START_TAG} for tag=${TAG}"
 
@@ -570,17 +589,38 @@ jobs:
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release upload "$TAG" "${FILES[@]}" --clobber
           else
-            # --notes-start-tag controls which previous tag GitHub compares against
-            # when auto-generating the release notes. Default behaviour (most recent
-            # prior release by date) doesn't work for this fork because the v1.4.0
-            # release in the fork was re-published after v1.5.0, which makes GitHub
-            # pick v1.4.0 as the "previous" for any v1.5.x release.
+            if [[ -n "$PRERELEASE_FLAG" ]]; then
+              # RC notes come from `git log`, not --generate-notes. GitHub's generator
+              # lists only the PRs it manages to associate, and on this repo it silently
+              # drops real ones — #254 and #261 were merged into the release branch and
+              # never appeared in v1.9.0-rc.2's body — so an RC could omit the very fix
+              # the re-cut was for. The commit range is the actual diff and can't lie.
+              # Stable releases keep --generate-notes below: they're the public-facing
+              # ones and want the PR links and the New Contributors section.
+              {
+                echo "## Changes since ${NOTES_START_TAG}"
+                echo
+                git log --no-merges --reverse --pretty='- %s' \
+                  --invert-grep --grep='^chore(release): bump to' \
+                  "${NOTES_START_TAG}..${TAG}"
+                echo
+                echo "**Full Changelog**: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${NOTES_START_TAG}...${TAG}"
+              } > "${RUNNER_TEMP}/rc-notes.md"
+              cat "${RUNNER_TEMP}/rc-notes.md"
+              NOTES_ARGS=(--notes-file "${RUNNER_TEMP}/rc-notes.md")
+            else
+              # --notes-start-tag controls which previous tag GitHub compares against
+              # when auto-generating the release notes. Default behaviour (most recent
+              # prior release by date) doesn't work for this fork because the v1.4.0
+              # release in the fork was re-published after v1.5.0, which makes GitHub
+              # pick v1.4.0 as the "previous" for any v1.5.x release.
+              NOTES_ARGS=(--generate-notes --notes-start-tag "$NOTES_START_TAG")
+            fi
             # shellcheck disable=SC2086
             gh release create "$TAG" "${FILES[@]}" \
               --target "$GITHUB_SHA" \
               --title "$TAG" \
-              --generate-notes \
-              --notes-start-tag "$NOTES_START_TAG" \
+              "${NOTES_ARGS[@]}" \
               $PRERELEASE_FLAG
           fi
 


### PR DESCRIPTION
## Problem

Every RC of a line ships the same release body. [v1.8.0-rc.8](https://github.com/getopenscreen/openscreen/releases/tag/v1.8.0-rc.8) and [v1.8.0-rc.9](https://github.com/getopenscreen/openscreen/releases/tag/v1.8.0-rc.9) are byte-identical; [v1.9.0-rc.2](https://github.com/getopenscreen/openscreen/releases/tag/v1.9.0-rc.2) repeats all 18 of rc.1's entries before its own. The one question an RC body has to answer — *what changed since the last RC* — is the one it doesn't.

Two independent causes:

**1. The notes start tag is derived from the stable version.** `STABLE_VERSION="${VERSION%%-*}"` strips `-rc.N`, so every RC of 1.9.0 gets `v1.8.0` as its start tag and spans the whole release.

**2. `--generate-notes` lists only PRs GitHub manages to associate, and it drops real ones.** #254 and #261 were both merged into `release/v1.9.0` and both are in the rc.2 tag, yet neither appears in rc.2's body. Five of the eleven commits in `v1.9.0-rc.1..v1.9.0-rc.2` are invisible — including `fix(export): stop drawing the screen inside the PiP box on camera-less clips`. An RC body can silently omit the fix it was cut for.

## Fix

- Resolve the previous RC of the same line as the start tag, walking down from the current rc number so a skipped or failed RC doesn't break the chain. rc.1 still falls back to the previous stable.
- Build the RC body from `git log` over that range. The commit range is the actual diff and can't lie.
- Stable releases are untouched — they keep `--generate-notes` for PR links and New Contributors.
- `fetch-depth: 0` on the publish job's checkout, needed for the tags and history.

## What rc.2 would have looked like

```
## Changes since v1.9.0-rc.1

- fix(ci): sign the macOS .app ad-hoc when no certificate is available
- fix(recording): stream the native webcam to disk instead of losing it
- test(recording): make the re-index suite run off Linux
- fix(ci): notarize release candidates like stable releases
- fix(build): declare all 13 supported locales in the AppX package
- ci(macos): reject a MAC_CSC_NAME that carries its certificate type
- fix(recording): stop the WGC helper from hanging on stop
- fix(recording): stop a webcam finalize from discarding the screen capture
- ci(diagnostic): build the bundle for release branches too
- fix(export): stop drawing the screen inside the PiP box on camera-less clips
- fix(layout): resolve the webcam layout per clip, not once per timeline
```

## Verification

Ran locally against the real tag graph:

- start-tag resolution: `rc.1 → v1.8.0`, `rc.2 → v1.9.0-rc.1`, `v1.9.0 → v1.8.0`, `v1.8.0-rc.9 → v1.8.0-rc.8`, and an unstarted line falls back correctly.
- the notes block dry-run under GitHub's shell flags (`set -eo pipefail`) for the prerelease path, the stable path, and an empty range — the last one being the `set -e` risk, since `git log` over an empty range is what a re-tag would hit. All exit 0.
- YAML parses; both edited `run:` blocks pass `bash -n`.

Targets `release/v1.9.0` so an rc.3 gets it immediately; reaches `main` through the usual back-merge at promote.

<!-- discord-thread-id:1534457574617776210 -->