### PR TITLE
fix(hud): stop being born click-through, wait for the renderer to ask

### DIFF
--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -266,11 +266,11 @@ export function createHudOverlayWindow(): BrowserWindow {
 	});
 
 	// Deliberately NOT born click-through: the renderer asks for it on mount, over
-	// "hud-overlay-ignore-mouse-events", within a frame or two of the first paint
-	// (`show: false` holds this window back until ready-to-show). What that leaves
-	// open is an invisible rectangle that swallows a desktop click for those two
-	// frames, right after the user launched the app — against what doing it here cost
-	// them: the whole app (issue #266). On Windows the `forward` option is a global
+	// "hud-overlay-ignore-mouse-events" (`show: false` holds this window back until
+	// ready-to-show, so the two are ~85 ms apart — measured, not assumed). What that
+	// leaves open is an invisible rectangle that can swallow one desktop click in
+	// those 85 ms, right after the user launched the app — against what doing it here
+	// cost them: the whole app (issue #266). On Windows the `forward` option is a global
 	// WH_MOUSE_LL hook, and that hook is the only way out of the state, because
 	// Chromium sends no pointermove to a window it has made input-transparent — so
 	// the renderer can never ask to leave it on its own. Electron latches

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -264,7 +264,22 @@ export function createHudOverlayWindow(): BrowserWindow {
 			backgroundThrottling: false,
 		},
 	});
-	win.setIgnoreMouseEvents(true, { forward: true });
+
+	// Deliberately NOT born click-through: the renderer asks for it on mount, over
+	// "hud-overlay-ignore-mouse-events", within a frame or two of the first paint
+	// (`show: false` holds this window back until ready-to-show). What that leaves
+	// open is an invisible rectangle that swallows a desktop click for those two
+	// frames, right after the user launched the app — against what doing it here cost
+	// them: the whole app (issue #266). On Windows the `forward` option is a global
+	// WH_MOUSE_LL hook, and that hook is the only way out of the state, because
+	// Chromium sends no pointermove to a window it has made input-transparent — so
+	// the renderer can never ask to leave it on its own. Electron latches
+	// the install behind `forwarding_mouse_messages_` and retries only after a
+	// setIgnoreMouseEvents(false) — the very call a dead hook prevents. One refused
+	// or revoked hook (Windows drops any whose callback overruns the 300 ms
+	// LowLevelHooksTimeout — on this thread, still busy booting the app) and the HUD
+	// is painted, inert, forever. Asking later moves the install onto an IPC message,
+	// i.e. onto a main thread that is provably pumping.
 
 	// Keep the recording controls out of the recording (see applyContentProtection).
 	applyContentProtection(win, "HUD");

--- a/tests/e2e/windows-native-checklist.spec.ts
+++ b/tests/e2e/windows-native-checklist.spec.ts
@@ -319,4 +319,80 @@ test.describe("Windows native checklist smoke tests", () => {
 			}
 		}
 	});
+
+	// The HUD must reach click-through by *asking* for it from the renderer, never
+	// by being born that way. On Windows the `forward` option is a global
+	// WH_MOUSE_LL hook, and it is the only route back out: a HUD that is already
+	// input-transparent when the hook fails to install can never be clicked again,
+	// which is what bricked the app in issue #266. Both halves matter — that nothing
+	// asks during construction, and that the renderer still does after mount.
+	test("the HUD asks for click-through instead of being born with it", async () => {
+		const app = await launchApp();
+
+		try {
+			const hudWindow = await app.firstWindow({ timeout: 60_000 });
+			await hudWindow.waitForLoadState("domcontentloaded");
+			await dismissLanguagePrompt(hudWindow);
+
+			// A second window keeps the window list non-empty while the HUD is torn
+			// down below — emptying it fires window-all-closed, which quits the app.
+			await hudWindow.getByTestId("launch-source-selector-button").click();
+			await app.waitForEvent("window", {
+				predicate: (w) => w.url().includes("windowType=source-selector"),
+				timeout: 15_000,
+			});
+
+			// Recreate the HUD through the app's own path (second-instance →
+			// showMainWindow → createHudOverlayWindow) with the native call taped.
+			// Nothing awaits between the tape going on and the snapshot coming off,
+			// so no IPC from the renderer can slip into it: what comes back is
+			// construction, and construction only.
+			const duringConstruction = await app.evaluate(({ app: electronApp, BrowserWindow }) => {
+				const tape: unknown[][] = [];
+				const original = BrowserWindow.prototype.setIgnoreMouseEvents;
+				globalThis.__hudTape = tape;
+				globalThis.__hudSetIgnoreMouseEvents = original;
+				BrowserWindow.prototype.setIgnoreMouseEvents = function patched(
+					this: InstanceType<typeof BrowserWindow>,
+					...args: Parameters<typeof original>
+				) {
+					tape.push(args);
+					return original.apply(this, args);
+				};
+
+				BrowserWindow.getAllWindows()
+					.find((w) => w.webContents.getURL().includes("windowType=hud-overlay"))
+					?.destroy();
+				electronApp.emit("second-instance");
+
+				return tape.slice();
+			});
+
+			expect(duringConstruction).toEqual([]);
+
+			// And the renderer does ask, once it has mounted.
+			await expect
+				.poll(() => app.evaluate(() => globalThis.__hudTape ?? []), { timeout: 20_000 })
+				.toContainEqual([true, { forward: true }]);
+		} finally {
+			await app.evaluate(({ BrowserWindow }) => {
+				const original = globalThis.__hudSetIgnoreMouseEvents;
+				if (original) {
+					BrowserWindow.prototype.setIgnoreMouseEvents = original;
+				}
+				globalThis.__hudTape = undefined;
+				globalThis.__hudSetIgnoreMouseEvents = undefined;
+			});
+			await closeApp(app);
+		}
+	});
 });
+
+declare global {
+	// Set inside the main process by the click-through test above, read back by a
+	// second evaluate — the only way to observe calls that land between two of them.
+	var __hudTape: unknown[][] | undefined;
+	var __hudSetIgnoreMouseEvents:
+		| ((ignore: boolean, options?: { forward?: boolean }) => void)
+		| undefined;
+}


### PR DESCRIPTION
Refs #266 — the HUD painted on screen, and every click, drag and button dead from the very first launch.

## What was wrong

`createHudOverlayWindow()` asked for click-through **twice**: once at construction, and once from the renderer's mount effect (`hud-overlay-ignore-mouse-events`). Only the second one is safe.

On Windows, `setIgnoreMouseEvents(true, { forward: true })` is not a Chromium hit-test — Electron installs a **global `WH_MOUSE_LL` hook** and reposts `WM_MOUSEMOVE` by hand ([`native_window_views_win.cc:678`](https://github.com/electron/electron/blob/main/shell/browser/native_window_views_win.cc#L678)):

```cpp
void NativeWindowViews::SetForwardMouseMessages(bool forward) {
  if (forward && !forwarding_mouse_messages_) {
    forwarding_mouse_messages_ = true;
    ...
    if (!mouse_hook_) {
      mouse_hook_ = SetWindowsHookEx(WH_MOUSE_LL, MouseHookProc, nullptr, 0);
    }
  }
```

That hook is the **only** route out of the state, and its install is latched:

- Chromium delivers no `pointermove` to a window it has made input-transparent, so the renderer can never ask to leave click-through on its own.
- The install sits behind `!forwarding_mouse_messages_`, so a later `forward: true` is a no-op. Electron only retries after a `setIgnoreMouseEvents(false)` (the `ERROR_INVALID_HOOK_HANDLE` branch, l.706) — which is precisely the call a dead hook prevents.

**Deadlock.** One hook refused, or silently revoked by Windows for overrunning `LowLevelHooksTimeout` (300 ms), and the bar is painted, inert, forever — with no user-reachable way back.

And construction is the worst moment to ask: that hook callback runs on the main thread, which at that point is still booting the app.

## The change

One statement deleted. The renderer already asks, on mount, a frame or two later — over IPC, on a main thread that is provably pumping messages.

The failure mode inverts: if the ask never arrives, the bar stays **clickable** instead of becoming a ghost.

## Cost — measured, ~85 ms

An invisible 820×560 rectangle can swallow one desktop click between `ready-to-show` and `LaunchWindow`'s mount effect. Timed in the real app: **83 ms and 90 ms** over two runs (a third read negative — an IPC still in flight from the destroyed HUD landing on the new window — and is discarded). `LaunchWindow` is a static import, not `lazy`, so that window does not stretch.

It can be closed to ~0 by asking from `src/main.tsx` at module scope, before React mounts. **Deliberately not done:** that moves the `SetWindowsHookEx` install earlier into the boot, back toward the busy main thread this PR is trying to get it away from. One swallowed click is recoverable; the deadlock is not.

**One swallowed click, not a dragged HUD.** The obvious worry is 2bc9d706 — the drag region that sat on the window root, which on Linux (no click-through) meant pressing empty space dragged the HUD from a spot the user was aiming past. That needed two ingredients, and the second is gone: the region now lives on the grab handle, and it is gated `nativeDrag={isLinuxHud}`, so on Windows/macOS there is no `-webkit-app-region: drag` in the HUD at all. `.hudAnchor` is `pointer-events: none` on top of that. Nothing in those 85 ms can move the window.

## Not Windows-only, and what each platform sees

The deleted line ran on all three platforms. What changes:

- **Windows / macOS** — the HUD is a normal input target for those ~85 ms, then identical to before.
- **Linux** — end state unchanged. `LaunchWindow` gates on `isLinuxHud` and never requests click-through there, so this line was the only thing making the HUD input-transparent on Linux, transiently, until mount. Removing it removes a transient hole rather than opening one.

Nothing else depended on the state: `setHudOverlayIgnoreMouseEvents` has exactly two call sites, both in `LaunchWindow.tsx`. `git log -S` dates the deleted line to a bulk "ui revamp" commit — it was never a targeted fix for anything. The countdown overlay keeps its own `setIgnoreMouseEvents(true)` at construction on purpose: no `forward`, so no hook, no latch, and it is meant to stay click-through for its whole life.

Not verifiable here: macOS. No machine.

## What this does not cover

A hook revoked **mid-session** still deadlocks. Closing that needs an independent wake-up in the main process (poll `screen.getCursorScreenPoint()` while click-through, ~12 lines). Left out on purpose — it addresses a symptom nobody has reported yet, and this PR targets the RC window.

## Getting this into 1.9.0

Targets `main`, per AGENTS.md § PR & commit conventions. The RC window is open (1.9.0-rc.2), so shipping it in 1.9.0 means a cherry-pick onto `release/v1.9.0` once this lands — which is what § Release branches asks for.

## Verification

- `biome check` clean, `tsc --noEmit` clean.
- Playwright e2e on Windows — results in a comment below.
- The deadlock itself is not reproducible on demand (it needs the hook to be refused or revoked), so the e2e evidence is non-regression of the normal path: the HUD still goes click-through after mount, and the bar still takes clicks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HUD mouse interaction handling during startup.
  * Click-through behavior is now enabled after the HUD is ready, helping prevent missed or unexpected mouse interactions.

* **Tests**
  * Added Windows-native coverage to verify the HUD’s click-through behavior and startup sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->