### PR TITLE
feat(editor): turn on roundness, shadow and motion blur by default

### DIFF
--- a/src/components/video-editor/editorDefaults.ts
+++ b/src/components/video-editor/editorDefaults.ts
@@ -36,10 +36,12 @@ export const DEFAULT_EDITOR_APPEARANCE_SETTINGS: {
 	motionBlurAmount: number;
 	borderRadius: number;
 } = {
-	shadowIntensity: 0,
+	// Keep in sync with `DEFAULT_EDITOR_SETTINGS` (lib/ai-edition/store/editorSettings.ts),
+	// which is what the mounted v4 shell reads — see the rationale there.
+	shadowIntensity: 0.2,
 	showBlur: false,
-	motionBlurAmount: 0,
-	borderRadius: 0,
+	motionBlurAmount: 0.2,
+	borderRadius: 40,
 };
 
 export const DEFAULT_EDITOR_LAYOUT_SETTINGS: {

--- a/src/lib/ai-edition/store/editorSettings.test.ts
+++ b/src/lib/ai-edition/store/editorSettings.test.ts
@@ -39,7 +39,7 @@ describe("getEditorSettings", () => {
 		const snap = getEditorSettings(baseDoc);
 		expect(snap.wallpaper).toBe(DEFAULT_EDITOR_SETTINGS.wallpaper);
 		expect(snap.aspectRatio).toBe("16:9");
-		expect(snap.shadowIntensity).toBe(0);
+		expect(snap.shadowIntensity).toBe(DEFAULT_EDITOR_SETTINGS.shadowIntensity);
 		expect(snap.showBlur).toBe(false);
 		expect(snap.webcamLayoutPreset).toBe(DEFAULT_WEBCAM_LAYOUT_PRESET);
 		expect(snap.webcamMaskShape).toBe(DEFAULT_WEBCAM_MASK_SHAPE);
@@ -91,7 +91,7 @@ describe("patchEditorSettings", () => {
 		const next = patchEditorSettings(baseDoc, { showBlur: true });
 		const snap = getEditorSettings(next);
 		expect(snap.showBlur).toBe(true);
-		expect(snap.shadowIntensity).toBe(0);
+		expect(snap.shadowIntensity).toBe(DEFAULT_EDITOR_SETTINGS.shadowIntensity);
 		expect(snap.cropRegion).toEqual(DEFAULT_CROP_REGION);
 	});
 

--- a/src/lib/ai-edition/store/editorSettings.ts
+++ b/src/lib/ai-edition/store/editorSettings.ts
@@ -62,10 +62,15 @@ export interface EditorSettingsSnapshot {
 export const DEFAULT_EDITOR_SETTINGS: EditorSettingsSnapshot = {
 	wallpaper: DEFAULT_WALLPAPER,
 	aspectRatio: "16:9",
-	shadowIntensity: 0,
+	// Opinionated by default: the wallpaper and the padding were already on, but
+	// with square corners and no shadow the recording read as a rectangle pasted
+	// onto the background rather than a window floating above it (#271 reported
+	// the symptom and blamed the padding). These three are the rest of that look;
+	// shipping the background without them was shipping half a composition.
+	shadowIntensity: 0.2,
 	showBlur: false,
-	motionBlurAmount: 0,
-	borderRadius: 0,
+	motionBlurAmount: 0.2,
+	borderRadius: 40,
 	padding: 50,
 	cropRegion: DEFAULT_CROP_REGION,
 	webcamLayoutPreset: DEFAULT_WEBCAM_LAYOUT_PRESET,


### PR DESCRIPTION
Closes #271 — by doing the opposite of what it asked, and here is why.

## The defaults were internally inconsistent

| Setting | Before | After |
|---|---|---|
| wallpaper | `wallpaper1.jpg` (on) | unchanged |
| padding | `50` → content block at 80% of the frame | unchanged |
| roundness | **0 px** | **40 px** |
| shadow | **0 %** | **20 %** |
| motion blur | **0 %** | **20 %** |

#271 argues on friction: the padding is one more slider to reset on every new project. But a neutral default isn't the direction here — the point is that the app hands you the best-looking result without you opening the effects panel at all. Today it doesn't quite: we ship a decorative background *and* a margin, then draw the recording into it as a hard-edged rectangle with no shadow. That is half a composition.

Setting padding to 0 would also hide the wallpaper completely behind the screen, i.e. remove the background feature by way of a default. So this PR ships the missing half instead of dropping the half we had.

## Values

Picked by eye on Windows: roundness 40px, shadow 20%, motion blur 20%. The rendering reference already assumed non-zero roundness — `NATIVE_SCREEN_BASE_RADIUS_PX` in `src/native/paramUnits.ts` is documented as "the fixture's screen corner radius", and the compositor goldens render with `shadow` well above 0. Only the app shipped zeros.

## Existing projects

`legacyEditor` is a sparse store: `patchEditorSettings` only writes keys the user actually changed. So a project where someone moved the roundness slider keeps its value, while a project that never touched these picks up the new look on reopen. That is deliberate — the point of an opinionated default is that people who never opened the panel get the better result.

## Testing

- `vitest --run` on the affected suites: 229 passed (`editorSettings`, `migrate`, `editorDefaults`, `projectPersistence`, `sceneDescription`, `nativeCompositorStore`, `compositeLayout`, `WebcamOverlay`).
- Full suite: only pre-existing failures in `electron/recording/webm-seek-index.test.ts` (identical with and without this change).
- `tsc -p tsconfig.test.json --noEmit` and `biome check` clean.

Two assertions in `editorSettings.test.ts` hardcoded `0` where they meant "the default"; they now reference `DEFAULT_EDITOR_SETTINGS`.

## Follow-up, not in this PR

The legitimate need behind #271 — a flush, full-frame output to embed in a doc — deserves a one-click "Full frame" preset. There is no effects preset mechanism today, only webcam layout presets. Worth its own issue if it comes up again.
