### PR TITLE
fix(cursor): make the Windows cursor sampler DPI-aware

### DIFF
--- a/electron/native-bridge/cursor/recording/windowsNativeRecordingSession.ts
+++ b/electron/native-bridge/cursor/recording/windowsNativeRecordingSession.ts
@@ -186,7 +186,10 @@ export class WindowsNativeRecordingSession implements CursorRecordingSession {
 		}
 
 		if (payload.asset?.id && !this.assets.has(payload.asset.id)) {
-			const assetDisplay = screen.getDisplayNearestPoint({ x: payload.x, y: payload.y });
+			// payload.x/y are physical screen pixels; `screen` works in DIPs.
+			const assetDisplay = screen.getDisplayNearestPoint(
+				screen.screenToDipPoint({ x: payload.x, y: payload.y }),
+			);
 			this.assets.set(payload.asset.id, {
 				id: payload.asset.id,
 				platform: "win32",

--- a/electron/native/wgc-capture/src/cursor-sampler.cpp
+++ b/electron/native/wgc-capture/src/cursor-sampler.cpp
@@ -410,6 +410,14 @@ static void runSamplingLoop(int intervalMs, HWND targetWindow, const CLSID& pngC
 // main
 // ─────────────────────────────────────────────────────────────────────────────
 int main(int argc, char* argv[]) {
+    // Without this the process is DPI-unaware and Win32 virtualises every
+    // coordinate it hands back — GetCursorInfo().ptScreenPos and GetWindowRect
+    // come out divided by the primary display's scale factor — while the WGC
+    // capture and the consumer both work in physical pixels.  On any scaled
+    // display the cursor then lands short of its real position, by more the
+    // further it is from the origin (getopenscreen/openscreen#272).
+    SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+
     if (argc < 2) {
         std::cerr << "Usage: cursor-sampler <intervalMs> [windowHandle]" << std::endl;
         return 1;


### PR DESCRIPTION
Fixes #272.

## The bug

The cursor drawn in the editor preview sits short of where it really was, by more the further it is from the top-left of the display. Only on **Windows**, only on a **display (screen) capture**, only at a **display scaling other than 100%**.

## Root cause

`cursor-sampler.exe` ships with no `dpiAware` manifest and never calls `SetProcessDpiAwareness*`:

```
<assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0'>
  <trustInfo …><security><requestedPrivileges>
    <requestedExecutionLevel level='asInvoker' uiAccess='false' />
  </requestedPrivileges></security></trustInfo>
</assembly>
```

So the process is DPI-**unaware**, and Win32 hands it *virtualized* coordinates — `GetCursorInfo().ptScreenPos` and `GetWindowRect` both come back divided by the primary display's scale factor.

`b31bb71f` (shipped in v1.7.0, so present in the reported 1.8.0) assumed the opposite — *"the cursor-sampler reports raw x/y in physical screen pixels"* — and converted the Electron display bounds to physical with `dipToScreenRect` before normalizing. Numerator and denominator then lived in different spaces:

```
cx = (x / s) / W_physical        instead of        x / W_physical
```

The preview cursor lands at `1/s` of its true offset from the display origin. At 150% on a 2560px-wide screen that is ~850px short at the right edge. At 100% the two spaces coincide, which is why it was invisible on the dev machines and in the Windows smoke tests.

**Window captures were never affected**: there the sampler supplies its own `GetWindowRect` bounds, so both sides were virtualized together and the ratio came out right either way.

## The fix

Opt the helper into per-monitor-v2 awareness, rather than walking the normalization back to DIPs. The reported numbers then really are physical — which is what every consumer already assumes — and unlike DIP normalization this also holds on mixed-DPI multi-monitor setups, where virtualization always uses the *primary* display's scale whatever monitor the cursor is on.

Second hunk: `payload.x/y` being physical now, the asset's display lookup goes through `screenToDipPoint` — `screen.getDisplayNearestPoint` works in DIPs and would otherwise pick the wrong monitor.

## Verification

| | `GetProcessDpiAwareness` |
|---|---|
| `cursor-sampler.exe` as shipped in 1.8.0 | `UNAWARE` |
| rebuilt from this branch | `PER_MONITOR_AWARE` |

- Builds clean (MSVC / Ninja, no new warnings), `tsc --noEmit` and `biome check` pass.
- At 100% scaling the rebuilt sampler reports exactly the same position as before (`253,611` == `253,611`) — no regression on unscaled displays.
- End-to-end on a scaled display: the bug reproduces on demand by setting the display to 150% and recording a screen, and is gone on a build from this branch. Confirmed manually — there is no automated coverage for it (see below).

## Cross-OS

| Platform | Status |
|---|---|
| Windows | broken → fixed here |
| macOS | unaffected — the SCK helper reports its capture frame in **points** (`ScreenCaptureRecorder.swift:127`), the same space as `screen.getCursorScreenPoint()` |
| Linux | unaffected — the PipeWire helper normalizes against the **stream's own pixel dimensions**, which it repeats on every sample, deliberately ignoring Electron's DIP bounds |

No test is added: the whole failure lives in a Win32 process attribute, and CI is Linux-only, so a guard here would never run.
