### PR TITLE
fix(ci): re-pin ffmpeg on a month-end BtbN build

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -26,11 +26,11 @@ distributed by their own registries, not redistributed inside our binaries.
   verifies this before vendoring — it reads `ffmpeg -L`, `-buildconf` and
   `-encoders` and refuses any binary that reports otherwise.
 - **Upstream binaries**: BtbN/FFmpeg-Builds, release
-  `autobuild-2026-07-30-13-32`, the `*-lgpl-shared-8.1` assets. Pinned by
+  `autobuild-2026-07-31-14-10`, the `*-lgpl-shared-8.1` assets. Pinned by
   SHA-256 in `scripts/fetch-ffmpeg.mjs`; the digests there identify the exact
   artifacts we ship.
-  <https://github.com/BtbN/FFmpeg-Builds/releases/tag/autobuild-2026-07-30-13-32>
-- **Corresponding source**: FFmpeg n8.1.2, commit `cfa62de001`, from
+  <https://github.com/BtbN/FFmpeg-Builds/releases/tag/autobuild-2026-07-31-14-10>
+- **Corresponding source**: FFmpeg n8.1.2, commit `9b6c8969e0`, from
   <https://github.com/FFmpeg/FFmpeg>. The build configuration and scripts that
   produced these exact binaries are published at
   <https://github.com/BtbN/FFmpeg-Builds>.

--- a/crates/.cargo/config.toml
+++ b/crates/.cargo/config.toml
@@ -2,8 +2,8 @@
 # ffmpeg LGPL-shared (voir README). LIBCLANG_PATH = install LLVM locale (bindgen).
 # Ces valeurs cèdent à une vraie variable d'environnement (force=false par défaut).
 #
-# Pinné sur le MÊME build release-branch (n8.1.2-32-gcfa62de001, tag BtbN
-# autobuild-2026-07-30-13-32) que scripts/fetch-ffmpeg.mjs vendorise dans
+# Pinné sur le MÊME build release-branch (n8.1.2-34-g9b6c8969e0, tag BtbN
+# autobuild-2026-07-31-14-10) que scripts/fetch-ffmpeg.mjs vendorise dans
 # electron/native/bin/<tag>/ pour le packaging — pas un snapshot "master-latest"
 # flottant. L'addon (compositor-view-napi) doit être lié à la même version de
 # ffmpeg que celle shippée, sinon les DLLs vendorisées ne matchent pas les

--- a/scripts/fetch-ffmpeg.mjs
+++ b/scripts/fetch-ffmpeg.mjs
@@ -65,37 +65,51 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, "..");
 
-/** Immutable dated tag. `latest` is an alias that moves — do not use it here. */
-const RELEASE_TAG = "autobuild-2026-07-30-13-32";
+/**
+ * Immutable dated tag. `latest` is an alias that moves — do not use it here.
+ *
+ * MUST be a **last-day-of-the-month** autobuild. Immutable is not the same as
+ * permanent: BtbN keeps only ~15 days of daily autobuilds and prunes the rest,
+ * retaining month-end builds long term. A daily tag therefore 404s about two
+ * weeks after it is pinned, which breaks `npm run fetch:ffmpeg*` — and with it
+ * `build:linux` and `build:win`, which `publish-release` both depend on. That
+ * has already happened twice: `autobuild-2026-07-15-14-01` (fixed in 81e05972)
+ * and `autobuild-2026-07-30-13-32`, a Thursday.
+ *
+ * Check before re-pinning: `gh api repos/BtbN/FFmpeg-Builds/releases -q
+ * '.[].tag_name'` — anything older than ~15 days that is still listed is a
+ * month-end build, and only those are safe.
+ */
+const RELEASE_TAG = "autobuild-2026-07-31-14-10";
 const BASE = `https://github.com/BtbN/FFmpeg-Builds/releases/download/${RELEASE_TAG}`;
 
 /** Tag, asset and digest move together. Re-pin all three or none. */
 const PINNED = {
 	"win32-x64": {
-		asset: "ffmpeg-n8.1.2-32-gcfa62de001-win64-lgpl-8.1.zip",
-		sha256: "c5a091e6a0e446f737f5ae78f9ed38dc02081c014156097468c196b606c4717f",
+		asset: "ffmpeg-n8.1.2-34-g9b6c8969e0-win64-lgpl-8.1.zip",
+		sha256: "089e4169e93b2b3f3acbfced3c0704d24276a225641bdda04d796d28b07a2a38",
 		exe: "ffmpeg.exe",
 	},
 	"win32-arm64": {
-		asset: "ffmpeg-n8.1.2-32-gcfa62de001-winarm64-lgpl-8.1.zip",
-		sha256: "c5b600e5577142fe7d9d4c9788b91d09a4eaf36900abc5b7cf82b8af54663d7a",
+		asset: "ffmpeg-n8.1.2-34-g9b6c8969e0-winarm64-lgpl-8.1.zip",
+		sha256: "5b55ac00360811ef08513c76240c93e52a369cd29040d21799e7758fc7e9eaea",
 		exe: "ffmpeg.exe",
 	},
 	"linux-x64": {
-		asset: "ffmpeg-n8.1.2-32-gcfa62de001-linux64-lgpl-8.1.tar.xz",
-		sha256: "c54903d95c31d283441bc30ad61ed5d58ed968e18d6169b606dbf175d3719c30",
+		asset: "ffmpeg-n8.1.2-34-g9b6c8969e0-linux64-lgpl-8.1.tar.xz",
+		sha256: "8c8b2897f2a8093ae2d985f7f1867d218451d4c567c1b2437f86a7c73a950b9f",
 		exe: "ffmpeg",
 	},
 	"linux-arm64": {
-		asset: "ffmpeg-n8.1.2-32-gcfa62de001-linuxarm64-lgpl-8.1.tar.xz",
-		sha256: "f7a5ffe5e8f10957ce4675e0fab8d8a739a33abcf626721a9cfc7fcae40afb3d",
+		asset: "ffmpeg-n8.1.2-34-g9b6c8969e0-linuxarm64-lgpl-8.1.tar.xz",
+		sha256: "0c8716a94ac1fe22eb56e7a0cedd0f00c1d8fae712ec19973d679a7a87916743",
 		exe: "ffmpeg",
 	},
 };
 
 /**
  * The "-shared" sibling of PINNED, from the *same* release tag and source
- * commit (n8.1.2-32-gcfa62de001) — same ffmpeg, just built with shared libraries
+ * commit (n8.1.2-34-g9b6c8969e0) — same ffmpeg, just built with shared libraries
  * instead of static linking.
  *
  * Two consumers now: the Windows D3D11 compositor addon, and the Linux
@@ -108,16 +122,16 @@ const PINNED = {
  */
 const SHARED_PINNED = {
 	"linux-x64": {
-		asset: "ffmpeg-n8.1.2-32-gcfa62de001-linux64-lgpl-shared-8.1.tar.xz",
-		sha256: "74ef679aa7e4f8cdbd5193da3d99bf220a679f64d35daf078397081b789f150e",
+		asset: "ffmpeg-n8.1.2-34-g9b6c8969e0-linux64-lgpl-shared-8.1.tar.xz",
+		sha256: "c882a80f06617149198a98a07a0880a7e881953ae9f9cb931f5be09a4f93caae",
 	},
 	"win32-x64": {
-		asset: "ffmpeg-n8.1.2-32-gcfa62de001-win64-lgpl-shared-8.1.zip",
-		sha256: "23429f940316ea92e376f6946c0a1f1b9043c930f3bc068228461d65ae24f8b8",
+		asset: "ffmpeg-n8.1.2-34-g9b6c8969e0-win64-lgpl-shared-8.1.zip",
+		sha256: "c222a490dde4e7059f45495deef6bfb98dbcacc2b43df5b607546252037aa95c",
 	},
 	"win32-arm64": {
-		asset: "ffmpeg-n8.1.2-32-gcfa62de001-winarm64-lgpl-shared-8.1.zip",
-		sha256: "7e8ede09fb48087478a272c57dab1a11eaba6688ee7a3d82728fd365425a1b6e",
+		asset: "ffmpeg-n8.1.2-34-g9b6c8969e0-winarm64-lgpl-shared-8.1.zip",
+		sha256: "4abab52904037ecad91b54811d69005a0b2e1f591242fd1517d32b299246ece0",
 	},
 };
 

--- a/technical-documentation/architecture/native-compositor.md
+++ b/technical-documentation/architecture/native-compositor.md
@@ -232,8 +232,8 @@ LIBCLANG_PATH = "C:\\Program Files\\LLVM\\bin"
 ```
 
 So the thirdparty ffmpeg is **`crates/thirdparty/ffmpeg-n8.1.2-win64-lgpl-shared`**
-(the BtbN LGPL-shared build of ffmpeg-n8.1.2-32-gcfa62de001, tag
-`autobuild-2026-07-30-13-32`). It must be the **same build** that
+(the BtbN LGPL-shared build of ffmpeg-n8.1.2-34-g9b6c8969e0, tag
+`autobuild-2026-07-31-14-10`). It must be the **same build** that
 `scripts/fetch-ffmpeg.mjs` vendorises into
 `electron/native/bin/<tag>/` for packaging. The addon's `require()` loads
 `avcodec-NN.dll` / `avformat-NN.dll` / etc. against the vendorised tree at


### PR DESCRIPTION
## Summary

`scripts/fetch-ffmpeg.mjs` was pinned to `autobuild-2026-07-30-13-32` — a **Thursday** daily autobuild. BtbN keeps only ~15 days of dailies and prunes the rest, retaining month-end builds long term. The pin was due to 404 around **2026-08-14**.

When it 404s, `npm run fetch:ffmpeg*` throws (`downloadAndExtract` has no retry and no fallback), so `build:linux` and `build:win` die before cargo — and `publish-release` has both in `needs:`. No release, any platform.

Evidence for the retention rule:

```
autobuild-2026-08-06 … autobuild-2026-07-23   ← 14 dailies
autobuild-2026-06-30, 2026-05-31, 2026-04-30, 2026-03-31, 2026-02-28, …
```

Nothing between 2026-07-23 and 2026-06-30 survives, and every older tag is a last-day-of-month build.

This is the **second** occurrence — 81e05972 re-pinned after `autobuild-2026-07-15-14-01` was purged the same way. The header comment described the tag as "immutable", which is true and beside the point; it now states the retention rule and the `gh api` one-liner to check a candidate.

Re-pinned to **`autobuild-2026-07-31-14-10`** (`n8.1.2-34-g9b6c8969e0`), the last day of July, still a release-branch 8.1.x build — not an `N-…` master snapshot.

Tag, asset names and digests move as one unit, so the diff covers all four places that name them:

| File | What changed |
|---|---|
| `scripts/fetch-ffmpeg.mjs` | `RELEASE_TAG`, 4 `PINNED` + 3 `SHARED_PINNED` entries (asset + sha256), retention rule in the header comment |
| `THIRD-PARTY-NOTICES.md` | release tag ×2, corresponding-source commit — the LGPL source offer must point at the binaries we actually ship |
| `crates/.cargo/config.toml` | pin comment |
| `technical-documentation/architecture/native-compositor.md` | pin reference |

## Related issue

No issue — found while auditing the Linux build/packaging chain.

## Type of change
- [x] Bug fix

## Release impact
- [x] Patch

## Desktop impact
- [x] Windows
- [x] Linux
- [x] Installer / packaging

## Screenshots / video

n/a

## Testing

`npm run fetch:ffmpeg` on Ubuntu 24.04 x86_64, against a cleaned `electron/native/bin/linux-x64/`, exit 0:

```
Downloading ffmpeg-n8.1.2-34-g9b6c8969e0-linux64-lgpl-8.1.tar.xz
  from autobuild-2026-07-31-14-10
  sha256 ok (107 MB)
Verifying licence...
ffmpeg version n8.1.2-34-g9b6c8969e0-20260731
  hardware encoders: h264_nvenc, h264_vaapi
LGPL verified: safe to ship with an MIT app.

Downloading ffmpeg-n8.1.2-34-g9b6c8969e0-linux64-lgpl-shared-8.1.tar.xz
  sha256 ok (54 MB)
Vendored ffmpeg SDK (include/ + lib/) -> crates/thirdparty/ffmpeg-linux64-lgpl-shared
LGPL verified: safe to ship with an MIT app.
```

Both digests verified against the release's own `checksums.sha256`, and the script's own SHA-256 gate then re-verified them on the downloaded bytes. The Windows and arm64 digests come from the same file; they are not exercised by this run and will be by the first CI build.

### Note for #293

That PR adds a `linux-arm64` entry to `SHARED_PINNED` and will conflict here. Its digest at this tag is:

```
eec386482ac6799bb547b5f507dedd19ef6354eee0ca4ddb04bdd053d03c3cfb  ffmpeg-n8.1.2-34-g9b6c8969e0-linuxarm64-lgpl-shared-8.1.tar.xz
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1535209536665686080 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled multimedia processing components to a newer FFmpeg release.
  * Improved retrieval reliability across supported Windows and Linux builds.
  * Added integrity verification for downloaded components.

* **Documentation**
  * Updated technical documentation and notices to reflect the current FFmpeg release.
  * Documented release-selection guidance to help ensure long-term availability of required build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->