### PR TITLE
fix(release): publish before syncing main, and stop racing the merge

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -101,7 +101,50 @@ jobs:
           git tag "$STABLE_TAG"
           git push origin "$STABLE_TAG"
 
+      # ORDER MATTERS. Everything that actually publishes the release runs before the
+      # main-sync below. The stable tag is already pushed at this point, so the build
+      # and the announcement depend on nothing the sync produces — while the sync is a
+      # PR round-trip against a remote that fails for reasons of its own. It used to
+      # run first, and every one of its failures silently skipped both steps under it:
+      # v1.7.0, v1.8.0 and v1.9.0 all shipped without an automated build (dispatched by
+      # hand minutes later) and without a #releases announcement.
+      - name: Trigger build workflow
+        env:
+          GH_TOKEN: ${{ secrets.OPENSCREEN_RELEASE_TOKEN }}
+          STABLE_TAG: ${{ steps.version.outputs.stable_tag }}
+        run: |
+          set -euo pipefail
+          # GITHUB_TOKEN tag pushes don't fire build.yml in this setup, dispatch it.
+          #
+          # --ref pins the build to the stable tag (the frozen release-branch tip), which
+          # is also what makes running this before the main-sync correct: the tag already
+          # points at the released snapshot, so checkout gets the matching package.json +
+          # code whatever main looks like, and signing/notarization is enabled (tag has
+          # no '-').
+          gh workflow run build.yml \
+            --ref "${STABLE_TAG}" \
+            -f release_tag="${STABLE_TAG}" \
+            -f arch=both \
+            --repo "$GITHUB_REPOSITORY"
+
+      - name: Announce stable on Discord
+        if: success()
+        env:
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_RELEASE_CHANNEL_ID: ${{ vars.DISCORD_RELEASE_CHANNEL_ID }}
+          GITHUB_TOKEN: ${{ secrets.OPENSCREEN_RELEASE_TOKEN }}
+          STABLE_TAG: ${{ steps.version.outputs.stable_tag }}
+          RC_TAG: ${{ steps.version.outputs.rc_tag }}
+          EXTRA: ${{ inputs.release_notes_extra }}
+          KIND: stable
+        run: node .github/scripts/discord-release-announce.mjs
+
+      # Bookkeeping, not publishing: the release is already out by now. Allowed to fail
+      # so a stuck PR never masks a successful release — the summary reports it and it
+      # is trivially redone by hand.
       - name: Merge release branch into main
+        id: sync_main
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.OPENSCREEN_RELEASE_TOKEN }}
           STABLE_VERSION: ${{ steps.version.outputs.stable_version }}
@@ -127,43 +170,40 @@ jobs:
             --body "Sync main with the released snapshot (RC + cherry-picked bugfixes + version bump). Rebase-merged via PAT; bypass applies because EtienneLescot is a ruleset bypass actor." \
             --repo "$GITHUB_REPOSITORY" || echo "(PR already exists — skipping)"
           PR_NUMBER=$(gh pr list --head "${BRANCH}-sync" --state open --json number -q '.[0].number' --repo "$GITHUB_REPOSITORY")
-          if [[ -n "$PR_NUMBER" ]]; then
-            gh pr merge "$PR_NUMBER" --rebase --delete-branch --admin \
-              --repo "$GITHUB_REPOSITORY"
+          if [[ -z "$PR_NUMBER" ]]; then
+            echo "No open sync PR found — nothing to merge."
+            exit 0
+          fi
+          # GitHub computes mergeability asynchronously. Merging ~3s after creating the
+          # PR raced that computation every time: v1.9.0 got "This branch can't be
+          # rebased" 2.9s after create, v1.8.0 "has merge conflicts" after 1.7s — and
+          # both merged by hand, unchanged, minutes later. Wait for a real verdict.
+          for _ in $(seq 1 30); do
+            STATE=$(gh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus \
+              --repo "$GITHUB_REPOSITORY" 2>/dev/null || echo UNKNOWN)
+            echo "mergeStateStatus=${STATE}"
+            if [[ "$STATE" != "UNKNOWN" ]]; then break; fi
+            sleep 5
+          done
+          # Retry anyway: leaving UNKNOWN is necessary, not sufficient. MERGED must be
+          # set by a successful merge — a bare `&& break` loop exits 0 after five
+          # failures and reports a merge that never happened.
+          MERGED=0
+          for _ in $(seq 1 5); do
+            if gh pr merge "$PR_NUMBER" --rebase --delete-branch --admin \
+              --repo "$GITHUB_REPOSITORY"; then
+              MERGED=1
+              break
+            fi
+            sleep 15
+          done
+          if [[ "$MERGED" -ne 1 ]]; then
+            echo "::error::Could not rebase-merge sync PR #${PR_NUMBER} into main after 5 attempts. The release itself is published; merge it by hand."
+            exit 1
           fi
           # The release branch itself was already used to publish and contains frozen
           # history — leave it in place for forensics. A v1.6.0 release branch should
           # never be deleted until the next major cuts over.
-
-      - name: Trigger build workflow
-        env:
-          GH_TOKEN: ${{ secrets.OPENSCREEN_RELEASE_TOKEN }}
-          STABLE_TAG: ${{ steps.version.outputs.stable_tag }}
-        run: |
-          set -euo pipefail
-          # GITHUB_TOKEN tag pushes don't fire build.yml in this setup, dispatch it.
-          #
-          # --ref pins the build to the stable tag (the frozen release-branch tip). The
-          # prior main-merge step usually leaves main at the stable version already, but
-          # relying on that is fragile; building the tag guarantees checkout has the
-          # matching package.json + code and enables signing/notarization (tag has no '-').
-          gh workflow run build.yml \
-            --ref "${STABLE_TAG}" \
-            -f release_tag="${STABLE_TAG}" \
-            -f arch=both \
-            --repo "$GITHUB_REPOSITORY"
-
-      - name: Announce stable on Discord
-        if: success()
-        env:
-          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
-          DISCORD_RELEASE_CHANNEL_ID: ${{ vars.DISCORD_RELEASE_CHANNEL_ID }}
-          GITHUB_TOKEN: ${{ secrets.OPENSCREEN_RELEASE_TOKEN }}
-          STABLE_TAG: ${{ steps.version.outputs.stable_tag }}
-          RC_TAG: ${{ steps.version.outputs.rc_tag }}
-          EXTRA: ${{ inputs.release_notes_extra }}
-          KIND: stable
-        run: node .github/scripts/discord-release-announce.mjs
 
       - name: Workflow summary
         run: |
@@ -173,4 +213,11 @@ jobs:
             echo "- Stable tag: \`${{ steps.version.outputs.stable_tag }}\`"
             echo "- Promoted from: \`${{ steps.version.outputs.rc_tag }}\`"
             echo "- Tier 3 (homebrew/winget/nix/aur) will fire on the published release via OPENSCREEN_RELEASE_TOKEN."
+            if [[ "${{ steps.sync_main.outcome }}" != "success" ]]; then
+              echo ""
+              echo "> [!WARNING]"
+              echo "> **main was not synced.** The release is published and the build was"
+              echo "> dispatched; only the \`release/v${{ steps.version.outputs.stable_version }}-sync\` → main PR is"
+              echo "> outstanding. Merge it by hand, then main is back in line."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -171,8 +171,20 @@ jobs:
             --repo "$GITHUB_REPOSITORY" || echo "(PR already exists — skipping)"
           PR_NUMBER=$(gh pr list --head "${BRANCH}-sync" --state open --json number -q '.[0].number' --repo "$GITHUB_REPOSITORY")
           if [[ -z "$PR_NUMBER" ]]; then
-            echo "No open sync PR found — nothing to merge."
-            exit 0
+            # L'échec de `gh pr create` ci-dessus est converti en echo, donc on
+            # arrive ici aussi bien quand la PR existait déjà que quand sa création
+            # a échoué pour une autre raison. Sortir en 0 dans le second cas
+            # reportait sync_main en succès alors que le test d'ascendance du haut
+            # avait justement établi que main ne contient pas la branche, et
+            # l'avertissement de fin sautait. On re-teste plutôt que de supposer :
+            # quelqu'un a pu merger la synchro à la main entre-temps.
+            git fetch origin main "$BRANCH"
+            if git merge-base --is-ancestor "origin/${BRANCH}" origin/main; then
+              echo "origin/${BRANCH} is already an ancestor of origin/main — nothing to merge."
+              exit 0
+            fi
+            echo "::error::No open sync PR exists and main does not contain ${BRANCH}."
+            exit 1
           fi
           # GitHub computes mergeability asynchronously. Merging ~3s after creating the
           # PR raced that computation every time: v1.9.0 got "This branch can't be


### PR DESCRIPTION
## Summary

`promote.yml` has failed on **every run since v1.7.0**. Last success: `28734947685` (2026-07-05).

| Run | Tag | Failure | Delay after `gh pr create` |
|---|---|---|---|
| `31029721368` | v1.9.0 | `GraphQL: This branch can't be rebased (mergePullRequest)` | **2.9 s** |
| `30873203114` | v1.8.0 | `Pull Request has merge conflicts` | **1.7 s** |
| `29706639667` / `29702095523` | v1.7.0 | same class | — |

These are not real conflicts. PR #288 (v1.9.0's sync PR) was rebase-merged **by hand 24 minutes later**, base and head SHAs unchanged, and `gh api .../pulls/288/commits` shows a linear chain whose first parent is exactly `base.sha` — a head that descends directly from its base cannot conflict. `allow_rebase_merge` is `true`, so it is not a repo setting either. What it is: GitHub computes `mergeable` / `mergeStateStatus` asynchronously, and the mutation fails while the state is still `UNKNOWN`.

**The expensive part is not the race, it is where the step sits.** "Merge release branch into main" ran *before* "Trigger build workflow" and "Announce stable on Discord", with no `continue-on-error` and no `if: always()` below it. So every failure skipped both:

```
✗ Merge release branch into main
- Trigger build workflow          ← skipped
- Announce stable on Discord      ← skipped
- Workflow summary                ← skipped
```

Consequences, verified: v1.7.0, v1.8.0 and v1.9.0 were all built by a manual `workflow_dispatch` (e.g. run `31029970478`, dispatched 2 min 32 s after promote died), and **#releases has had no announcement since v1.6.0** — while #rc-testing keeps working, because `prerelease.yml` puts its announce step last.

## What changed

**Order.** Build trigger and Discord announce now run immediately after the stable tag is pushed. They depend on nothing the sync produces — the build is dispatched with `--ref` on the *stable tag*, not on main, so the checkout gets the released snapshot whatever main looks like. Publishing no longer depends on a PR round-trip.

**Reliability.** The sync now polls `mergeStateStatus` (30 × 5 s) until it leaves `UNKNOWN`, then retries `gh pr merge` up to 5 times with a 15 s backoff.

**Failure handling.** The sync is `continue-on-error: true` — the release is already out by the time it runs, so a stuck PR should not redden a successful release. To keep that from hiding anything, the job summary emits a warning block naming the outstanding `-sync` branch when `steps.sync_main.outcome != 'success'`.

## Related issue

No issue — found while auditing the Linux build/packaging chain. Same family as #148 (winget publishing broken), which this does not fix.

## Type of change
- [x] Bug fix

## Release impact
- [x] No release note needed

## Desktop impact
- [x] Not platform-specific

## Screenshots / video

n/a

## Testing

CI-only change; the workflow can only be exercised by a real promotion. What I verified locally:

- YAML parses and the step order is what the diff claims (`yaml.safe_load` → step 6 `Trigger build workflow`, 7 `Announce stable on Discord`, 8 `Merge release branch into main` with `id: sync_main`, `continue-on-error: True`).
- The retry loop **propagates** its final failure. This is the trap worth naming: the obvious `gh pr merge … && break; sleep 15` form exits **0** after five failed attempts and reports a merge that never happened. Simulated with a merge that always fails → `::error::` then exit 1.
- The polling loop does not trip `set -euo pipefail` when the state stays `UNKNOWN` for all 30 iterations (`if … then break; fi`, not `[[ … ]] && break`).

The next promotion is the real test. If the race still bites, the sync now fails alone and the release goes out regardless — which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1535210266306940959 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Stable releases are now announced before synchronization begins.
  * Release-branch synchronization with the main branch is more resilient, with mergeability checks and automatic retries.
  * Release completion clearly reports if synchronization remains incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->