### PR TITLE
fix(win): ship the compositor addon beside its ffmpeg DLLs

### DIFF
--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -185,16 +185,21 @@
         "filter": ["win32-*/*", "!win32-*/ffmpeg.exe"]
       }
     ],
-    // Native D3D11 compositor addon (Windows-only). Built by
-    // `npm run build:native:compositor` (scripts/build-windows-compositor-addon.mjs)
-    // before packaging. Packed into asar, then auto-unpacked by the top-level
-    // `asarUnpack: ["**/*.node"]` rule to app.asar.unpacked/... — matches the
-    // `.asar` -> `.asar.unpacked` rewrite compositorViewService.ts's
-    // buildCandidatePaths() already applies for packaged builds. Appends to
-    // (doesn't replace) the top-level `files` list.
-    "files": [
-      "electron/native/compositor-view/build"
-    ]
+    // The D3D11 compositor addon deliberately does NOT travel through `files` into
+    // app.asar. It ships with the ffmpeg DLLs it links against, via the
+    // `extraResources` entry above, because it has to sit in the SAME directory as
+    // them — exactly like the Metal addon on macOS.
+    //
+    // It used to be listed here and unpacked to app.asar.unpacked/…, one directory
+    // away from `electron/native/bin/win32-x64/*.dll`. That only ever worked because
+    // `ensureFfmpegSharedDllsOnPath` prepends the DLL directory to PATH before the
+    // require. MSIX ignores PATH when resolving dependent DLLs — it resolves through
+    // the package graph — so the Store build of 1.9.0 loaded no compositor at all and
+    // the editor ran with no preview while audio kept playing.
+    //
+    // Node loads .node files with LOAD_WITH_ALTERED_SEARCH_PATH, so the addon's own
+    // directory is searched for its dependencies; colocation makes the load work with
+    // no PATH at all, on every Windows packaging format.
   },
   "nsis": {
     "oneClick": false,

--- a/scripts/before-pack.cjs
+++ b/scripts/before-pack.cjs
@@ -202,6 +202,56 @@ function checkNativePayload({ dir, required, osLabel, bundleNoun, emptyDirFix })
 	);
 }
 
+/**
+ * The Windows addon must sit in the SAME directory as the ffmpeg DLLs it links
+ * against, because that is the only arrangement that loads under MSIX.
+ *
+ * The addon dlopens avcodec/avformat/avutil at require() time. While it shipped from
+ * app.asar.unpacked — one directory away from the DLLs — loading it depended on
+ * `ensureFfmpegSharedDllsOnPath` prepending their directory to PATH. That works for
+ * the NSIS installer and does not work under MSIX, which resolves dependent DLLs
+ * through the package graph and ignores PATH. Measured inside a registered package,
+ * with the directory correctly on PATH: `require` failed both before and after the
+ * PATH was set; with the addon beside its DLLs it loaded with no PATH at all.
+ *
+ * That shipped as 1.9.0 on the Store: no compositor loaded, so the editor showed no
+ * preview at all while audio kept playing — and it looked like an app bug, not a
+ * packaging one, because every file was present and the NSIS build of the same commit
+ * was fine.
+ *
+ * `win.extraResources` ships this directory wholesale (filter `win32-*​/*`), so
+ * "together here" is the same thing as "together in the installed app".
+ */
+const WIN_REQUIRED = [
+	{
+		match: (name) => name === "compositor_view.node",
+		what: "the D3D11 compositor addon",
+		breaks: "the preview renders nothing and every export falls back to the no-op compositor",
+		fix: FIX,
+	},
+	// One requirement per library, not `atLeast: 3` over a combined regex — the same
+	// trap LINUX_REQUIRED documents above. Several versioned copies of one library
+	// (avcodec-60/61/62.dll left by an earlier fetch) would satisfy a combined count
+	// while another library was missing entirely, and the addon would still fail to
+	// load.
+	...["avcodec", "avformat", "avutil"].map((library) => ({
+		match: (name) => new RegExp(`^${library}-\\d+\\.dll$`).test(name),
+		what: `the ${library} DLL the compositor links`,
+		breaks: "the addon cannot be loaded at all under MSIX, which ignores PATH",
+		fix: "Fetch them with:\n\n    npm run fetch:ffmpeg",
+	})),
+];
+
+function checkWinNativePayload() {
+	checkNativePayload({
+		dir: path.join(ROOT, "electron", "native", "bin", "win32-x64"),
+		required: WIN_REQUIRED,
+		osLabel: "Windows",
+		bundleNoun: "the installer",
+		emptyDirFix: `${FIX}\n\nThe STT helper and the capture helper are separate builds — see\ntechnical-documentation/engineering/build-and-packaging.md.`,
+	});
+}
+
 function checkMacNativePayload(context) {
 	checkNativePayload({
 		dir: path.join(ROOT, "electron", "native", "bin", `darwin-${archTagFor(context)}`),
@@ -313,7 +363,19 @@ function checkCompositorAddonFreshness(
 exports.default = async function beforePack(context) {
 	const platform = context?.electronPlatformName ?? process.platform;
 	if (platform === "win32") {
-		checkCompositorAddonFreshness();
+		// The copy that ships is the arch-tagged one under electron/native/bin/
+		// (win.extraResources), beside its ffmpeg DLLs — not the dev copy this hook
+		// used to be the sole guardian of. Same reasoning as the darwin branch below.
+		const shipped = path.join(
+			ROOT,
+			"electron",
+			"native",
+			"bin",
+			"win32-x64",
+			"compositor_view.node",
+		);
+		checkWinNativePayload();
+		checkCompositorAddonFreshness(shipped, FIX, "D3D11");
 		return;
 	}
 	if (platform === "darwin") {
@@ -376,6 +438,20 @@ if (require.main === module) {
 				HELPER_SOURCE_PATHS,
 			);
 			console.log(`Linux native payload complete in electron/native/bin/${tag}, addon up to date.`);
+		} else if (process.platform === "win32") {
+			const shipped = path.join(
+				ROOT,
+				"electron",
+				"native",
+				"bin",
+				"win32-x64",
+				"compositor_view.node",
+			);
+			checkWinNativePayload();
+			checkCompositorAddonFreshness(shipped, FIX, "D3D11");
+			console.log(
+				"Windows native payload complete in electron/native/bin/win32-x64 (addon beside its ffmpeg DLLs), addon up to date.",
+			);
 		} else {
 			checkCompositorAddonFreshness();
 			console.log("compositor addon is up to date with its Rust sources.");

--- a/scripts/build-windows-compositor-addon.mjs
+++ b/scripts/build-windows-compositor-addon.mjs
@@ -95,5 +95,34 @@ fs.mkdirSync(BUILD_OUT_DIR, { recursive: true });
 const dest = path.join(BUILD_OUT_DIR, "compositor_view.node");
 fs.copyFileSync(builtDll, dest);
 
+// Also install next to the ffmpeg DLLs the addon links against, which is the copy
+// that actually ships (win `extraResources`, filter `win32-*/*`). macOS has always
+// done this — see build-macos-compositor-addon.mjs's archBinDir — and Windows not
+// doing it is what broke the Store build of 1.9.0:
+//
+// The addon dlopens avcodec/avformat/avutil at require() time. Shipped from inside
+// app.asar.unpacked it sat in a different directory from those DLLs, so loading it
+// depended on `ensureFfmpegSharedDllsOnPath` prepending their directory to PATH.
+// That works for the NSIS installer and does NOT work under MSIX: a packaged app
+// resolves dependent DLLs through its package graph and ignores PATH. Measured
+// inside a registered package, with the directory correctly on PATH:
+//
+//   require BEFORE PATH: FAILED: The specified module could not be found.
+//   require AFTER  PATH: FAILED: The specified module could not be found.
+//
+// and with the addon sitting beside its DLLs, no PATH involved:
+//
+//   require BEFORE PATH: LOADED OK
+//
+// Node loads .node files with LOAD_WITH_ALTERED_SEARCH_PATH, so the addon's own
+// directory is searched for its dependencies. Colocating removes the PATH mechanism
+// rather than repairing it. `buildCandidatePaths` already probes this location
+// first, so no loader change is needed.
+const archBinDir = path.join(ROOT, "electron", "native", "bin", "win32-x64");
+fs.mkdirSync(archBinDir, { recursive: true });
+const archDest = path.join(archBinDir, "compositor_view.node");
+fs.copyFileSync(builtDll, archDest);
+
 console.log(`Built ${builtDll}`);
 console.log(`Copied ${dest}`);
+console.log(`Copied ${archDest}`);

--- a/technical-documentation/engineering/build-and-packaging.md
+++ b/technical-documentation/engineering/build-and-packaging.md
@@ -36,7 +36,31 @@ A usable full package depends on generated artifacts that are not committed:
 | Native Metal compositor addon | `electron/native/bin/darwin-<arch>/compositor_view.node` (plus a dev copy under `electron/native/compositor-view/build/`) | Rust, Xcode, and the LGPL FFmpeg tree from `fetch:ffmpeg:mac` |
 | FFmpeg runtime files | matching `electron/native/bin/<platform>-<arch>/` directory | Downloaded by `fetch:ffmpeg` on Windows; **built from source** by `fetch:ffmpeg:mac` on macOS (~5 min) — BtbN publishes no macOS target and every circulating macOS build is GPL, which would relicense this MIT app |
 
-Electron-builder copies only the matching `electron/native/bin/<platform>-<arch>/` directory into each package. The compositor `.node` file is included by the Windows `files` rule and unpacked from ASAR because native addons cannot be loaded from inside the archive.
+Electron-builder copies only the matching `electron/native/bin/<platform>-<arch>/` directory into each package. On both Windows and macOS the compositor `.node` ships from inside that directory, beside the ffmpeg libraries it links against, and never travels through ASAR.
+
+### The compositor addon must sit beside its ffmpeg libraries
+
+This is a hard requirement on Windows, not a tidiness preference.
+
+The addon dlopens `avcodec`/`avformat`/`avutil` at `require()` time. Until 1.9.0 the Windows build shipped it inside `app.asar.unpacked/electron/native/compositor-view/build/`, one directory away from `electron/native/bin/win32-x64/*.dll`, and the gap was bridged at runtime by `ensureFfmpegSharedDllsOnPath` prepending the DLL directory to `PATH` before the require.
+
+That works for the NSIS installer. **It does not work under MSIX**, which resolves an addon's dependent DLLs through the package graph and ignores `PATH`. Measured inside a registered package, with the directory verifiably present and correctly prepended to `PATH`:
+
+```
+dllDir existsSync   : true
+require BEFORE PATH : FAILED: The specified module could not be found.
+require AFTER  PATH : FAILED: The specified module could not be found.
+```
+
+and with the addon sitting beside those same DLLs, no `PATH` involved:
+
+```
+require BEFORE PATH : LOADED OK
+```
+
+Node loads `.node` files with `LOAD_WITH_ALTERED_SEARCH_PATH`, so the addon's own directory is searched for its dependencies. Colocating removes the `PATH` mechanism rather than repairing it, and works on every Windows packaging format.
+
+This shipped: the 1.9.0 Store build loaded no compositor at all, so the editor opened with a permanently blank preview while audio kept playing — audio comes from the renderer, every frame comes from the addon. It read as an application bug rather than a packaging one, because every file was present in the package and the NSIS build of the same commit was fine. `scripts/before-pack.cjs` now refuses to package unless the addon and at least `avcodec`/`avformat`/`avutil` are in the same directory, on Windows as it already did on macOS.
 
 `electron/native/bin/`, local native build directories, the compositor build output, models, and caches are gitignored. Rebuilding from a source checkout therefore requires the complete platform toolchain and third-party SDKs; running the generic `npm run build` alone does not manufacture missing native artifacts. The Windows compositor's D3D11/FFmpeg prerequisites are described by the source POC in `crates/README.md`, while capture helper lookup and output conventions are documented in `electron/native/README.md`.
 


### PR DESCRIPTION
Fixes the Store build of 1.9.0, which is **live and broken**: the editor opens with a permanently blank preview while audio keeps playing. The NSIS build of the same commit is fine.

## Why the symptom points at exactly one thing

Audio comes from the renderer; every preview frame comes from the native compositor addon. Sound with no picture is what an addon that failed to load produces — `CompositorViewService` falls back to a silent no-op, which the code's own comment describes as "the editor silently ran without a compositor".

## Root cause

The addon dlopens `avcodec`/`avformat`/`avutil` at `require()` time. It shipped from `app.asar.unpacked/electron/native/compositor-view/build/`, **one directory away** from `electron/native/bin/win32-x64/*.dll`, and the gap was bridged at runtime by `ensureFfmpegSharedDllsOnPath` prepending the DLL directory to `PATH`.

That works for NSIS. It does not work under MSIX, which resolves an addon's dependent DLLs through the package graph and **ignores `PATH`**.

## Measured, not inferred

I registered the shipped 1.9.0 appx as a loose package (`Add-AppxPackage -Register`, real package identity) and ran the loader's own logic inside it via `Invoke-CommandInDesktopPackage`:

```
resourcesPath       : …\app\resources          ← correct
dllDir existsSync   : true                     ← the probe finds it
avcodec existsSync  : true
addon existsSync    : true
require BEFORE PATH : FAILED: The specified module could not be found.
require AFTER  PATH : FAILED: The specified module could not be found.   ← PATH set, still fails
```

That rules out the alternative explanation — it is not a wrong path, not a missing file, not an ACL problem. `PATH` is correctly set and simply not consulted.

Then, with the DLLs copied beside the addon in the same package, nothing else changed:

```
require BEFORE PATH : LOADED OK                ← loads with no PATH at all
```

## The fix

Ship the addon from `electron/native/bin/win32-x64/`, beside the DLLs, via `extraResources` — and stop routing it through `files` into the asar.

Node loads `.node` files with `LOAD_WITH_ALTERED_SEARCH_PATH`, so the addon's own directory is searched for its dependencies. This removes the `PATH` mechanism rather than repairing it, and works on every Windows packaging format.

**macOS has always done this** (`build-macos-compositor-addon.mjs` installs into `bin/darwin-<arch>/` and vendors its dylibs there). Windows was the outlier.

**No loader change is needed**: `buildCandidatePaths` already probes `bin/<tag>/compositor_view.node` first.

## Regression guard

`before-pack.cjs` now refuses to package unless the addon **and** each of `avcodec`, `avformat`, `avutil` are in that directory — on Windows as it already did on macOS and Linux.

One requirement per library rather than a count over a combined regex. That is the trap `LINUX_REQUIRED` already documents: three copies of `avcodec-60/61/62.dll` left by an earlier fetch would satisfy `atLeast: 3` while `avformat` and `avutil` were missing. Verified it catches exactly that case:

```
=== 3 copies of avcodec, nothing else:
Missing:
  - the avformat DLL the compositor links
  - the avutil DLL the compositor links
```

All four paths exercised: missing directory, missing addon, missing DLLs, complete payload. `compositorViewService` tests still green (21).

## Testing before the Store update

The loose-registration route above reproduces the failure and will verify the fix on a real MSIX identity, without signing or a Store submission — so the 1.9.1 package can be validated locally before it goes anywhere near Partner Center.

<!-- discord-thread-id:1535610463864233995 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows packaging so the compositor addon and required media libraries are bundled together, preventing loading failures in packaged formats.
  * Added validation to ensure required Windows native components are present and up to date.

* **Documentation**
  * Updated build and packaging guidance for native compositor components on Windows and macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->