### PR TITLE
feat(update): add manual release checking

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,10 +4,13 @@ import { fileURLToPath } from "node:url";
 import {
 	app,
 	BrowserWindow,
+	dialog,
 	ipcMain,
 	Menu,
 	nativeImage,
+	net,
 	session,
+	shell,
 	systemPreferences,
 	Tray,
 } from "electron";
@@ -24,6 +27,7 @@ import { mainT, setMainLocale } from "./i18n";
 import { getSelectedDesktopSource, registerIpcHandlers } from "./ipc/handlers";
 import { installMainProcessErrorGuards } from "./main-process-errors";
 import { registerSttIpc } from "./stt";
+import { checkLatestRelease } from "./update-checker";
 import {
 	createCountdownOverlayWindow,
 	createEditorWindow,
@@ -340,6 +344,55 @@ function getTrayIcon(filename: string, size: number) {
 		});
 }
 
+let updateCheckInFlight = false;
+
+async function checkForUpdates() {
+	if (updateCheckInFlight) return;
+	updateCheckInFlight = true;
+	try {
+		const result = await checkLatestRelease({
+			currentVersion: app.getVersion(),
+			fetchLatest: (url, init) => net.fetch(url, init),
+			signal: AbortSignal.timeout(10_000),
+		});
+		if (result.kind === "current") {
+			await dialog.showMessageBox({
+				type: "info",
+				title: app.name,
+				message: mainT("common", "updates.current", {
+					currentVersion: result.currentVersion,
+				}),
+			});
+			return;
+		}
+
+		const choice = await dialog.showMessageBox({
+			type: "info",
+			title: app.name,
+			message: mainT("common", "updates.available", {
+				currentVersion: result.currentVersion,
+				latestVersion: result.latestVersion,
+			}),
+			buttons: [
+				mainT("common", "actions.viewRelease") || "View Release",
+				mainT("common", "actions.cancel") || "Cancel",
+			],
+			defaultId: 0,
+			cancelId: 1,
+		});
+		if (choice.response === 0) await shell.openExternal(result.releaseUrl);
+	} catch (error) {
+		await dialog.showMessageBox({
+			type: "error",
+			title: app.name,
+			message: mainT("common", "updates.failed"),
+			detail: error instanceof Error ? error.message : String(error),
+		});
+	} finally {
+		updateCheckInFlight = false;
+	}
+}
+
 function updateTrayMenu(recording: boolean = false) {
 	if (!tray) return;
 	const trayIcon = recording ? recordingTrayIcon : defaultTrayIcon;
@@ -366,6 +419,13 @@ function updateTrayMenu(recording: boolean = false) {
 						showMainWindow();
 					},
 				},
+				{
+					label: mainT("common", "actions.checkForUpdates") || "Check for Updates",
+					click: () => {
+						void checkForUpdates();
+					},
+				},
+				{ type: "separator" as const },
 				{
 					label: mainT("common", "actions.quit") || "Quit",
 					click: () => {

--- a/electron/update-checker.test.ts
+++ b/electron/update-checker.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { checkLatestRelease, compareVersions } from "./update-checker";
+
+function releaseResponse(payload: unknown, status = 200) {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		json: vi.fn().mockResolvedValue(payload),
+	};
+}
+
+describe("compareVersions", () => {
+	it("implements semantic version ordering for stable and prerelease builds", () => {
+		expect(compareVersions("v2.0.0", "1.9.9")).toBeGreaterThan(0);
+		expect(compareVersions("1.9.0", "1.9.0-rc.2")).toBeGreaterThan(0);
+		expect(compareVersions("1.9.0-rc.10", "1.9.0-rc.2")).toBeGreaterThan(0);
+		expect(compareVersions("1.9.0+build.2", "v1.9.0+build.1")).toBe(0);
+	});
+});
+
+describe("checkLatestRelease", () => {
+	it("reports a newer official stable release", async () => {
+		const fetchLatest = vi.fn().mockResolvedValue(
+			releaseResponse({
+				tag_name: "v1.10.0",
+				html_url: "https://github.com/getopenscreen/openscreen/releases/tag/v1.10.0",
+				draft: false,
+				prerelease: false,
+			}),
+		);
+
+		await expect(checkLatestRelease({ currentVersion: "1.9.0", fetchLatest })).resolves.toEqual({
+			kind: "available",
+			currentVersion: "1.9.0",
+			latestVersion: "1.10.0",
+			releaseUrl: "https://github.com/getopenscreen/openscreen/releases/tag/v1.10.0",
+		});
+		expect(fetchLatest).toHaveBeenCalledWith(
+			"https://api.github.com/repos/getopenscreen/openscreen/releases/latest",
+			expect.objectContaining({
+				headers: expect.objectContaining({ Accept: "application/vnd.github+json" }),
+			}),
+		);
+	});
+
+	it("reports current when the installed version is equal or newer", async () => {
+		const fetchLatest = vi.fn().mockResolvedValue(
+			releaseResponse({
+				tag_name: "v1.9.0",
+				html_url: "https://github.com/getopenscreen/openscreen/releases/tag/v1.9.0",
+				draft: false,
+				prerelease: false,
+			}),
+		);
+
+		await expect(checkLatestRelease({ currentVersion: "1.9.1", fetchLatest })).resolves.toEqual({
+			kind: "current",
+			currentVersion: "1.9.1",
+			latestVersion: "1.9.0",
+		});
+	});
+
+	it("rejects a release URL outside the official repository", async () => {
+		const fetchLatest = vi.fn().mockResolvedValue(
+			releaseResponse({
+				tag_name: "v9.9.9",
+				html_url: "https://example.com/openscreen-9.9.9.exe",
+				draft: false,
+				prerelease: false,
+			}),
+		);
+
+		await expect(checkLatestRelease({ currentVersion: "1.9.0", fetchLatest })).rejects.toThrow(
+			"untrusted release URL",
+		);
+	});
+
+	it("rejects unsuccessful or malformed GitHub responses", async () => {
+		const unavailable = vi.fn().mockResolvedValue(releaseResponse({}, 503));
+		await expect(
+			checkLatestRelease({ currentVersion: "1.9.0", fetchLatest: unavailable }),
+		).rejects.toThrow("GitHub release check failed (503)");
+
+		const malformed = vi.fn().mockResolvedValue(releaseResponse({ tag_name: "v2.0.0" }));
+		await expect(
+			checkLatestRelease({ currentVersion: "1.9.0", fetchLatest: malformed }),
+		).rejects.toThrow("invalid GitHub release response");
+	});
+});

--- a/electron/update-checker.test.ts
+++ b/electron/update-checker.test.ts
@@ -16,6 +16,19 @@ describe("compareVersions", () => {
 		expect(compareVersions("1.9.0-rc.10", "1.9.0-rc.2")).toBeGreaterThan(0);
 		expect(compareVersions("1.9.0+build.2", "v1.9.0+build.1")).toBe(0);
 	});
+
+	it("preserves precision for oversized core identifiers", () => {
+		expect(compareVersions("9007199254740993.0.0", "9007199254740992.0.0")).toBeGreaterThan(0);
+	});
+
+	it.each([
+		"01.0.0",
+		"1.02.0",
+		"1.0.03",
+		"1.0.0-rc.01",
+	])("rejects leading-zero numeric identifiers in %s", (version) => {
+		expect(() => compareVersions(version, "1.0.0")).toThrow("invalid semantic version");
+	});
 });
 
 describe("checkLatestRelease", () => {
@@ -58,6 +71,52 @@ describe("checkLatestRelease", () => {
 			currentVersion: "1.9.1",
 			latestVersion: "1.9.0",
 		});
+		await expect(checkLatestRelease({ currentVersion: "1.9.0", fetchLatest })).resolves.toEqual({
+			kind: "current",
+			currentVersion: "1.9.0",
+			latestVersion: "1.9.0",
+		});
+	});
+
+	it("forwards the cancellation signal", async () => {
+		const fetchLatest = vi.fn().mockResolvedValue(
+			releaseResponse({
+				tag_name: "v1.9.0",
+				html_url: "https://github.com/getopenscreen/openscreen/releases/tag/v1.9.0",
+				draft: false,
+				prerelease: false,
+			}),
+		);
+		const controller = new AbortController();
+
+		await checkLatestRelease({
+			currentVersion: "1.9.0",
+			fetchLatest,
+			signal: controller.signal,
+		});
+
+		expect(fetchLatest).toHaveBeenCalledWith(
+			"https://api.github.com/repos/getopenscreen/openscreen/releases/latest",
+			expect.objectContaining({ signal: controller.signal }),
+		);
+	});
+
+	it.each([
+		{ draft: true, prerelease: false },
+		{ draft: false, prerelease: true },
+	])("rejects draft and prerelease payloads: %o", async ({ draft, prerelease }) => {
+		const fetchLatest = vi.fn().mockResolvedValue(
+			releaseResponse({
+				tag_name: "v2.0.0",
+				html_url: "https://github.com/getopenscreen/openscreen/releases/tag/v2.0.0",
+				draft,
+				prerelease,
+			}),
+		);
+
+		await expect(checkLatestRelease({ currentVersion: "1.9.0", fetchLatest })).rejects.toThrow(
+			"invalid GitHub release response",
+		);
 	});
 
 	it("rejects a release URL outside the official repository", async () => {
@@ -65,6 +124,26 @@ describe("checkLatestRelease", () => {
 			releaseResponse({
 				tag_name: "v9.9.9",
 				html_url: "https://example.com/openscreen-9.9.9.exe",
+				draft: false,
+				prerelease: false,
+			}),
+		);
+
+		await expect(checkLatestRelease({ currentVersion: "1.9.0", fetchLatest })).rejects.toThrow(
+			"untrusted release URL",
+		);
+	});
+
+	it.each([
+		"https://github.com/getopenscreen/openscreen/releases/download/v9.9.9/app.zip",
+		"https://github.com/getopenscreen/openscreen/releases/tag/v9.9.8",
+		"https://github.com/getopenscreen/openscreen/releases/tag/v9.9.9?download=1",
+		"https://github.com/getopenscreen/openscreen/releases/tag/v9.9.9#notes",
+	])("rejects an invalid official-repository URL: %s", async (htmlUrl) => {
+		const fetchLatest = vi.fn().mockResolvedValue(
+			releaseResponse({
+				tag_name: "v9.9.9",
+				html_url: htmlUrl,
 				draft: false,
 				prerelease: false,
 			}),

--- a/electron/update-checker.ts
+++ b/electron/update-checker.ts
@@ -16,9 +16,9 @@ type FetchLatestRelease = (
 ) => Promise<ReleaseResponse>;
 
 interface ParsedVersion {
-	major: number;
-	minor: number;
-	patch: number;
+	major: bigint;
+	minor: bigint;
+	patch: bigint;
 	prerelease: string[];
 	normalized: string;
 }
@@ -29,11 +29,22 @@ function parseVersion(value: string): ParsedVersion {
 	);
 	if (!match) throw new Error(`invalid semantic version: ${value}`);
 	const prerelease = match[4]?.split(".") ?? [];
-	const core = `${Number(match[1])}.${Number(match[2])}.${Number(match[3])}`;
+	const coreIdentifiers = [match[1], match[2], match[3]];
+	if (
+		[...coreIdentifiers, ...prerelease].some(
+			(identifier) => /^\d+$/.test(identifier) && identifier.length > 1 && identifier[0] === "0",
+		)
+	) {
+		throw new Error(`invalid semantic version: ${value}`);
+	}
+	const major = BigInt(match[1]);
+	const minor = BigInt(match[2]);
+	const patch = BigInt(match[3]);
+	const core = `${major}.${minor}.${patch}`;
 	return {
-		major: Number(match[1]),
-		minor: Number(match[2]),
-		patch: Number(match[3]),
+		major,
+		minor,
+		patch,
 		prerelease,
 		normalized: prerelease.length > 0 ? `${core}-${prerelease.join(".")}` : core,
 	};

--- a/electron/update-checker.ts
+++ b/electron/update-checker.ts
@@ -1,0 +1,153 @@
+const LATEST_RELEASE_API = "https://api.github.com/repos/getopenscreen/openscreen/releases/latest";
+const OFFICIAL_RELEASE_PREFIX = "/getopenscreen/openscreen/releases/tag/";
+
+interface ReleaseResponse {
+	ok: boolean;
+	status: number;
+	json(): Promise<unknown>;
+}
+
+type FetchLatestRelease = (
+	url: string,
+	init: {
+		headers: Record<string, string>;
+		signal?: AbortSignal;
+	},
+) => Promise<ReleaseResponse>;
+
+interface ParsedVersion {
+	major: number;
+	minor: number;
+	patch: number;
+	prerelease: string[];
+	normalized: string;
+}
+
+function parseVersion(value: string): ParsedVersion {
+	const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(
+		value.trim(),
+	);
+	if (!match) throw new Error(`invalid semantic version: ${value}`);
+	const prerelease = match[4]?.split(".") ?? [];
+	const core = `${Number(match[1])}.${Number(match[2])}.${Number(match[3])}`;
+	return {
+		major: Number(match[1]),
+		minor: Number(match[2]),
+		patch: Number(match[3]),
+		prerelease,
+		normalized: prerelease.length > 0 ? `${core}-${prerelease.join(".")}` : core,
+	};
+}
+
+function comparePrerelease(left: string[], right: string[]): number {
+	if (left.length === 0 || right.length === 0) {
+		return left.length === right.length ? 0 : left.length === 0 ? 1 : -1;
+	}
+	for (let i = 0; i < Math.max(left.length, right.length); i++) {
+		const a = left[i];
+		const b = right[i];
+		if (a === undefined || b === undefined) return a === b ? 0 : a === undefined ? -1 : 1;
+		if (a === b) continue;
+		const aNumeric = /^\d+$/.test(a);
+		const bNumeric = /^\d+$/.test(b);
+		if (aNumeric && bNumeric) return BigInt(a) > BigInt(b) ? 1 : -1;
+		if (aNumeric !== bNumeric) return aNumeric ? -1 : 1;
+		return a > b ? 1 : -1;
+	}
+	return 0;
+}
+
+export function compareVersions(left: string, right: string): number {
+	const a = parseVersion(left);
+	const b = parseVersion(right);
+	for (const key of ["major", "minor", "patch"] as const) {
+		if (a[key] !== b[key]) return a[key] > b[key] ? 1 : -1;
+	}
+	return comparePrerelease(a.prerelease, b.prerelease);
+}
+
+function officialReleaseUrl(value: string, tag: string): string {
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		throw new Error("untrusted release URL");
+	}
+	const encodedTag = url.pathname.slice(OFFICIAL_RELEASE_PREFIX.length);
+	let decodedTag = "";
+	try {
+		decodedTag = decodeURIComponent(encodedTag);
+	} catch {
+		throw new Error("untrusted release URL");
+	}
+	if (
+		url.protocol !== "https:" ||
+		url.hostname !== "github.com" ||
+		url.port !== "" ||
+		!url.pathname.startsWith(OFFICIAL_RELEASE_PREFIX) ||
+		decodedTag !== tag ||
+		url.search !== "" ||
+		url.hash !== ""
+	) {
+		throw new Error("untrusted release URL");
+	}
+	return url.toString();
+}
+
+export type UpdateCheckResult =
+	| {
+			kind: "available";
+			currentVersion: string;
+			latestVersion: string;
+			releaseUrl: string;
+	  }
+	| {
+			kind: "current";
+			currentVersion: string;
+			latestVersion: string;
+	  };
+
+export async function checkLatestRelease(options: {
+	currentVersion: string;
+	fetchLatest: FetchLatestRelease;
+	signal?: AbortSignal;
+}): Promise<UpdateCheckResult> {
+	const response = await options.fetchLatest(LATEST_RELEASE_API, {
+		headers: {
+			Accept: "application/vnd.github+json",
+			"X-GitHub-Api-Version": "2022-11-28",
+		},
+		...(options.signal ? { signal: options.signal } : {}),
+	});
+	if (!response.ok) throw new Error(`GitHub release check failed (${response.status})`);
+
+	const payload = await response.json();
+	if (
+		typeof payload !== "object" ||
+		payload === null ||
+		typeof (payload as Record<string, unknown>).tag_name !== "string" ||
+		typeof (payload as Record<string, unknown>).html_url !== "string" ||
+		(payload as Record<string, unknown>).draft !== false ||
+		(payload as Record<string, unknown>).prerelease !== false
+	) {
+		throw new Error("invalid GitHub release response");
+	}
+	const release = payload as { tag_name: string; html_url: string };
+	const current = parseVersion(options.currentVersion);
+	const latest = parseVersion(release.tag_name);
+	const comparison = compareVersions(latest.normalized, current.normalized);
+	if (comparison <= 0) {
+		return {
+			kind: "current",
+			currentVersion: current.normalized,
+			latestVersion: latest.normalized,
+		};
+	}
+
+	return {
+		kind: "available",
+		currentVersion: current.normalized,
+		latestVersion: latest.normalized,
+		releaseUrl: officialReleaseUrl(release.html_url, release.tag_name),
+	};
+}

--- a/src/i18n/locales/ar/common.json
+++ b/src/i18n/locales/ar/common.json
@@ -7,6 +7,8 @@
 		"share": "مشاركة",
 		"done": "تم",
 		"open": "فتح",
+		"checkForUpdates": "التحقق من وجود تحديثات",
+		"viewRelease": "عرض الإصدار",
 		"upload": "رفع",
 		"export": "تصدير",
 		"showInFolder": "عرض في المجلد",
@@ -36,6 +38,11 @@
 		"hide": "إخفاء OpenScreen",
 		"hideOthers": "إخفاء الآخرين",
 		"unhide": "إظهار الكل"
+	},
+	"updates": {
+		"available": "يتوفر OpenScreen {{latestVersion}}. الإصدار المثبت هو {{currentVersion}}.",
+		"current": "OpenScreen محدّث ({{currentVersion}}).",
+		"failed": "تعذّر التحقق من وجود تحديثات."
 	},
 	"playback": {
 		"play": "تشغيل",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -7,6 +7,8 @@
 		"share": "Share",
 		"done": "Done",
 		"open": "Open",
+		"checkForUpdates": "Check for Updates",
+		"viewRelease": "View Release",
 		"upload": "Upload",
 		"export": "Export",
 		"showInFolder": "Show in Folder",
@@ -36,6 +38,11 @@
 		"hide": "Hide OpenScreen",
 		"hideOthers": "Hide Others",
 		"unhide": "Show All"
+	},
+	"updates": {
+		"available": "OpenScreen {{latestVersion}} is available. You are using {{currentVersion}}.",
+		"current": "OpenScreen is up to date ({{currentVersion}}).",
+		"failed": "Could not check for updates."
 	},
 	"playback": {
 		"play": "Play",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -7,6 +7,8 @@
 		"share": "Compartir",
 		"done": "Listo",
 		"open": "Abrir",
+		"checkForUpdates": "Buscar actualizaciones",
+		"viewRelease": "Ver versión",
 		"upload": "Subir",
 		"export": "Exportar",
 		"showInFolder": "Mostrar en carpeta",
@@ -36,6 +38,11 @@
 		"hide": "Ocultar OpenScreen",
 		"hideOthers": "Ocultar otros",
 		"unhide": "Mostrar todo"
+	},
+	"updates": {
+		"available": "OpenScreen {{latestVersion}} está disponible. Estás usando {{currentVersion}}.",
+		"current": "OpenScreen está actualizado ({{currentVersion}}).",
+		"failed": "No se pudieron buscar actualizaciones."
 	},
 	"playback": {
 		"play": "Reproducir",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -7,6 +7,8 @@
 		"share": "Partager",
 		"done": "Terminer",
 		"open": "Ouvrir",
+		"checkForUpdates": "Rechercher des mises à jour",
+		"viewRelease": "Voir la version",
 		"upload": "Téléverser",
 		"export": "Exporter",
 		"showInFolder": "Afficher dans le dossier",
@@ -36,6 +38,11 @@
 		"hide": "Masquer OpenScreen",
 		"hideOthers": "Masquer les autres",
 		"unhide": "Tout afficher"
+	},
+	"updates": {
+		"available": "OpenScreen {{latestVersion}} est disponible. Vous utilisez la version {{currentVersion}}.",
+		"current": "OpenScreen est à jour ({{currentVersion}}).",
+		"failed": "Impossible de rechercher les mises à jour."
 	},
 	"playback": {
 		"play": "Lecture",

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -7,6 +7,8 @@
 		"share": "Condividi",
 		"done": "Fatto",
 		"open": "Apri",
+		"checkForUpdates": "Controlla aggiornamenti",
+		"viewRelease": "Visualizza versione",
 		"upload": "Carica",
 		"export": "Esporta",
 		"showInFolder": "Mostra nella cartella",
@@ -36,6 +38,11 @@
 		"hide": "Nascondi OpenScreen",
 		"hideOthers": "Nascondi gli altri",
 		"unhide": "Mostra tutto"
+	},
+	"updates": {
+		"available": "OpenScreen {{latestVersion}} è disponibile. Stai usando la versione {{currentVersion}}.",
+		"current": "OpenScreen è aggiornato ({{currentVersion}}).",
+		"failed": "Impossibile controllare gli aggiornamenti."
 	},
 	"playback": {
 		"play": "Riproduci",

--- a/src/i18n/locales/ja-JP/common.json
+++ b/src/i18n/locales/ja-JP/common.json
@@ -7,6 +7,8 @@
 		"share": "共有",
 		"done": "完了",
 		"open": "開く",
+		"checkForUpdates": "アップデートを確認",
+		"viewRelease": "リリースを表示",
 		"upload": "読み込む",
 		"export": "エクスポート",
 		"showInFolder": "フォルダに表示",
@@ -36,6 +38,11 @@
 		"hide": "OpenScreenを隠す",
 		"hideOthers": "ほかを隠す",
 		"unhide": "すべて表示"
+	},
+	"updates": {
+		"available": "OpenScreen {{latestVersion}} を利用できます。現在のバージョンは {{currentVersion}} です。",
+		"current": "OpenScreen は最新です（{{currentVersion}}）。",
+		"failed": "アップデートを確認できませんでした。"
 	},
 	"playback": {
 		"play": "再生",

--- a/src/i18n/locales/ko-KR/common.json
+++ b/src/i18n/locales/ko-KR/common.json
@@ -7,6 +7,8 @@
 		"share": "공유",
 		"done": "완료",
 		"open": "열기",
+		"checkForUpdates": "업데이트 확인",
+		"viewRelease": "릴리스 보기",
 		"upload": "업로드",
 		"export": "내보내기",
 		"showInFolder": "폴더에 표시",
@@ -36,6 +38,11 @@
 		"hide": "OpenScreen 숨기기",
 		"hideOthers": "다른 항목 숨기기",
 		"unhide": "모두 보기"
+	},
+	"updates": {
+		"available": "OpenScreen {{latestVersion}} 버전을 사용할 수 있습니다. 현재 버전은 {{currentVersion}}입니다.",
+		"current": "OpenScreen이 최신 버전입니다({{currentVersion}}).",
+		"failed": "업데이트를 확인할 수 없습니다."
 	},
 	"playback": {
 		"play": "재생",

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -7,6 +7,8 @@
 		"share": "Compartilhar",
 		"done": "Concluir",
 		"open": "Abrir",
+		"checkForUpdates": "Verificar atualizações",
+		"viewRelease": "Ver versão",
 		"upload": "Upload",
 		"export": "Exportar",
 		"showInFolder": "Mostrar na Pasta",
@@ -36,6 +38,11 @@
 		"hide": "Ocultar OpenScreen",
 		"hideOthers": "Ocultar Outros",
 		"unhide": "Mostrar Todos"
+	},
+	"updates": {
+		"available": "O OpenScreen {{latestVersion}} está disponível. Você está usando a versão {{currentVersion}}.",
+		"current": "O OpenScreen está atualizado ({{currentVersion}}).",
+		"failed": "Não foi possível verificar atualizações."
 	},
 	"playback": {
 		"play": "Play",

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -7,6 +7,8 @@
 		"share": "Поделиться",
 		"done": "Готово",
 		"open": "Открыть",
+		"checkForUpdates": "Проверить обновления",
+		"viewRelease": "Открыть выпуск",
 		"upload": "Загрузить",
 		"export": "Экспорт",
 		"showInFolder": "Показать в папке",
@@ -36,6 +38,11 @@
 		"hide": "Скрыть OpenScreen",
 		"hideOthers": "Скрыть остальные",
 		"unhide": "Показать все"
+	},
+	"updates": {
+		"available": "Доступен OpenScreen {{latestVersion}}. Установлена версия {{currentVersion}}.",
+		"current": "Установлена последняя версия OpenScreen ({{currentVersion}}).",
+		"failed": "Не удалось проверить наличие обновлений."
 	},
 	"playback": {
 		"play": "Воспроизвести",

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -7,6 +7,8 @@
 		"share": "Paylaş",
 		"done": "Tamam",
 		"open": "Aç",
+		"checkForUpdates": "Güncellemeleri denetle",
+		"viewRelease": "Sürümü görüntüle",
 		"upload": "Yükle",
 		"export": "Dışa Aktar",
 		"showInFolder": "Klasörde Göster",
@@ -36,6 +38,11 @@
 		"hide": "OpenScreen’i Gizle",
 		"hideOthers": "Diğerlerini Gizle",
 		"unhide": "Tümünü Göster"
+	},
+	"updates": {
+		"available": "OpenScreen {{latestVersion}} kullanılabilir. Mevcut sürümünüz {{currentVersion}}.",
+		"current": "OpenScreen güncel ({{currentVersion}}).",
+		"failed": "Güncellemeler denetlenemedi."
 	},
 	"playback": {
 		"play": "Oynat",

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -41,7 +41,7 @@
 	},
 	"updates": {
 		"available": "Đã có OpenScreen {{latestVersion}}. Bạn đang dùng phiên bản {{currentVersion}}.",
-		"current": "OpenScreen đã được cập nhật ({{currentVersion}}).",
+		"current": "OpenScreen đang ở phiên bản mới nhất ({{currentVersion}}).",
 		"failed": "Không thể kiểm tra bản cập nhật."
 	},
 	"playback": {

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -7,6 +7,8 @@
 		"share": "Chia sẻ",
 		"done": "Hoàn tất",
 		"open": "Mở",
+		"checkForUpdates": "Kiểm tra bản cập nhật",
+		"viewRelease": "Xem bản phát hành",
 		"upload": "Tải lên",
 		"export": "Xuất",
 		"showInFolder": "Hiển thị trong thư mục",
@@ -36,6 +38,11 @@
 		"hide": "Ẩn OpenScreen",
 		"hideOthers": "Ẩn ứng dụng khác",
 		"unhide": "Hiển thị tất cả"
+	},
+	"updates": {
+		"available": "Đã có OpenScreen {{latestVersion}}. Bạn đang dùng phiên bản {{currentVersion}}.",
+		"current": "OpenScreen đã được cập nhật ({{currentVersion}}).",
+		"failed": "Không thể kiểm tra bản cập nhật."
 	},
 	"playback": {
 		"play": "Phát",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -7,6 +7,8 @@
 		"share": "分享",
 		"done": "完成",
 		"open": "打开",
+		"checkForUpdates": "检查更新",
+		"viewRelease": "查看版本",
 		"upload": "上传",
 		"export": "导出",
 		"showInFolder": "在文件夹中显示",
@@ -36,6 +38,11 @@
 		"hide": "隐藏 OpenScreen",
 		"hideOthers": "隐藏其他",
 		"unhide": "显示全部"
+	},
+	"updates": {
+		"available": "OpenScreen {{latestVersion}} 已发布。当前版本为 {{currentVersion}}。",
+		"current": "OpenScreen 已是最新版本（{{currentVersion}}）。",
+		"failed": "无法检查更新。"
 	},
 	"playback": {
 		"play": "播放",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -7,6 +7,8 @@
 		"share": "分享",
 		"done": "完成",
 		"open": "開啟",
+		"checkForUpdates": "檢查更新",
+		"viewRelease": "檢視版本",
 		"upload": "上傳",
 		"export": "匯出",
 		"showInFolder": "在資料夾中顯示",
@@ -36,6 +38,11 @@
 		"hide": "隱藏 OpenScreen",
 		"hideOthers": "隱藏其他",
 		"unhide": "全部顯示"
+	},
+	"updates": {
+		"available": "OpenScreen {{latestVersion}} 已推出。目前版本為 {{currentVersion}}。",
+		"current": "OpenScreen 已是最新版本（{{currentVersion}}）。",
+		"failed": "無法檢查更新。"
 	},
 	"playback": {
 		"play": "播放",


### PR DESCRIPTION
## Summary

- add a localized `Check for Updates` action to the idle system-tray menu
- query GitHub's official latest-stable-release endpoint with a 10-second timeout
- compare installed/latest versions with semantic-version and prerelease ordering
- report up-to-date, available, and failure states in native dialogs
- open the exact official `getopenscreen/openscreen` release-tag page only after explicit user confirmation

This is intentionally the safe manual-checking slice of #301. It does not download, install, execute, or automatically poll for updates; automatic update policy/settings remain future work.

## Related issue

Part of #301

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor / maintenance
- [ ] Performance
- [x] Security

## Release impact

- [ ] Patch
- [x] Minor
- [ ] Major / breaking change
- [ ] No release note needed

## Desktop impact

- [x] Windows
- [x] macOS
- [x] Linux
- [ ] Installer / packaging
- [ ] Not platform-specific

## Screenshots / video

Not included; this adds a native tray item and native result dialogs.

## Testing

- Started with a failing updater-service test before the implementation existed
- `npx vitest --run electron/update-checker.test.ts` (5 passed)
  - stable/prerelease semantic ordering
  - newer and installed-newer results
  - malformed/error responses
  - untrusted release URL rejection
- `npm run test` (1,682 passed, 1 skipped across 141 files)
- `npx tsc --noEmit`
- `npx tsc -p tsconfig.test.json --noEmit`
- `npx biome check` on the Electron, updater, test, and locale files
- `npm run docs:check`
- `npm run i18n:check`
- `npm run build-vite`
- Queried the live official releases API; it returned stable `v1.9.0` and `https://github.com/getopenscreen/openscreen/releases/tag/v1.9.0`, matching the guarded contract

Authored with Codex assistance and manually security-reviewed to ensure this path cannot open a non-official download URL.

<!-- discord-thread-id:1535719640859148299 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Check for Updates” option to the app’s tray menu.
  - The app now checks for newer releases and clearly indicates whether an update is available, the app is current, or the check could not be completed.
  - Added an option to open the official release page when an update is available.
- **Localization**
  - Added update-related messages in Arabic, Chinese, English, French, German? Wait German absent. Don't mention German. Spanish, Italian, Japanese, Korean, Portuguese, Russian, Turkish, and Vietnamese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->