### PR TITLE
test(ci): cover the missing-tag path under STRICT

### DIFF
--- a/.github/scripts/discord-release-announce.test.mjs
+++ b/.github/scripts/discord-release-announce.test.mjs
@@ -199,6 +199,15 @@ describe("strict mode", () => {
 	const STRICT_ENV = { ...BASE_ENV, STRICT: "1", DISCORD_RELEASE_CHANNEL_ID: "123" };
 	const exits1 = /process\.exit unexpectedly called with "1"/;
 
+	it("fails when the release tag is missing", async () => {
+		await expect(
+			loadScript({ ...BASE_ENV, STABLE_TAG: "", STRICT: "1", DISCORD_RELEASE_CHANNEL_ID: "123" }),
+		).rejects.toThrow(exits1);
+		expect(vi.mocked(setFailed)).toHaveBeenCalledWith(
+			expect.stringContaining("STABLE_TAG missing"),
+		);
+	});
+
 	it("fails when the Discord configuration is missing", async () => {
 		await expect(loadScript({ STABLE_TAG: "v1.5.0", STRICT: "1" })).rejects.toThrow(exits1);
 		expect(vi.mocked(setFailed)).toHaveBeenCalledWith(expect.stringContaining("DISCORD_BOT_TOKEN"));


### PR DESCRIPTION
Follow-up to #289, which merged before this landed.

CodeRabbit's nitpick on that PR was right: the strict set exercised three of the four `bail()` paths — missing Discord config, failed channel lookup, failed post — and left `STABLE_TAG` dark. Under `STRICT` that path calls `setFailed` and exits 1 like the others, but nothing pinned it.

One test, asserting `setFailed` receives the missing-tag message. 13 tests, suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1535762909169451143 -->