### PR TITLE
fix(linux): give the compositor's build.rs its own freestanding-header fallback

### DIFF
--- a/crates/compositor/build.rs
+++ b/crates/compositor/build.rs
@@ -124,6 +124,15 @@ fn main() {
         .derive_default(true)
         .layout_tests(false);
 
+    // Linux uniquement : cf. `freestanding_header_args()`. Sur macOS le sysroot arrive
+    // par `xcrun` juste en dessous, sur Windows par MSVC — dans les deux cas clang a
+    // déjà ses en-têtes builtin et injecter ceux de gcc n'aurait aucun sens.
+    if target_os == "linux" {
+        for arg in freestanding_header_args() {
+            builder = builder.clang_arg(arg);
+        }
+    }
+
     // Sur macOS le bindgen doit viser aarch64-apple-darwin pour que les layouts
     // générés (long=8, etc.) matchent la cible. Sans ce flag, bindgen utilise
     // le défaut du host (probablement x86_64), et les structs ffmpeg sont mal
@@ -160,6 +169,61 @@ fn main() {
     if let Ok(prefix) = env::var("OPENSCREEN_FFMPEG_SYMBOL_PREFIX") {
         prefix_ffmpeg_symbols(&ffi_path, &prefix);
     }
+}
+
+/// Flags `-I` supplémentaires pour que clang trouve les en-têtes « freestanding » qu'il
+/// embarque normalement lui-même (`stddef.h`, `limits.h`, `stdint.h`).
+///
+/// Ubuntu scinde libclang : `libclang.so.1` vient du paquet runtime, le répertoire
+/// d'en-têtes builtin de `libclang-N-dev`. Avec seulement le premier — le cas courant —
+/// parser n'importe quel header réel échoue sur
+/// `/usr/include/stdio.h: 'stddef.h' file not found`, parce que la copie de la glibc fait
+/// un `#include_next` de celle du compilateur et qu'il n'y en a aucune. Celles de gcc
+/// sont interchangeables pour cet usage : on y pointe clang plutôt que d'imposer une
+/// seconde toolchain à chaque contributeur.
+///
+/// Jumeau de `freestanding_header_args()` dans
+/// electron/native/pipewire-capture/build.rs, et comme lui ça vit DANS build.rs plutôt
+/// que dans scripts/build-linux-compositor-addon.mjs : tant que seul le script posait
+/// `BINDGEN_EXTRA_CLANG_ARGS`, un `cargo check -p openscreen-compositor` nu échouait sur
+/// une Ubuntu de série — y compris en x86_64.
+fn freestanding_header_args() -> Vec<String> {
+    if let Ok(extra) = env::var("BINDGEN_EXTRA_CLANG_ARGS") {
+        // Déjà configuré par l'appelant ; bindgen le lit de lui-même.
+        if !extra.trim().is_empty() {
+            return Vec::new();
+        }
+    }
+    // Le triplet vendeur n'est PAS codé en dur : c'est `x86_64-linux-gnu` sur Debian/
+    // Ubuntu amd64, `aarch64-linux-gnu` sur arm64 et `x86_64-pc-linux-gnu` sur Arch.
+    // Matcher sur le préfixe d'architecture de la CIBLE couvre les trois, et sur une
+    // machine où un cross-gcc est installé refuse quand même les en-têtes de l'AUTRE
+    // architecture, dont les largeurs de types seraient fausses.
+    let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| env::consts::ARCH.to_string());
+    let prefix = format!("{arch}-");
+    let Ok(vendors) = std::fs::read_dir("/usr/lib/gcc") else {
+        return Vec::new();
+    };
+    // Les DEUX en-têtes sont exigés : l'échec observé porte tantôt sur `stddef.h`
+    // (compositor) tantôt sur `limits.h` (pipewire-capture), et un répertoire qui n'a
+    // que l'un des deux ne réglerait qu'une moitié du problème tout en ayant l'air
+    // d'un candidat valable.
+    let mut dirs: Vec<PathBuf> = vendors
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_name().to_string_lossy().starts_with(&prefix))
+        .filter_map(|vendor| std::fs::read_dir(vendor.path()).ok())
+        .flatten()
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path().join("include"))
+        .filter(|dir| dir.join("limits.h").is_file() && dir.join("stddef.h").is_file())
+        .collect();
+    // gcc le plus récent d'abord, pour une machine qui en a plusieurs.
+    dirs.sort();
+    dirs.reverse();
+    dirs.into_iter()
+        .take(1)
+        .map(|dir| format!("-I{}", dir.display()))
+        .collect()
 }
 
 /// Ajoute `#[link_name = "<prefix><nom>"]` devant chaque `pub fn` ffmpeg de `ffi.rs`.

--- a/electron/native/pipewire-capture/build.rs
+++ b/electron/native/pipewire-capture/build.rs
@@ -63,9 +63,12 @@ fn build_pipewire_shim(root: &Path) {
 /// `/usr/include/limits.h: 'limits.h' file not found`, because glibc's copy
 /// `#include_next`s the compiler's and there is none. gcc's copies are
 /// interchangeable for this purpose, so point clang at those instead of making
-/// every contributor install a second toolchain. Mirrors `bindgenClangArgs()` in
-/// scripts/build-linux-compositor-addon.mjs, but lives here so that a bare
-/// `cargo build` in this directory works too.
+/// every contributor install a second toolchain.
+///
+/// Twin of `freestanding_header_args()` in crates/compositor/build.rs. Both live in
+/// build.rs rather than in the npm build scripts so that a bare `cargo build` works
+/// too — scripts/build-linux-compositor-addon.mjs used to carry a copy of this, and
+/// `cargo check -p openscreen-compositor` stayed broken for as long as it did.
 fn freestanding_header_args() -> Vec<String> {
     if let Ok(extra) = std::env::var("BINDGEN_EXTRA_CLANG_ARGS") {
         // Already configured by the caller; bindgen picks that up on its own.

--- a/scripts/build-linux-compositor-addon.mjs
+++ b/scripts/build-linux-compositor-addon.mjs
@@ -118,38 +118,15 @@ function resolveLibclangDir() {
 	return found;
 }
 
-/**
- * On distributions that ship only `libclang.so.1` (no -dev package) clang also
- * cannot find its own `stddef.h`. Point it at gcc's copy in that case rather
- * than making the caller discover it.
- *
- * Kept behaviourally identical to `freestanding_header_args()` in
- * electron/native/pipewire-capture/build.rs, which is the authority — that one
- * runs for a bare `cargo build` too. Two properties matter and both were once
- * wrong here: `limits.h` must be required alongside `stddef.h` (the failure
- * being fixed is `'limits.h' file not found` — glibc's copy `#include_next`s
- * the compiler's), and the newest gcc must be picked deterministically rather
- * than whatever `readdirSync` happened to return first.
- */
-function bindgenClangArgs() {
-	if (process.env.BINDGEN_EXTRA_CLANG_ARGS) {
-		return process.env.BINDGEN_EXTRA_CLANG_ARGS;
-	}
-	const gccIncludeRoot = `/usr/lib/gcc/${MULTIARCH}`;
-	if (!fs.existsSync(gccIncludeRoot)) {
-		return "";
-	}
-	const usable = fs
-		.readdirSync(gccIncludeRoot)
-		.map((version) => path.join(gccIncludeRoot, version, "include"))
-		.filter(
-			(dir) =>
-				fs.existsSync(path.join(dir, "limits.h")) && fs.existsSync(path.join(dir, "stddef.h")),
-		)
-		.sort()
-		.reverse();
-	return usable.length > 0 ? `-I${usable[0]}` : "";
-}
+// No BINDGEN_EXTRA_CLANG_ARGS is set below, on purpose. On distributions shipping only
+// `libclang.so.1` (no -dev package) clang cannot find its own `stddef.h`, and this
+// script used to paper over that by pointing bindgen at gcc's copies. That only ever
+// covered the build that goes through here: `cargo check -p openscreen-compositor` on a
+// stock Ubuntu still died on `'stddef.h' file not found`, x86_64 included. The fallback
+// now lives in crates/compositor/build.rs (`freestanding_header_args()`), which covers
+// both entry points — and, being the only claimant, cannot lose to a worse guess made
+// here. Setting the variable again would suppress it, since build.rs defers to a
+// caller-supplied value.
 
 /**
  * Prefix applied to every ffmpeg dynamic symbol. Anything unique works; this one is
@@ -302,7 +279,6 @@ await run("cargo", ["build", "-p", "compositor-view-napi", "--release"], {
 		FFMPEG_DIR: stagedFfmpegDir,
 		OPENSCREEN_FFMPEG_SYMBOL_PREFIX: SYMBOL_PREFIX,
 		LIBCLANG_PATH: resolveLibclangDir(),
-		BINDGEN_EXTRA_CLANG_ARGS: bindgenClangArgs(),
 		// `$ORIGIN` is resolved by the dynamic linker against the directory the
 		// .node itself lives in, so the ffmpeg copies below are found wherever the
 		// app is installed. Single-quoted on purpose: the shell must not expand it.


### PR DESCRIPTION
## Summary

`cargo check -p openscreen-compositor --manifest-path crates/Cargo.toml` fails on a stock Ubuntu box — **x86_64 included**, this is not an arm64 issue:

```
/usr/include/stdio.h:34:10: fatal error: 'stddef.h' file not found
thread 'main' panicked at compositor/build.rs:150:10:
bindgen a échoué sur les headers ffmpeg: ClangDiagnostic(...)
```

Ubuntu ships `libclang.so.1` from the runtime package and its builtin header directory from `libclang-N-dev`. With only the former — the common case — clang has no freestanding headers of its own, and glibc's `#include_next` finds none.

`scripts/build-linux-compositor-addon.mjs` already worked around this by exporting `BINDGEN_EXTRA_CLANG_ARGS`, but that only ever covered the build going through the script; cargo on its own stayed broken. `electron/native/pipewire-capture` hit the same wall and solved it *inside* its `build.rs` precisely so a bare `cargo build` works too — its doc comment says as much. This ports that fix to the compositor.

| Change | Why |
| --- | --- |
| `crates/compositor/build.rs` | Gains `freestanding_header_args()`. gcc vendor dir derived from `CARGO_CFG_TARGET_ARCH`, matched on the `<arch>-` prefix so Debian's `x86_64-linux-gnu`, arm64's `aarch64-linux-gnu` and Arch's `x86_64-pc-linux-gnu` all resolve, while a cross-gcc for the *other* architecture is refused (wrong type widths). Requires both `limits.h` and `stddef.h`. Defers to a non-empty caller-supplied value. |
| `scripts/build-linux-compositor-addon.mjs` | `bindgenClangArgs()` deleted. |

**Deleting the script's copy is load-bearing, not cleanup.** `build.rs` defers to a non-empty caller-supplied `BINDGEN_EXTRA_CLANG_ARGS`, so if the script kept setting one, its guess would keep winning — including when it is the worse of the two. Leaving it would have made this fix inert on exactly the machines that need it.

## Related issue

No existing issue — found while verifying #293.

## Type of change
- [x] Bug fix

## Release impact
- [ ] Patch
- [x] No release note needed

Build-time only; nothing in the shipped artifact changes.

## Desktop impact
- [x] Linux

The new code is gated on `target_os == "linux"`. On macOS the sysroot comes from `xcrun`, on Windows from MSVC — neither path is touched, and `scripts/build-linux-compositor-addon.mjs` already exits early when `process.platform !== "linux"`.

## Screenshots / video

No visual change.

## Testing

Ubuntu, x86_64, `libclang-18` runtime only (no `libclang-18-dev`).

**A/B on clean builds** (`cargo clean -p openscreen-compositor` between each), `BINDGEN_EXTRA_CLANG_ARGS` unset:

| `build.rs` | Result |
| --- | --- |
| current `main` | `fatal error: 'stddef.h' file not found` → panic |
| this branch | `Finished` |

**Script path** — `npm run build:native:compositor:linux`, with `BINDGEN_EXTRA_CLANG_ARGS` unset: builds, stages the renamed ffmpeg libraries, copies the addon, and passes its own `Verified: no unprefixed ffmpeg imports remain in the addon` check.

**Suite** — `npx vitest run` → 141 files, 1694 passed, 1 skipped, 0 failed. `biome check` clean. `cargo fmt --check` shows no diff in `build.rs` (the deviations it reports are pre-existing in `audio.rs` / `compositor_linux.rs` on `main`).

Not verified on Windows or macOS locally — only the `x86_64-unknown-linux-gnu` target is installed here. The `target_os == "linux"` gate is the argument, and CI's `windows-latest` / `macos` build jobs are the check.

## Note on #293

Rebased onto `main` after #293 merged. The expected conflict in `scripts/build-linux-compositor-addon.mjs` is resolved: `bindgenClangArgs()` is gone, and #293's `MULTIARCH` constant stays — `resolveLibclangDir()` still needs it for the *library* path, only the gcc-include half went away.

Deleting it also left a dangling doc reference in `electron/native/pipewire-capture/build.rs`, which pointed readers at `bindgenClangArgs()`. It now names its actual twin, `freestanding_header_args()` in `crates/compositor/build.rs`.

Re-verified after the rebase: clean `cargo check` with `BINDGEN_EXTRA_CLANG_ARGS` unset, `npm run build:native:compositor:linux` green through its unprefixed-symbol check, `npx vitest run` 142 files / 1698 passed / 0 failed, `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
