### PR TITLE
ci(docs): bump the SHA-pinned Pages actions to their Node 24 majors

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,10 +39,10 @@ jobs:
     name: Build site
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -57,9 +57,15 @@ jobs:
         working-directory: website
         run: npm run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: website/build
+          # v4 stopped bundling dotfiles, and Docusaurus writes a `.nojekyll`
+          # into website/build. The artifact-based Pages deploy never runs
+          # Jekyll, so losing it would probably be harmless — but "probably" is
+          # not worth finding out on the live site, and this restores exactly
+          # what v3 uploaded. `.git`/`.github` stay excluded either way.
+          include-hidden-files: true
 
   deploy:
     name: Deploy to GitHub Pages
@@ -76,4 +82,4 @@ jobs:
       id-token: write
     steps:
       - id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## Problem

[#97](https://github.com/getopenscreen/openscreen/pull/97) moved every **tag-pinned** action to its Node 24 major. `docs.yml` pins by **SHA** instead, so it was left out of that sweep and still logs:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24 ...
```

## Fix

Bump all four, keeping the SHA pinning this file deliberately uses:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4.1.1 | v7.0.1 |
| `actions/setup-node` | v4.0.3 | v7.0.0 |
| `actions/upload-pages-artifact` | v3.0.1 | v5.0.0 |
| `actions/deploy-pages` | v4.0.5 | v5.0.0 |

`upload-pages-artifact` is a composite action, so its own `using:` is `composite`; what matters for the warning is the `actions/upload-artifact@v7.0.0` it calls internally, which is `node24`. The other three were verified as `node24` by reading `action.yml` at each pinned SHA.

## The one real behavior change

**`upload-pages-artifact` v4 stopped bundling dotfiles.** Docusaurus writes a `.nojekyll` into `website/build`, so this bump would have silently dropped it.

The artifact-based Pages deploy never runs Jekyll, so losing it would most likely be harmless — but that is not something worth confirming on the live site. `include-hidden-files: true` (added in v5) restores exactly what v3 uploaded. `.git` and `.github` stay excluded either way.

## Validation

Changing this file matches the workflow's own `paths` filter, so the **build and upload steps run on this PR**.

The `deploy` job only runs on push to `main`, so it stays unvalidated until merge. That is the residual risk, and it is small: `v4.0.5 → v5.0.0` is a pure runtime bump with no input or output changes.

## Not covered

`ilammy/msvc-dev-cmd@v1` in `build-whisper-stt.yml` is the last remaining `node20` reference in the repo. Upstream is abandoned (last push April 2024, two open "update to Node 24" PRs unmerged), so there is nothing to bump to — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1535769540141785221 -->