### PR TITLE
docs(ci): correct the include-hidden-files rationale in docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,11 +60,15 @@ jobs:
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: website/build
-          # v4 stopped bundling dotfiles, and Docusaurus writes a `.nojekyll`
-          # into website/build. The artifact-based Pages deploy never runs
-          # Jekyll, so losing it would probably be harmless — but "probably" is
-          # not worth finding out on the live site, and this restores exactly
-          # what v3 uploaded. `.git`/`.github` stay excluded either way.
+          # v4 stopped bundling dotfiles by default. Nothing in website/build
+          # is hidden today — the deployed artifact from 7c4827b9 was checked
+          # and contains no dot-entries at all, so this changes nothing now
+          # (Docusaurus only writes a `.nojekyll` on its own `deploy` command,
+          # not in a plain `build`). It is set so that stays true by accident
+          # rather than by omission: a `.well-known/` for domain verification
+          # or security.txt is the realistic case, and under the v4+ default it
+          # would vanish from the deploy silently. `.git` and `.github` are
+          # excluded regardless of this flag.
           include-hidden-files: true
 
   deploy:


### PR DESCRIPTION
## Problem

The comment I added in [#316](https://github.com/getopenscreen/openscreen/pull/316) (`7c4827b9`) states:

> v4 stopped bundling dotfiles, and Docusaurus writes a `.nojekyll` into website/build

**That is wrong.** Docusaurus writes `.nojekyll` from its own `deploy` command, not from a plain `build`. This site runs `npm run build` and deploys the artifact, so no `.nojekyll` is ever produced.

Verified rather than assumed — the Pages artifact published by that very commit (id `9028339047`) was downloaded and unpacked:

```
$ tar -tf artifact.tar | wc -l
59
$ tar -tf artifact.tar | grep -E '(^|/)\.[^/]'
(no dot-entries at all)
```

So `include-hidden-files: true` is currently a **no-op**, and the risk I used to justify splitting `docs.yml` out of [#97](https://github.com/getopenscreen/openscreen/pull/97) did not actually exist.

## Fix

Keep the flag, correct the reason.

The value is forward-looking, not current: a `.well-known/` directory added later for domain verification or `security.txt` would be dropped from the deploy silently under the v4+ default. That is the failure worth guarding — it is invisible until someone wonders why a verification never completes.

No behavior change; this touches a comment only.

## Note

The Pages deploy on `main` after #316 succeeded end to end — `Build site` and `Deploy to GitHub Pages` both green, https://getopenscreen.com/ serving `200`, and zero Node 20 deprecation lines in the run. The bump itself is fine; only its stated rationale was off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1535771132559491213 -->