### PR TITLE
test(media): stop the media-links temp-dir cleanup failing its own race

### DIFF
--- a/electron/media/mediaLinksRegistry.test.ts
+++ b/electron/media/mediaLinksRegistry.test.ts
@@ -13,6 +13,33 @@ async function makeTempDir(): Promise<string> {
 	return fs.mkdtemp(path.join(os.tmpdir(), "openscreen-media-links-"));
 }
 
+/**
+ * `fs.rm` that is allowed to lose a race against a write landing in the directory.
+ *
+ * `force: true` covers ENOENT — the write lost and the path is already gone — but
+ * NOT ENOTEMPTY, which is what the write WINNING looks like: it recreates an entry
+ * between rm's recursive walk and its final rmdir. `fs.rm` does not retry unless
+ * asked (`maxRetries` defaults to 0), so that rejection escapes and fails whichever
+ * test or hook was running.
+ *
+ * This suite races a write against removal on purpose (see "survives the directory
+ * disappearing while the refresh is queued"), and every `afterEach` inherits the
+ * same exposure because a queued refresh can outlive the test that started it.
+ * Losing is explicitly fine — the contract under test is that no rejection escapes
+ * into the process, not that the removal succeeds. The retries are so the temp dir
+ * still usually gets cleaned up; the catch is so a loss is never a red test.
+ *
+ * Seen twice on CI, once on a `main` push (run 31279698618), and reproduced 14
+ * times in 40 locally by racing a write against `fs.rm` over a large tree.
+ */
+async function rmBestEffort(dir: string): Promise<void> {
+	try {
+		await fs.rm(dir, { recursive: true, force: true, maxRetries: 3 });
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOTEMPTY") throw err;
+	}
+}
+
 async function writeFileOfSize(filePath: string, sizeBytes: number, fill = "a"): Promise<void> {
 	// Not all-identical bytes at the seams so head/tail samples aren't trivially
 	// equal to each other for small files — irrelevant for correctness, just
@@ -28,7 +55,7 @@ describe("mediaLinksRegistry", () => {
 	});
 
 	afterEach(async () => {
-		await fs.rm(tempDir, { recursive: true, force: true });
+		await rmBestEffort(tempDir);
 	});
 
 	describe("computeFingerprint", () => {
@@ -288,7 +315,7 @@ describe("mediaLinksRegistry", () => {
 			try {
 				const rejections = await withoutUnhandledRejections(async () => {
 					const lookup = findMediaLinksByFingerprint(tempDir, moved);
-					await fs.rm(tempDir, { recursive: true, force: true });
+					await rmBestEffort(tempDir);
 					await lookup;
 				});
 				expect(rejections).toEqual([]);


### PR DESCRIPTION
## Summary

`electron/media/mediaLinksRegistry.test.ts` goes red intermittently on CI:

```
FAIL electron/media/mediaLinksRegistry.test.ts > mediaLinksRegistry > the background path refresh
     > survives the directory disappearing while the refresh is queued
Error: ENOTEMPTY: directory not empty, rmdir '/tmp/openscreen-media-links-kW1c1T'
```

Seen twice, including on a **`main` push** ([run 31279698618](https://github.com/getopenscreen/openscreen/actions/runs/31279698618), commit `bd5e71ad`) — so it is not tied to any one branch. It most recently took down an unrelated PR's `Test` job, which passed on a plain re-run.

### Why it happens

`force: true` covers `ENOENT` — the write **lost** the race and the path is already gone. It does not cover `ENOTEMPTY`, which is what the write **winning** looks like: it recreates an entry between `fs.rm`'s recursive walk and its final `rmdir`. And `fs.rm` does not retry unless asked — `maxRetries` defaults to `0`.

The rejection then escapes. `withoutUnhandledRejections` awaits its callback in a `try`/`finally` with no `catch`, so it fails the test.

The test already declares either outcome acceptable, and asserts on `rejections`, not on the removal:

> Whoever wins the race is fine — what must not happen is a rejection escaping into the process.

Only the removal disagreed.

### Both sites, not one

`afterEach` inherits exactly the same exposure — a queued refresh can outlive the test that started it, which is literally the shape the test's own comment describes. Fixing only the in-test removal would leave the hook flaky for every other case in the suite. Both now go through `rmBestEffort()`: retries a few times so the directory still gets cleaned, tolerates `ENOTEMPTY` so a loss is never a red test, and rethrows every other errno so real failures still surface.

## Related issue

No existing issue — found while investigating a CI failure on #315.

## Type of change
- [x] Bug fix

## Release impact
- [x] No release note needed

Test-only; no shipped code changes.

## Desktop impact
- [x] Not platform-specific

## Screenshots / video

No visual change.

## Testing

**Reproduced the mechanism outside the suite**, by racing a write against `fs.rm` over a large tree:

| Harness | Result |
| --- | --- |
| raw `fs.rm(recursive, force)` | **14 ENOTEMPTY in 40** |
| through `rmBestEffort()` | **0 escaping rejections in 40**, **0 leaked temp dirs** |
| `rmBestEffort()` on an EACCES target | still rethrows — the catch stays narrow |

Note the flake does **not** reproduce by simply re-running the suite locally (0 failures in 15 runs of the file, before or after): the window only opens under CI-level load. The harness above is what makes it observable.

**Suite** — `npx vitest run` → 142 files, 1698 passed, 1 skipped, 0 failed. `biome check` and `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1535774372441100339 -->