### PR TITLE
feat(wgc): report which GPU capture landed on, and let the tool test audio

### DIFF
--- a/electron/native/wgc-capture/src/main.cpp
+++ b/electron/native/wgc-capture/src/main.cpp
@@ -195,6 +195,94 @@ std::string jsonEscape(const std::string& value) {
     return result;
 }
 
+// Reports which GPU the capture device landed on, and which one actually drives
+// the monitor being captured.
+//
+// WgcSession creates its device with D3D11CreateDevice(nullptr, ...) -- the
+// default adapter -- and nothing anywhere asks whether that is the adapter that
+// owns the target display. On a single-GPU machine the question does not arise.
+// On a hybrid laptop, a machine with a discrete card, or one with virtual
+// display adapters, the two can differ, and then every frame WGC delivers has
+// crossed an adapter boundary before the caller ever touches it. That crossing
+// is driver work on both GPUs, and it is the most plausible remaining candidate
+// for the stop hangs in #252 / #327, which nobody has reproduced on hardware we
+// control.
+//
+// This does not change behaviour, and deliberately so: it turns the next bug
+// report into evidence instead of another round of guessing. Failures here are
+// silent -- a diagnostic that can abort a recording is worse than no diagnostic.
+void reportCaptureAdapters(ID3D11Device* device, HMONITOR targetMonitor) {
+    if (!device) {
+        return;
+    }
+
+    Microsoft::WRL::ComPtr<IDXGIDevice> dxgiDevice;
+    if (FAILED(device->QueryInterface(IID_PPV_ARGS(&dxgiDevice)))) {
+        return;
+    }
+    Microsoft::WRL::ComPtr<IDXGIAdapter> deviceAdapter;
+    if (FAILED(dxgiDevice->GetAdapter(&deviceAdapter))) {
+        return;
+    }
+    DXGI_ADAPTER_DESC deviceDesc{};
+    if (FAILED(deviceAdapter->GetDesc(&deviceDesc))) {
+        return;
+    }
+
+    // The device's own adapter knows its factory, so there is no need to create
+    // one (and no second code path to keep alive if that ever needs a flag).
+    Microsoft::WRL::ComPtr<IDXGIFactory1> factory;
+    if (FAILED(deviceAdapter->GetParent(IID_PPV_ARGS(&factory)))) {
+        return;
+    }
+
+    std::wstring monitorAdapterName;
+    bool monitorAdapterFound = false;
+    bool sameAdapter = false;
+    for (UINT adapterIndex = 0;; ++adapterIndex) {
+        Microsoft::WRL::ComPtr<IDXGIAdapter1> adapter;
+        if (factory->EnumAdapters1(adapterIndex, &adapter) == DXGI_ERROR_NOT_FOUND) {
+            break;
+        }
+        for (UINT outputIndex = 0;; ++outputIndex) {
+            Microsoft::WRL::ComPtr<IDXGIOutput> output;
+            if (adapter->EnumOutputs(outputIndex, &output) == DXGI_ERROR_NOT_FOUND) {
+                break;
+            }
+            DXGI_OUTPUT_DESC outputDesc{};
+            if (FAILED(output->GetDesc(&outputDesc)) || outputDesc.Monitor != targetMonitor) {
+                continue;
+            }
+            DXGI_ADAPTER_DESC1 adapterDesc{};
+            if (FAILED(adapter->GetDesc1(&adapterDesc))) {
+                continue;
+            }
+            monitorAdapterName = adapterDesc.Description;
+            monitorAdapterFound = true;
+            // Compared by LUID rather than by description, because two adapters
+            // of the same model report the same string.
+            sameAdapter = adapterDesc.AdapterLuid.LowPart == deviceDesc.AdapterLuid.LowPart &&
+                adapterDesc.AdapterLuid.HighPart == deviceDesc.AdapterLuid.HighPart;
+        }
+        if (monitorAdapterFound) {
+            break;
+        }
+    }
+
+    std::cout << "{\"event\":\"capture-adapter\",\"schemaVersion\":2,\"deviceAdapter\":\""
+              << jsonEscape(wideToUtf8(deviceDesc.Description)) << "\",\"monitorAdapter\":";
+    if (monitorAdapterFound) {
+        std::cout << "\"" << jsonEscape(wideToUtf8(monitorAdapterName)) << "\",\"sameAdapter\":"
+                  << (sameAdapter ? "true" : "false");
+    } else {
+        // No output claims this monitor: it is driven by something DXGI does not
+        // enumerate, which on the machines in #252 means a virtual display
+        // adapter. Worth seeing in a report in its own right.
+        std::cout << "null,\"sameAdapter\":null";
+    }
+    std::cout << "}" << std::endl;
+}
+
 bool hasVisibleBgraContent(const std::vector<BYTE>& frame) {
     if (frame.size() < 4) {
         return false;
@@ -489,6 +577,7 @@ int main(int argc, char* argv[]) {
     std::cout << "{\"event\":\"ready\",\"schemaVersion\":2}" << std::endl;
 
     WgcSession session;
+    HMONITOR capturedMonitor = nullptr;
     if (config.sourceType == "display") {
         HMONITOR monitor = findMonitorForCapture(
             config.displayId,
@@ -497,6 +586,7 @@ int main(int argc, char* argv[]) {
             std::cerr << "ERROR: Could not resolve monitor" << std::endl;
             return 1;
         }
+        capturedMonitor = monitor;
         if (!session.initialize(monitor, config.fps, config.captureCursor)) {
             std::cerr << "ERROR: Failed to initialize WGC display session" << std::endl;
             return 1;
@@ -507,6 +597,9 @@ int main(int argc, char* argv[]) {
             std::cerr << "ERROR: Native window capture requires a valid HWND" << std::endl;
             return 1;
         }
+        // A window is captured by whichever display it currently sits on, which
+        // is the adapter that matters for the same reason a monitor's does.
+        capturedMonitor = MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST);
         if (!session.initialize(window, config.fps, config.captureCursor)) {
             std::cerr << "ERROR: Failed to initialize WGC window session" << std::endl;
             return 1;
@@ -515,6 +608,8 @@ int main(int argc, char* argv[]) {
         std::cerr << "ERROR: Unsupported native capture source type: " << config.sourceType << std::endl;
         return 1;
     }
+
+    reportCaptureAdapters(session.device(), capturedMonitor);
 
     // WGC owns the captured texture size. Encoding must use that exact size
     // until a dedicated GPU scaling pass is introduced; CopyResource requires

--- a/electron/native/wgc-capture/src/main.cpp
+++ b/electron/native/wgc-capture/src/main.cpp
@@ -239,14 +239,22 @@ void reportCaptureAdapters(ID3D11Device* device, HMONITOR targetMonitor) {
     std::wstring monitorAdapterName;
     bool monitorAdapterFound = false;
     bool sameAdapter = false;
+    // Both loops end on FAILED(), not on DXGI_ERROR_NOT_FOUND specifically.
+    // NOT_FOUND is itself a failure code, so one test covers the normal end of
+    // the enumeration and every other way it can stop -- and the other ways are
+    // what matter here. EnumOutputs returns DXGI_ERROR_NOT_CURRENTLY_AVAILABLE
+    // to a process in session 0, and neither call fills its out-pointer when it
+    // fails. Testing only for NOT_FOUND left a null ComPtr to be dereferenced on
+    // the next line, which would take down a recording from inside the one
+    // function in this file that promises never to.
     for (UINT adapterIndex = 0;; ++adapterIndex) {
         Microsoft::WRL::ComPtr<IDXGIAdapter1> adapter;
-        if (factory->EnumAdapters1(adapterIndex, &adapter) == DXGI_ERROR_NOT_FOUND) {
+        if (FAILED(factory->EnumAdapters1(adapterIndex, &adapter)) || !adapter) {
             break;
         }
         for (UINT outputIndex = 0;; ++outputIndex) {
             Microsoft::WRL::ComPtr<IDXGIOutput> output;
-            if (adapter->EnumOutputs(outputIndex, &output) == DXGI_ERROR_NOT_FOUND) {
+            if (FAILED(adapter->EnumOutputs(outputIndex, &output)) || !output) {
                 break;
             }
             DXGI_OUTPUT_DESC outputDesc{};

--- a/scripts/diagnostic-tool/README.md
+++ b/scripts/diagnostic-tool/README.md
@@ -28,7 +28,14 @@ Flags:
 - `-d, --duration <seconds>` recording length before sending stop (default 10)
 - `-o, --output <path>` output JSON path (default `./openscreen-diagnostic-<timestamp>.json`)
 - `--window` capture a window instead of the full display (default: display)
+- `--system-audio` also capture system (loopback) audio
+- `--mic` also capture the default microphone
 - `-h, --help` show help
+
+The audio flags matter for reproducing a stop hang. Audio and video writes take
+the same sink-writer lock, so a run without audio has nothing to contend with
+and can pass on a machine where the app hangs every time. If you are reporting a
+hang that happens in the app but not here, re-run with `--system-audio`.
 
 Or use the bundled launcher:
 - Windows: `diagnostic.bat`

--- a/scripts/diagnostic-tool/README.md
+++ b/scripts/diagnostic-tool/README.md
@@ -35,7 +35,8 @@ Flags:
 The audio flags matter for reproducing a stop hang. Audio and video writes take
 the same sink-writer lock, so a run without audio has nothing to contend with
 and can pass on a machine where the app hangs every time. If you are reporting a
-hang that happens in the app but not here, re-run with `--system-audio`.
+hang that happens in the app but not here, re-run with whichever sources the
+failing recording used: `--system-audio`, `--mic`, or both together.
 
 Or use the bundled launcher:
 - Windows: `diagnostic.bat`

--- a/scripts/diagnostic-tool/diagnostic.mjs
+++ b/scripts/diagnostic-tool/diagnostic.mjs
@@ -43,6 +43,8 @@ function parseArgs(argv) {
 		duration: 10_000,
 		output: null,
 		source: "display",
+		systemAudio: false,
+		mic: false,
 		help: false,
 	};
 	const requireNumber = (raw, flag) => {
@@ -68,6 +70,10 @@ function parseArgs(argv) {
 			opts.source = value;
 		} else if (arg === "--window") {
 			opts.source = "window";
+		} else if (arg === "--system-audio") {
+			opts.systemAudio = true;
+		} else if (arg === "--mic") {
+			opts.mic = true;
 		} else if (arg === "--help" || arg === "-h") {
 			opts.help = true;
 		} else if (arg.startsWith("--")) {
@@ -88,7 +94,14 @@ Flags:
   -o, --output  <path>       Output JSON path (default: ./openscreen-diagnostic-<timestamp>.json)
   --source <display|window>  Capture source type (default: display)
   --window                   Shortcut for --source window
+  --system-audio             Also capture system (loopback) audio
+  --mic                      Also capture the default microphone
   -h, --help                 Show this help
+
+The audio flags are off by default, which is why a plain run cannot reproduce a
+hang that only happens with audio: an audio write and a video write contend for
+the same sink-writer lock, and with no audio there is nothing to contend with.
+If a recording hangs in the app but not here, re-run with --system-audio.
 `);
 }
 
@@ -135,8 +148,8 @@ function buildConfig(opts) {
 		displayW: 1920,
 		displayH: 1080,
 		hasDisplayBounds: true,
-		captureSystemAudio: false,
-		captureMic: false,
+		captureSystemAudio: opts.systemAudio,
+		captureMic: opts.mic,
 		captureCursor: false,
 		microphoneDeviceId: "default",
 		microphoneDeviceName: "",
@@ -163,7 +176,8 @@ function run(opts) {
 	const helper = findHelper();
 	console.log(`[diag] helper: ${helper.path}`);
 	console.log(`[diag] platform: ${process.platform}-${process.arch}`);
-	console.log(`[diag] duration: ${opts.duration}ms, source: ${opts.source}`);
+	const audioSummary = [opts.systemAudio && "system", opts.mic && "mic"].filter(Boolean).join("+") || "none";
+	console.log(`[diag] duration: ${opts.duration}ms, source: ${opts.source}, audio: ${audioSummary}`);
 
 	const config = buildConfig(opts);
 	config.outputs.screenPath = config.outputPath;

--- a/scripts/diagnostic-tool/diagnostic.mjs
+++ b/scripts/diagnostic-tool/diagnostic.mjs
@@ -101,7 +101,8 @@ Flags:
 The audio flags are off by default, which is why a plain run cannot reproduce a
 hang that only happens with audio: an audio write and a video write contend for
 the same sink-writer lock, and with no audio there is nothing to contend with.
-If a recording hangs in the app but not here, re-run with --system-audio.
+If a recording hangs in the app but not here, re-run with whichever sources the
+failing recording used -- --system-audio, --mic, or both.
 `);
 }
 

--- a/scripts/diagnostic-tool/diagnostic.mjs
+++ b/scripts/diagnostic-tool/diagnostic.mjs
@@ -176,8 +176,11 @@ function run(opts) {
 	const helper = findHelper();
 	console.log(`[diag] helper: ${helper.path}`);
 	console.log(`[diag] platform: ${process.platform}-${process.arch}`);
-	const audioSummary = [opts.systemAudio && "system", opts.mic && "mic"].filter(Boolean).join("+") || "none";
-	console.log(`[diag] duration: ${opts.duration}ms, source: ${opts.source}, audio: ${audioSummary}`);
+	const audioSummary =
+		[opts.systemAudio && "system", opts.mic && "mic"].filter(Boolean).join("+") || "none";
+	console.log(
+		`[diag] duration: ${opts.duration}ms, source: ${opts.source}, audio: ${audioSummary}`,
+	);
 
 	const config = buildConfig(opts);
 	config.outputs.screenPath = config.outputPath;


### PR DESCRIPTION
Neither #252 nor #327 has been reproduced on hardware we control. The two most recent reports arrived with no OS, no version and no trace, and the standalone diagnostic tool cannot exercise the configuration that fails most consistently. This PR changes no recording behaviour; it makes the next report answer a question.

## Which GPU the capture landed on

`WgcSession::createD3DDevice` calls `D3D11CreateDevice(nullptr, ...)` — the **default** adapter — and nothing anywhere asks whether that is the adapter driving the display being captured. There is no `EnumAdapters` or `EnumOutputs` in the helper at all.

On a single-GPU machine the question does not arise. On a hybrid laptop, a machine with a discrete card, or one with virtual display adapters, the two can differ — and then every frame WGC delivers has crossed an adapter boundary before the caller touches it. That crossing is driver work on both GPUs, and it is the most plausible remaining candidate for these hangs.

It also fits every data point we have:

| machine | GPUs | reproduces |
|---|---|---|
| #252 reporter | RTX 5070 Ti + AMD iGPU + two virtual display adapters | yes |
| #304/#306 author | RTX 4060 Ti | yes |
| our dev machine | Radeon iGPU only — device and display necessarily the same adapter | never |

The helper now emits, right after the session initialises:

```json
{"event":"capture-adapter","schemaVersion":2,"deviceAdapter":"AMD Radeon(TM) Graphics","monitorAdapter":"NVIDIA GeForce RTX 2050","sameAdapter":false}
```

Compared by LUID, not by description, because two cards of the same model report the same string. `monitorAdapter` is `null` when no DXGI output claims the monitor, which is worth seeing in its own right — on the #252 machine that would point at the virtual display adapters. Window capture resolves its monitor with `MonitorFromWindow`.

Every failure inside the reporting path returns silently. A diagnostic that can end a recording is worse than no diagnostic.

## Audio in the diagnostic tool

`captureSystemAudio` and `captureMic` were hardcoded `false` in `diagnostic.mjs`, so the tool could not test the system-audio case — the one that fails consistently for the #252 reporter, and the reason no clean trace of it exists.

Audio and video writes take the same sink-writer lock, so a run without audio has nothing to contend with and passes on a machine where the app hangs every time. That is a trap for anyone told "run the diagnostic tool and attach the JSON": it comes back green and proves nothing.

`--system-audio` and `--mic` now exist, with the reasoning in the tool's `--help` and in the README so a reporter knows when to re-run.

## Verified

- `--system-audio` produces an AAC 48 kHz stereo track alongside the video, stop in 152 ms, exit 0.
- The C++ half is compile-verified in CI only. This machine has a single adapter, so it can only ever print `sameAdapter=true` — the interesting branch cannot be exercised here, which is rather the point of shipping it.

Does not close anything. It is the instrument, not the fix.

<!-- discord-thread-id:1536449907605504085 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added capture diagnostics that report graphics adapter details when starting display or window capture.
  * Diagnostic tooling now supports optional system audio and microphone capture, with audio disabled by default.

* **Documentation**
  * Added guidance for using audio capture when investigating recording hangs.
  * Startup output now indicates which audio sources are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->