### PR TITLE
refactor(wgc): guard the WinRT calls that can kill the helper silently

### DIFF
--- a/electron/native/wgc-capture/src/wgc_session.cpp
+++ b/electron/native/wgc-capture/src/wgc_session.cpp
@@ -7,6 +7,7 @@
 #include <winrt/base.h>
 
 #include <chrono>
+#include <exception>
 #include <iostream>
 #include <thread>
 
@@ -30,6 +31,57 @@ bool succeeded(HRESULT hr, const char* label) {
               << std::endl;
     return false;
 }
+
+// Turns a C++/WinRT throw into a logged `false`.
+//
+// The projected calls on the setup path -- get_activation_factory, .as<>,
+// item_.Size(), CreateFreeThreaded, CreateCaptureSession, FrameArrived,
+// StartCapture -- report failure by throwing, and none of them was caught.
+// initialize() therefore could not return false: an exception from any of them
+// unwound past it into std::terminate and the process ended with no message at
+// all, leaving Electron to report "the helper exited before recording started"
+// and nothing else. The HRESULT was in the exception the whole time.
+//
+// No such failure has actually been observed. This is written from reading the
+// calls, not from a reproduction -- see the PR for the crash that prompted it
+// and turned out to be an unrelated stack-buffer overrun, which is a fastfail
+// rather than an exception and is not catchable here or anywhere.
+//
+// The label is the diagnostic, so a region never spans two calls a reader would
+// want told apart: the frame pool and the capture session get one each. Where a
+// region does cover several calls it is because they are one step under one
+// name -- "GraphicsCaptureItem for a monitor" is the activation factory, the
+// interop cast and Size(), and knowing which of those three threw would not
+// change what you do next. `succeeded()` above stays as it is for the calls
+// that return an HRESULT rather than throwing; this is its counterpart, not its
+// replacement.
+template <typename Body>
+bool guardWinrt(const char* what, Body&& body) {
+    try {
+        return body();
+    } catch (winrt::hresult_error const& error) {
+        std::cerr << "ERROR: " << what << " threw (hr=0x" << std::hex
+                  << static_cast<uint32_t>(error.code()) << std::dec << "): "
+                  << winrt::to_string(error.message()) << std::endl;
+        return false;
+    } catch (std::exception const& error) {
+        std::cerr << "ERROR: " << what << " threw (" << error.what() << ")" << std::endl;
+        return false;
+    } catch (...) {
+        std::cerr << "ERROR: " << what << " threw a non-standard exception" << std::endl;
+        return false;
+    }
+}
+
+// Deliberately no GraphicsCaptureSession::IsSupported() pre-flight here, though
+// it would give a nicer message than an HRESULT on some later call. It is the
+// one thing that could *refuse* a recording that works today: a machine where
+// IsSupported() answers false but capture would have succeeded records fine now
+// and would stop doing so, and there is no evidence either way about whether
+// such a machine exists. That is the exact shape of the #336 regression -- a new
+// gate in front of a path that was working -- and a better error message is not
+// worth carrying it. Everything below only adds a branch that did not exist, so
+// at worst it never runs.
 
 int64_t timeSpanToHns(wf::TimeSpan const& value) {
     return value.count();
@@ -132,43 +184,77 @@ bool WgcSession::createD3DDevice() {
 }
 
 bool WgcSession::createCaptureItem(HMONITOR monitor) {
-    auto factory = winrt::get_activation_factory<wgcap::GraphicsCaptureItem>();
-    auto interop = factory.as<IGraphicsCaptureItemInterop>();
+    return guardWinrt("GraphicsCaptureItem for a monitor", [&] {
+        auto factory = winrt::get_activation_factory<wgcap::GraphicsCaptureItem>();
+        auto interop = factory.as<IGraphicsCaptureItemInterop>();
 
-    wgcap::GraphicsCaptureItem item{nullptr};
-    HRESULT hr = interop->CreateForMonitor(
-        monitor,
-        winrt::guid_of<wgcap::GraphicsCaptureItem>(),
-        reinterpret_cast<void**>(winrt::put_abi(item)));
-    if (!succeeded(hr, "CreateForMonitor")) {
-        return false;
-    }
+        wgcap::GraphicsCaptureItem item{nullptr};
+        HRESULT hr = interop->CreateForMonitor(
+            monitor,
+            winrt::guid_of<wgcap::GraphicsCaptureItem>(),
+            reinterpret_cast<void**>(winrt::put_abi(item)));
+        if (!succeeded(hr, "CreateForMonitor")) {
+            return false;
+        }
 
-    item_ = item;
-    const auto size = item_.Size();
-    width_ = static_cast<int>(size.Width);
-    height_ = static_cast<int>(size.Height);
-    return width_ > 0 && height_ > 0;
+        item_ = item;
+        const auto size = item_.Size();
+        width_ = static_cast<int>(size.Width);
+        height_ = static_cast<int>(size.Height);
+        return width_ > 0 && height_ > 0;
+    });
 }
 
 bool WgcSession::createCaptureItem(HWND window) {
-    auto factory = winrt::get_activation_factory<wgcap::GraphicsCaptureItem>();
-    auto interop = factory.as<IGraphicsCaptureItemInterop>();
+    return guardWinrt("GraphicsCaptureItem for a window", [&] {
+        auto factory = winrt::get_activation_factory<wgcap::GraphicsCaptureItem>();
+        auto interop = factory.as<IGraphicsCaptureItemInterop>();
 
-    wgcap::GraphicsCaptureItem item{nullptr};
-    HRESULT hr = interop->CreateForWindow(
-        window,
-        winrt::guid_of<wgcap::GraphicsCaptureItem>(),
-        reinterpret_cast<void**>(winrt::put_abi(item)));
-    if (!succeeded(hr, "CreateForWindow")) {
+        wgcap::GraphicsCaptureItem item{nullptr};
+        HRESULT hr = interop->CreateForWindow(
+            window,
+            winrt::guid_of<wgcap::GraphicsCaptureItem>(),
+            reinterpret_cast<void**>(winrt::put_abi(item)));
+        if (!succeeded(hr, "CreateForWindow")) {
+            return false;
+        }
+
+        item_ = item;
+        const auto size = item_.Size();
+        width_ = roundUpToEven(static_cast<int>(size.Width));
+        height_ = roundUpToEven(static_cast<int>(size.Height));
+        return width_ > 0 && height_ > 0;
+    });
+}
+
+// Two guards, not one around both: they are separate projected calls, and a
+// single region would have reported a CreateCaptureSession throw under the
+// CreateFreeThreaded label -- naming the wrong call, which is worse than naming
+// none.
+bool WgcSession::createFramePoolAndSession() {
+    const bool pooled = guardWinrt("Direct3D11CaptureFramePool::CreateFreeThreaded", [&] {
+        framePool_ = wgcap::Direct3D11CaptureFramePool::CreateFreeThreaded(
+            winrtDevice_,
+            wgdx::DirectXPixelFormat::B8G8R8A8UIntNormalized,
+            2,
+            winrt::Windows::Graphics::SizeInt32{width_, height_});
+        return true;
+    });
+    if (!pooled) {
         return false;
     }
 
-    item_ = item;
-    const auto size = item_.Size();
-    width_ = roundUpToEven(static_cast<int>(size.Width));
-    height_ = roundUpToEven(static_cast<int>(size.Height));
-    return width_ > 0 && height_ > 0;
+    return guardWinrt("Direct3D11CaptureFramePool::CreateCaptureSession", [&] {
+        session_ = framePool_.CreateCaptureSession(item_);
+        return true;
+    });
+}
+
+bool WgcSession::registerFrameArrived() {
+    return guardWinrt("Direct3D11CaptureFramePool::FrameArrived", [&] {
+        frameArrivedToken_ = framePool_.FrameArrived({this, &WgcSession::onFrameArrived});
+        return true;
+    });
 }
 
 bool WgcSession::applySessionOptions(bool captureCursor) {
@@ -217,52 +303,26 @@ bool WgcSession::applySessionOptions(bool captureCursor) {
     return true;
 }
 
+// Every step reports its own failure, so the two overloads are the step list and
+// nothing else. Each returns false rather than throwing past its caller, which
+// is what main.cpp's "Failed to initialize WGC display session" has always
+// assumed and, until now, was not true of any of them.
 bool WgcSession::initialize(HMONITOR monitor, int fps, bool captureCursor) {
     fps_ = fps > 0 ? fps : 60;
-    if (!createD3DDevice()) {
-        return false;
-    }
-    if (!createCaptureItem(monitor)) {
-        return false;
-    }
-
-    framePool_ = wgcap::Direct3D11CaptureFramePool::CreateFreeThreaded(
-        winrtDevice_,
-        wgdx::DirectXPixelFormat::B8G8R8A8UIntNormalized,
-        2,
-        winrt::Windows::Graphics::SizeInt32{width_, height_});
-    session_ = framePool_.CreateCaptureSession(item_);
-
-    if (!applySessionOptions(captureCursor)) {
-        return false;
-    }
-
-    frameArrivedToken_ = framePool_.FrameArrived({this, &WgcSession::onFrameArrived});
-    return true;
+    return createD3DDevice() &&
+        createCaptureItem(monitor) &&
+        createFramePoolAndSession() &&
+        applySessionOptions(captureCursor) &&
+        registerFrameArrived();
 }
 
 bool WgcSession::initialize(HWND window, int fps, bool captureCursor) {
     fps_ = fps > 0 ? fps : 60;
-    if (!createD3DDevice()) {
-        return false;
-    }
-    if (!createCaptureItem(window)) {
-        return false;
-    }
-
-    framePool_ = wgcap::Direct3D11CaptureFramePool::CreateFreeThreaded(
-        winrtDevice_,
-        wgdx::DirectXPixelFormat::B8G8R8A8UIntNormalized,
-        2,
-        winrt::Windows::Graphics::SizeInt32{width_, height_});
-    session_ = framePool_.CreateCaptureSession(item_);
-
-    if (!applySessionOptions(captureCursor)) {
-        return false;
-    }
-
-    frameArrivedToken_ = framePool_.FrameArrived({this, &WgcSession::onFrameArrived});
-    return true;
+    return createD3DDevice() &&
+        createCaptureItem(window) &&
+        createFramePoolAndSession() &&
+        applySessionOptions(captureCursor) &&
+        registerFrameArrived();
 }
 
 void WgcSession::setFrameCallback(FrameCallback callback) {
@@ -277,7 +337,12 @@ bool WgcSession::start() {
     if (!applySessionOptions(captureCursor_)) {
         return false;
     }
-    session_.StartCapture();
+    if (!guardWinrt("GraphicsCaptureSession::StartCapture", [&] {
+            session_.StartCapture();
+            return true;
+        })) {
+        return false;
+    }
     started_ = true;
     return true;
 }
@@ -359,9 +424,36 @@ void WgcSession::stop() {
     d3dDevice_.Reset();
 }
 
+// The same defect as the setup path, on the hot path. TryGetNextFrame,
+// Surface(), the interop cast and SystemRelativeTime() are all projections that
+// throw, and a throw leaving a WinRT delegate goes straight to std::terminate --
+// a recording that ends with the process disappearing mid-capture, no stderr,
+// and the partial file as the only evidence.
+//
+// Dropping the frame is the only useful response: one bad frame is not a reason
+// to end a recording, and a surface that has gone bad usually stays bad. So it
+// is logged once and not at frame rate, which at 60 fps is the difference
+// between a diagnostic and a denial of service on the log.
 void WgcSession::onFrameArrived(
     wgcap::Direct3D11CaptureFramePool const& sender,
     wf::IInspectable const&) {
+    try {
+        deliverFrame(sender);
+    } catch (winrt::hresult_error const& error) {
+        if (!frameErrorLogged_.exchange(true)) {
+            std::cerr << "WARNING: Dropped a WGC frame (hr=0x" << std::hex
+                      << static_cast<uint32_t>(error.code()) << std::dec
+                      << "). Further frame errors are not repeated." << std::endl;
+        }
+    } catch (...) {
+        if (!frameErrorLogged_.exchange(true)) {
+            std::cerr << "WARNING: Dropped a WGC frame. "
+                      << "Further frame errors are not repeated." << std::endl;
+        }
+    }
+}
+
+void WgcSession::deliverFrame(wgcap::Direct3D11CaptureFramePool const& sender) {
     auto frame = sender.TryGetNextFrame();
     if (!frame) {
         return;

--- a/electron/native/wgc-capture/src/wgc_session.h
+++ b/electron/native/wgc-capture/src/wgc_session.h
@@ -46,10 +46,17 @@ private:
     bool createD3DDevice();
     bool createCaptureItem(HMONITOR monitor);
     bool createCaptureItem(HWND window);
+    bool createFramePoolAndSession();
+    bool registerFrameArrived();
     bool applySessionOptions(bool captureCursor);
     void onFrameArrived(
         winrt::Windows::Graphics::Capture::Direct3D11CaptureFramePool const& sender,
         winrt::Windows::Foundation::IInspectable const&);
+    // The body of onFrameArrived, split out so the handler itself is nothing but
+    // the try/catch that keeps a throwing projection from reaching the WinRT
+    // delegate and taking the process down with it.
+    void deliverFrame(
+        winrt::Windows::Graphics::Capture::Direct3D11CaptureFramePool const& sender);
 
     Microsoft::WRL::ComPtr<ID3D11Device> d3dDevice_;
     Microsoft::WRL::ComPtr<ID3D11DeviceContext> d3dContext_;
@@ -61,6 +68,8 @@ private:
     FrameCallback frameCallback_;
     std::mutex callbackMutex_;
     std::atomic<int> callbacksInFlight_ = 0;
+    // One line per recording, not one per bad frame.
+    std::atomic<bool> frameErrorLogged_ = false;
     bool quiesced_ = false;
     int width_ = 0;
     int height_ = 0;


### PR DESCRIPTION
## Summary

> **Correction, read this first.** This PR was opened on a misdiagnosis. I hit a helper that died with exit `0xC0000409` and no stderr, attributed it to an uncaught WinRT throw, and wrote these guards. It was not that: it was a `MAX_PATH` stack-buffer overrun, and **this branch crashes identically** — the guards catch nothing, because `__fastfail` is not a C++ exception. Details in [Testing](#testing).
>
> So this is **hardening with no observed failure behind it**, not a fix for a bug seen in the wild. Judge it on that basis. I have left it open because the defect it addresses is real and independently verifiable by reading; if you would rather not carry defensive code without a reproduction, closing it is a reasonable call.
>
> **Since then:** rebased onto `main` with #338 in it, and the `GraphicsCaptureSession::IsSupported()` pre-flight has been dropped — see [What changed](#what-changed). Nothing that remains can refuse a recording that works today.

Every projected C++/WinRT call on the capture-setup path reports failure by throwing, and none of them is caught:

- `winrt::get_activation_factory<GraphicsCaptureItem>()`
- `factory.as<IGraphicsCaptureItemInterop>()`
- `item_.Size()`
- `Direct3D11CaptureFramePool::CreateFreeThreaded()`
- `framePool_.CreateCaptureSession()`
- `framePool_.FrameArrived()`
- `session_.StartCapture()`
- and every projection inside `onFrameArrived`

If any of them ever throws, the exception leaves `initialize()` (or, worse, a WinRT delegate), reaches `std::terminate`, and the process dies with no message. [main.cpp](electron/native/wgc-capture/src/main.cpp) has an `ERROR: Failed to initialize WGC display session` line ready for exactly this and cannot reach it — `initialize()` does not return `false` on failure, it takes the process with it.

That is a real gap in a helper whose failures are already hard to diagnose from Electron's side. It is just not a gap anyone has been observed to fall into.

## Related issue

No issue. Found while working on #338; see the correction above for why it is *not* evidence for #252 / #292 / #327, contrary to what this PR first claimed.

## Type of change
- [x] Refactor / maintenance

## Release impact
- [x] No release note needed

## Desktop impact
- [x] Windows

## What changed

`guardWinrt()` turns a throw into a logged `false`, applied one or two calls at a time so its **label alone names the call that threw** — no breadcrumb to thread through the way `mf_encoder.cpp` needs one. It is the counterpart of the existing `succeeded()` (for calls that return an HRESULT rather than throwing) and reuses the catch shape `applySessionOptions` already had.

Both `initialize()` overloads become their step list and nothing else:

```cpp
return createD3DDevice() &&
    createCaptureItem(monitor) &&
    createFramePoolAndSession() &&
    applySessionOptions(captureCursor) &&
    registerFrameArrived();
```

which also drops the frame-pool block that was duplicated verbatim between them.

**No `GraphicsCaptureSession::IsSupported()` pre-flight**, deliberately — an earlier revision of this PR had one, and it has been removed. It was the only thing here that could *refuse* a recording that works today: a machine where `IsSupported()` answers false but capture would in fact have succeeded records fine now and would stop doing so, and there is no evidence either way about whether such a machine exists. That is precisely the shape of #336 — a new gate in front of a path that was working — and a nicer error message does not buy that risk.

Everything that remains only **adds** a branch that did not exist before, so at worst it never runs. That asymmetry is the whole argument for taking this without a reproduction.

**`onFrameArrived` gets the same treatment, on the hot path** — this is the part I would keep even if the rest went. `TryGetNextFrame`, `Surface()`, the interop cast and `SystemRelativeTime()` all throw, and a throw leaving a WinRT delegate is `std::terminate`: mid-recording, the process simply vanishes. A bad frame is now dropped instead, logged **once** rather than at frame rate (60 fps of identical warnings is not a diagnostic). The existing `InFlightGuard` already unwound correctly on exception, so `quiesceCapture()`'s drain is unaffected.

Not in scope: `quiesceCapture()` and `stop()` were already guarded and are untouched.

## Testing

| | |
|---|---|
| Compiles (Windows x64, `/W4`) | ✅ [run 31484293718](https://github.com/getopenscreen/openscreen/actions/runs/31484293718), rebased onto `main` with #338 in it |
| No behaviour change on a working machine | ✅ records cleanly: 132 frames in 4.4 s, full `[stop-timing]` sequence, exit 0 |
| Catches a real throw | ⬜ **not demonstrated — I have no way to make one of these calls throw** |

### The repro that motivated this, and why it was not this

On Windows 11 Home `10.0.26200`, the helper printed `{"event":"ready"}` and died ~230 ms later with `0xC0000409` and no stderr. I read that as an uncaught WinRT throw — `0xC0000409` is what `__fastfail` reports for an unhandled C++ exception, and there were seven uncaught candidates right where it died.

It was the **length of the helper's own `.exe` path**:

| exe path | output path | result |
|---|---|---|
| 259 chars | short | ❌ `0xC0000409` @ ~290 ms |
| short | 241 chars | ✅ records fine |
| short | short | ✅ records fine |
| 259 chars, **this branch** | short | ❌ `0xC0000409` @ ~319 ms — **guards log nothing** |

The last row is the one that matters. `0xC0000409` is `STATUS_STACK_BUFFER_OVERRUN`, and here it is the literal meaning — a `/GS` cookie check failing on a `MAX_PATH` buffer somewhere in the WinRT/WGC stack — not `__fastfail(FATAL_APP_EXIT)` from an unhandled exception. No `try`/`catch` can intercept it. The unzipped diagnostic bundle simply landed in a deeply nested scratch directory.

The helper is fine on this machine at a normal path, before and after this change.

**One thing worth someone's attention:** MSIX install paths under `C:\Program Files\WindowsApps\<publisher>.<package>_<version>_x64__<hash>\` are long by construction. I have not measured how close the Store build gets to 259 characters, and if it is close, this is a real crash with no diagnostic and no way to catch it. That seems worth checking independently of this PR.

### What was verified

```powershell
$env:OPENSCREEN_WGC_CAPTURE_EXE = "C:\short\path\wgc-capture.exe"; npm run test:wgc-helper:win
```

Recording still works end to end with this branch: `ready` → `cursor-capture` → `capture-adapter` → `encoder-selection` → `recording-started`, 139 frames in 4.6 s, full `[stop-timing]` sequence, exit 0. The guards only add a path that did not exist, and on a healthy machine nothing takes it.

What is **not** verified is the guards actually firing, because I cannot make `get_activation_factory` or `CreateFreeThreaded` throw on demand. That is the honest state of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when starting and running screen captures.
  * Capture setup failures are now handled gracefully instead of terminating the application.
  * Frame delivery errors no longer crash the capture process.
  * Added diagnostic logging to help identify capture initialization and frame-processing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->