### PR TITLE
fix(compositor): say when a declared camera is unreadable

### DIFF
--- a/crates/compositor/src/live.rs
+++ b/crates/compositor/src/live.rs
@@ -76,6 +76,42 @@ struct PrefetchedClip {
 /// Ouvre + positionne la paire de décodeurs d'un clip (même travail que
 /// `Player::set_active_clip`, mais autonome — sans instance `Player` existante, pour pouvoir
 /// tourner sur un thread dédié pendant que le `Player` réel joue encore le clip actif).
+/// Ouvre le décodeur webcam, ou un remplaçant si le clip n'en a pas.
+///
+/// Un clip sans caméra arrive ici avec un chemin VIDE (`assetCameraSource` côté TS renvoie
+/// `""`), et le reste du moteur veut une paire de décodeurs toujours valide plutôt qu'un
+/// `Option` à dérouler sur tout le chemin chaud. Le remplaçant est donc l'écran lui-même :
+/// il n'est jamais dessiné, puisque la composition ne pose une vignette que si le document
+/// déclare une caméra.
+///
+/// Le cas qui compte est l'autre : un chemin NON VIDE qui ne s'ouvre pas. Cela veut dire
+/// que le projet déclare une caméra dont le fichier a été déplacé ou supprimé — et là, la
+/// vignette EST dessinée, avec l'enregistrement d'écran dedans. C'est le symptôme de #265,
+/// et il était silencieux : aucune trace ne distinguait « pas de caméra » de « caméra
+/// introuvable ».
+///
+/// ponytail: on garde le remplaçant plutôt que de passer `wdec` en `Option<Decoder>`, ce qui
+/// toucherait 22 sites dont le pool et la boucle de composition `unsafe`. À faire si quelqu'un
+/// mesure que le décodeur inutile coûte (VRAM des pools D3D11VA, ouverture par clip) — le
+/// journal ci-dessous dit enfin combien de fois le mauvais cas se produit.
+unsafe fn open_webcam_or_stand_in(
+    screen_path: &str,
+    webcam_path: &str,
+    gpu: &Gpu,
+) -> Result<Decoder> {
+    match Decoder::open(webcam_path, gpu) {
+        Ok(d) => Ok(d),
+        Err(e) => {
+            if !webcam_path.is_empty() {
+                eprintln!(
+                    "WARNING: caméra déclarée mais illisible ({webcam_path}) : {e}.                      L'enregistrement d'écran sert de remplaçant, donc la vignette caméra                      affichera l'écran. Média à relier."
+                );
+            }
+            Decoder::open(screen_path, gpu)
+        }
+    }
+}
+
 unsafe fn open_and_seek_clip(
     screen_path: &str,
     webcam_path: &str,
@@ -85,10 +121,7 @@ unsafe fn open_and_seek_clip(
 ) -> Result<PrefetchedClip> {
     let source_time_sec = source_time_sec.max(0.0);
     let mut sdec = Decoder::open(screen_path, gpu)?;
-    let mut wdec = match Decoder::open(webcam_path, gpu) {
-        Ok(d) => d,
-        Err(_) => Decoder::open(screen_path, gpu)?,
-    };
+    let mut wdec = open_webcam_or_stand_in(screen_path, webcam_path, gpu)?;
     let sf = sdec.seek_to(source_time_sec)?;
     let mut wf = wdec.seek_to(webcam_seek_time(source_time_sec, webcam_offset_sec))?;
     if wf.is_null() {
@@ -225,10 +258,7 @@ pub struct Player {
 
 impl Player {
     pub unsafe fn open(screen: &str, webcam: &str, gpu: &Gpu) -> Result<Player> {
-        let wdec = match Decoder::open(webcam, gpu) {
-            Ok(d) => d,
-            Err(_) => Decoder::open(screen, gpu)?,
-        };
+        let wdec = open_webcam_or_stand_in(screen, webcam, gpu)?;
         Ok(Player {
             sdec: Decoder::open(screen, gpu)?,
             wdec,

--- a/crates/compositor/src/live.rs
+++ b/crates/compositor/src/live.rs
@@ -76,37 +76,40 @@ struct PrefetchedClip {
 /// Ouvre + positionne la paire de décodeurs d'un clip (même travail que
 /// `Player::set_active_clip`, mais autonome — sans instance `Player` existante, pour pouvoir
 /// tourner sur un thread dédié pendant que le `Player` réel joue encore le clip actif).
-/// Ouvre le décodeur webcam, ou un remplaçant si le clip n'en a pas.
+/// Ouvre le décodeur webcam, ou un remplaçant quand le clip n'a pas de caméra.
 ///
-/// Un clip sans caméra arrive ici avec un chemin VIDE (`assetCameraSource` côté TS renvoie
-/// `""`), et le reste du moteur veut une paire de décodeurs toujours valide plutôt qu'un
-/// `Option` à dérouler sur tout le chemin chaud. Le remplaçant est donc l'écran lui-même :
-/// il n'est jamais dessiné, puisque la composition ne pose une vignette que si le document
-/// déclare une caméra.
+/// La question « ce chemin désigne-t-il une vraie caméra ? » a déjà une réponse dans ce
+/// crate : `webcam_is_real`. Elle couvre le chemin vide, le chemin composé d'espaces, et le
+/// cas où l'appelant renvoie le chemin de l'écran lui-même — ce que fait `ExportDialog.tsx`
+/// et ce que contiennent les scènes plus anciennes. Un simple `is_empty()` en raterait deux
+/// sur trois, et le commentaire de `webcam_is_real` rappelle que c'est exactement cet oubli
+/// qui avait mis l'enregistrement d'écran dans la vignette caméra (#265).
 ///
-/// Le cas qui compte est l'autre : un chemin NON VIDE qui ne s'ouvre pas. Cela veut dire
-/// que le projet déclare une caméra dont le fichier a été déplacé ou supprimé — et là, la
-/// vignette EST dessinée, avec l'enregistrement d'écran dedans. C'est le symptôme de #265,
-/// et il était silencieux : aucune trace ne distinguait « pas de caméra » de « caméra
-/// introuvable ».
+/// Sans caméra, le remplaçant est l'écran : le moteur veut une paire de décodeurs toujours
+/// valide plutôt qu'un `Option` à dérouler sur tout le chemin chaud, et rien ne le dessine
+/// puisque la composition ne pose une vignette que si le document déclare une caméra.
+///
+/// Avec une caméra déclarée dont le fichier ne s'ouvre pas, c'est l'inverse : la vignette
+/// EST dessinée et affiche l'écran. Ce cas-là méritait une trace, et n'en avait aucune.
 ///
 /// ponytail: on garde le remplaçant plutôt que de passer `wdec` en `Option<Decoder>`, ce qui
-/// toucherait 22 sites dont le pool et la boucle de composition `unsafe`. À faire si quelqu'un
-/// mesure que le décodeur inutile coûte (VRAM des pools D3D11VA, ouverture par clip) — le
-/// journal ci-dessous dit enfin combien de fois le mauvais cas se produit.
+/// toucherait 22 sites dont le pool de décodeurs et la boucle de composition `unsafe`. À faire
+/// si quelqu'un mesure que le décodeur inutile coûte (VRAM des pools D3D11VA, une ouverture
+/// par clip) — l'avertissement ci-dessous dit enfin à quelle fréquence le cas visible arrive.
 unsafe fn open_webcam_or_stand_in(
     screen_path: &str,
     webcam_path: &str,
     gpu: &Gpu,
 ) -> Result<Decoder> {
+    if !webcam_is_real(webcam_path, screen_path) {
+        return Decoder::open(screen_path, gpu);
+    }
     match Decoder::open(webcam_path, gpu) {
         Ok(d) => Ok(d),
         Err(e) => {
-            if !webcam_path.is_empty() {
-                eprintln!(
-                    "WARNING: caméra déclarée mais illisible ({webcam_path}) : {e}.                      L'enregistrement d'écran sert de remplaçant, donc la vignette caméra                      affichera l'écran. Média à relier."
-                );
-            }
+            eprintln!(
+                "WARNING: caméra déclarée mais illisible ({webcam_path}) : {e}. La vignette caméra affichera l'enregistrement d'écran ; le média est à relier."
+            );
             Decoder::open(screen_path, gpu)
         }
     }


### PR DESCRIPTION
Both places that open the preview's webcam decoder fell back to opening the screen recording a second time, silently, on any error:

```rust
let wdec = match Decoder::open(webcam_path, gpu) {
    Ok(d) => d,
    Err(_) => Decoder::open(screen_path, gpu)?,
};
```

That collapses two cases which deserve opposite treatment.

## The harmless one

A clip with no camera arrives with an **empty** path (`assetCameraSource` returns `""`), and the stand-in costs only a wasted decoder: nothing draws it, because compositing places a webcam rect only when the document declares a camera.

Verified end to end today on 1.9.0: record with the camera off, stop, reopen the project both warm and from a cold start. No stray picture-in-picture, no crash. I had flagged this as a likely cause of #348 yesterday and it is not one.

## The one that matters

A **non-empty** path that fails to open means the project declares a camera whose file has moved or been deleted. The webcam rect **is** drawn, and what appears inside it is the screen recording. That is #265's symptom, still reachable, and nothing in the logs told it apart from the harmless case.

Both sites now share one named function, and the bad case logs the path and the underlying error. Behaviour is otherwise unchanged.

## What this deliberately does not do

Make `wdec` an `Option<Decoder>`. That is the structurally correct fix and it touches **22 sites**, including the decoder pool and the `unsafe` compositing loop — a refactor of the preview engine rather than a cleanup, for a cost nobody has measured. A `ponytail:` comment records the ceiling and the upgrade path.

The log is what would justify that work: it says how often the reachable case fires, and gives a way to count the wasted decoders before paying for removing them.

## Testing

- `rustfmt` clean on the lines changed (the file's pre-existing import order is left alone; CI does not enforce Rust formatting)
- compile-verified in CI only — the compositor needs `thirdparty/ffmpeg`, absent from a fresh checkout

Refs #265

<!-- discord-thread-id:1537381065285701714 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webcam playback reliability by automatically falling back to screen content when the webcam is unavailable.
  * Added warnings when declared webcam files are missing.
  * Updated clip and player playback to handle webcam sources consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->