### PR TITLE
fix(recording): stop macOS fragments carrying an offset the box cannot hold

### DIFF
--- a/electron/native/screencapturekit/Sources/OpenScreenScreenCaptureKitHelper/ScreenCaptureRecorder.swift
+++ b/electron/native/screencapturekit/Sources/OpenScreenScreenCaptureKitHelper/ScreenCaptureRecorder.swift
@@ -141,6 +141,7 @@ final class ScreenCaptureRecorder: NSObject, SCStreamOutput, SCStreamDelegate {
 	private var audioMixer: AudioTrackMixer?
 	private var didStartWriting = false
 	private var didEmitRecordingStarted = false
+	private var didReportWriterFailure = false
 	private var isStopping = false
 	private var isPaused = false
 	private var pauseStartedAt: CMTime?
@@ -309,7 +310,8 @@ final class ScreenCaptureRecorder: NSObject, SCStreamOutput, SCStreamDelegate {
 		}
 
 		if videoInput.isReadyForMoreMediaData {
-			if videoInput.append(sampleBuffer), !didEmitRecordingStarted {
+			let appended = videoInput.append(sampleBuffer)
+			if appended, !didEmitRecordingStarted {
 				didEmitRecordingStarted = true
 				emit([
 					"event": "recording-started",
@@ -318,8 +320,29 @@ final class ScreenCaptureRecorder: NSObject, SCStreamOutput, SCStreamDelegate {
 					"height": outputHeight,
 					"captureBounds": captureBoundsPayload(),
 				])
+			} else if !appended {
+				reportWriterFailure("video append")
 			}
 		}
+	}
+
+	/// A failed AVAssetWriter keeps accepting appends and keeps answering false, so
+	/// a recorder that discards that Bool records nothing while the HUD counts on.
+	/// That is how a two-minute take was already lost by its fourth second and only
+	/// said so at finishWriting(). The Windows helper checks every WriteSample
+	/// HRESULT and escalates; this is the macOS half of the same contract -- report
+	/// once, at the append that actually failed, carrying the live writer.error.
+	private func reportWriterFailure(_ stage: String) {
+		guard !didReportWriterFailure, let writer else {
+			return
+		}
+		didReportWriterFailure = true
+		emitError(
+			code: "writer-failed",
+			message: "\(stage): "
+				+ (writer.error.map { "\($0)" }
+					?? "AVAssetWriter status \(writer.status.rawValue)"),
+		)
 	}
 
 	private func ensureRequestedPermissions() throws {
@@ -456,6 +479,25 @@ final class ScreenCaptureRecorder: NSObject, SCStreamOutput, SCStreamDelegate {
 			AVVideoCompressionPropertiesKey: [
 				AVVideoAverageBitRateKey: request.video.bitrate ?? 18_000_000,
 				AVVideoExpectedSourceFrameRateKey: request.video.fps,
+				// Without this the encoder defaults to B-frames, and a reordered
+				// stream needs a composition offset per sample. AVAssetWriter emits
+				// those in a version 0 `trun`, where ISO/IEC 14496-12 8.8.8.2 defines
+				// the field as UNSIGNED -- so a negative offset goes out as
+				// 0xFFFFFFF6 and the fragment writer refuses the fragment it is
+				// about to emit. That refusal is -11800 / -16341, raised from the
+				// single site in MediaToolbox that writes moof/traf/trun, which is
+				// why it appears if and only if movieFragmentInterval is set and
+				// lands exactly on a fragment boundary.
+				//
+				// Turning reordering off makes every offset zero and PTS == DTS, so
+				// the fragment stays representable. A screen recorder gives up
+				// nothing for it: B-frames buy compression on lookahead-friendly
+				// content and cost encode latency, which is the wrong trade for
+				// real-time capture. Measured on macOS 26.5 / M1, 1080p30 with
+				// system audio: with reordering the writer dies after 1-2s, without
+				// it a 43.6s take stops clean and a SIGKILL at 25s still leaves 27
+				// readable `moof` fragments.
+				AVVideoAllowFrameReorderingKey: false,
 			],
 		]
 		let input = AVAssetWriterInput(mediaType: .video, outputSettings: settings)

--- a/electron/native/screencapturekit/Sources/OpenScreenScreenCaptureKitHelper/ScreenCaptureRecorder.swift
+++ b/electron/native/screencapturekit/Sources/OpenScreenScreenCaptureKitHelper/ScreenCaptureRecorder.swift
@@ -332,13 +332,22 @@ final class ScreenCaptureRecorder: NSObject, SCStreamOutput, SCStreamDelegate {
 	/// said so at finishWriting(). The Windows helper checks every WriteSample
 	/// HRESULT and escalates; this is the macOS half of the same contract -- report
 	/// once, at the append that actually failed, carrying the live writer.error.
+	///
+	/// Deliberately not the code finishWriter() emits, and the difference is load
+	/// bearing. That one is the terminal result of stopping, and the Electron side
+	/// settles its stop on exactly one of `recording-stopped` or `writer-failed`.
+	/// Give both sites the same code behind this one-shot guard and a writer that
+	/// died mid-capture emits nothing at all at stop, so the stop promise never
+	/// settles and every failure becomes the "Saving..." hang instead of an error.
+	/// This event answers "when did the writer die"; that one answers "did stopping
+	/// work". Two questions, two codes.
 	private func reportWriterFailure(_ stage: String) {
 		guard !didReportWriterFailure, let writer else {
 			return
 		}
 		didReportWriterFailure = true
 		emitError(
-			code: "writer-failed",
+			code: "writer-failed-during-capture",
 			message: "\(stage): "
 				+ (writer.error.map { "\($0)" }
 					?? "AVAssetWriter status \(writer.status.rawValue)"),
@@ -493,10 +502,18 @@ final class ScreenCaptureRecorder: NSObject, SCStreamOutput, SCStreamDelegate {
 				// the fragment stays representable. A screen recorder gives up
 				// nothing for it: B-frames buy compression on lookahead-friendly
 				// content and cost encode latency, which is the wrong trade for
-				// real-time capture. Measured on macOS 26.5 / M1, 1080p30 with
-				// system audio: with reordering the writer dies after 1-2s, without
-				// it a 43.6s take stops clean and a SIGKILL at 25s still leaves 27
-				// readable `moof` fragments.
+				// real-time capture.
+				//
+				// Measured on macOS 26.5 / M1, 1080p with system audio. How reliably
+				// the bug bites scales with append rate, so quote the rate with the
+				// result: at ~57 fps, the rate the app actually drives, reordering
+				// on dies at 13.0s while reordering off stops clean at 31.6s; at
+				// 30 fps it is intermittent, dying at 1.0s and 2.0s but once
+				// surviving 22.2s. That intermittency is why the byte-level evidence
+				// leads here and the run counts only corroborate: the offsets are
+				// out of spec in every fragmented file whether or not that
+				// particular run happened to die. Reordering off is 3/3 clean across
+				// both rates, and a SIGKILL at 25s still leaves 27 readable `moof`.
 				AVVideoAllowFrameReorderingKey: false,
 			],
 		]


### PR DESCRIPTION
Fixes the macOS half of `a6795d23`. Test results that found it: #374.

## What was broken

`a6795d23` gave macOS the same crash-resilience Windows got, in one line: `movieFragmentInterval`. On macOS that line destroyed recordings. Capture stopped while the HUD counted on, and stop answered `AVFoundationErrorDomain -11800` / `-16341`, so the take was discarded — no sidecars, no editor. Six takes on the shipped rc.1 lost **~530 MB of decodable video** between them.

## Root cause

Not the container, and not the timestamps — every sample file has strictly monotonic DTS. The defect is in the fragment bytes:

- every `trun` goes out **version 0** carrying composition offsets like `0xFFFFFFF6`, which is **−10 reinterpreted**
- ISO/IEC 14496-12 §8.8.8.2 defines that field as **unsigned** in version 0, signed only in version 1
- offsets are negative only because the encoder reorders frames, and it reorders because `AVVideoAllowFrameReorderingKey` is never set — so it runs High profile with `has_b_frames=2`

`-16341` is emitted from **exactly one site** in MediaToolbox, inside the function that writes `moof`/`mfhd`/`traf`/`trun`. Hence the failure requires `movieFragmentInterval` to exist at all, and lands on fragment boundaries — the two audio failures hit at **1.0 s and 2.0 s** against a 1 s interval.

Turning reordering off makes every offset zero and `PTS == DTS`, so the fragment becomes representable. A screen recorder pays nothing for it: B-frames buy compression on lookahead-friendly content and cost encode latency, the wrong trade for real-time capture.

## Measured

macOS 26.5 / M1, 1080p with system audio. **The failure is probabilistic and scales with append rate**, so the frame rate is quoted with every number:

| Frame rate | Reordering ON | Reordering OFF (this PR) |
|---|---|---|
| **~57 fps** (the rate the app drives) | dies at **13.0 s** | clean **31.6 s** |
| 30 fps | dies at 1.0 s, 2.0 s — but once survived 22.2 s | clean 43.6 s, 43.7 s |

Byte-level, on the fixed build: `has_b_frames` 2 → **0**, `pts != dts` **0 / 1794**.

Crash-resilience actually works now, which it never did on macOS: **SIGKILL at 25 s leaves 27 `moof`**, decodes clean (`ffmpeg -v error -f null -` exit 0) and recovers **28.01 s** with both tracks.

> **On the run counts.** An earlier revision of this PR claimed a clean 2/2-vs-3/3 A/B. Rebuilding the with-reordering arm while answering review showed it surviving 22.2 s at settings that had killed it twice, so those counts are a sample, not a law. The case rests on the bytes — offsets unrepresentable in a v0 `trun` in *every* fragmented file, whether or not that run happened to die — with the runs as corroboration.

## Second change

A failed `AVAssetWriter` keeps accepting appends and keeps answering `false`. The helper discarded that Bool after the first frame and read `writer.status` only in `finishWriter()` — the entire reason the HUD counted to `02:02` over a writer that died at `00:04`. The Windows helper checks every `WriteSample` HRESULT and escalates (`mf_encoder.cpp:1551`, `main.cpp:999-1007`).

The two reporting sites carry **different codes on purpose**:

- `writer-failed-during-capture` — diagnostic: when the writer died
- `writer-failed` — terminal: whether stopping worked

`handlers.ts:1487-1493` settles the stop promise on exactly one of `recording-stopped` or `writer-failed`. Giving both sites one code behind a one-shot guard would mean a writer that died mid-capture emits nothing at stop, so the promise never settles and every failure becomes the "Saving…" hang. Verified by putting the bug back: a failing run emits exactly one of each.

It deliberately does not abort the capture — handlers.ts tears its error listener down once `recording-started` arrives, so acting on this mid-recording is a TypeScript change for its own commit.

## Does this affect Windows?

**No.** Windows already enforces the invariant macOS lacked, twice independently — `main.cpp:999-1003` and `mf_encoder.cpp:573-575` — and its audio is a synthesized sample counter, not a device clock.

## Not covered

- **End-to-end in the packaged app.** macOS protects Developer ID bundles in `/Applications`, so the helper could not be swapped in place. Verification is at helper level, driven from the shell with the exact JSON contract the app sends. **A CI build should re-run the checklist's recording section before rc.2 ships.**
- **Microphone**: this Mac has no input device. The mechanism is the video track's composition offsets, so a mic track should be unaffected — untested.
- A regression test asserting `has_b_frames == 0` and `moof > 0` after a kill would be cheap, alongside the existing truncation test.