### PR TITLE
chore(release): set main to 1.9.5

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -37,7 +37,7 @@ buildNpmPackage {
       );
     };
 
-  npmDepsHash = "sha256-I0UeoZ8kWHwg2dZDHhCjBIo5BkPWi5c0DwrMywiphIo=";
+  npmDepsHash = "sha256-fBNFOicysW5FAbPERqzXUzIcQ0C+ICsQFtGt1agF1VI=";
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "openscreen",
-	"version": "1.9.2",
+	"version": "1.9.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "openscreen",
-			"version": "1.9.2",
+			"version": "1.9.5",
 			"dependencies": {
 				"@fix-webm-duration/fix": "^1.0.1",
 				"@langchain/anthropic": "^1.3.26",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "openscreen",
 	"private": true,
-	"version": "1.9.2",
+	"version": "1.9.5",
 	"type": "module",
 	"packageManager": "npm@10.9.4",
 	"engines": {


### PR DESCRIPTION
Replaces the sync PR the promote workflow opened (#377), which should be **closed rather than merged**.

## Why not merge #377

`v1.9.5` was built entirely from cherry-picks off `main`, so main already has every byte of the release. Proven rather than assumed — `git diff main v1.9.5` is empty across every path except `package.json`, `package-lock.json`, and the files belonging to `210e5da2`, which main has *extra*:

```
$ git diff --stat main v1.9.5 -- . ':!package.json' ':!package-lock.json' \
    ':!src/components/ai-edition/Modals.tsx' \
    ':!src/components/ai-edition/NewEditorShell.tsx' \
    ':!src/components/ai-edition/OpenProjectModal.test.tsx' ':!src/i18n/locales'
(empty)
```

A rebase-merge of #377 would nonetheless replay **26 commits**, 23 of them cherry-picks main already carries under different SHAs. One of those, `db101b91` (*import a recording once*), touches `src/components/ai-edition/NewEditorShell.tsx` — **the same file `210e5da2` changed after the release branch forked**. Replaying a pre-`210e5da2` version of that file on top of a post-`210e5da2` main is how a sync silently drops the newer change, and the promote workflow's own rebase already failed five times against exactly this. `feat(editor): delete a project from the Open project dialog` is deliberately held back for 1.10 and has to survive.

GitHub reports #377 as `MERGEABLE`, but that flag describes a three-way merge; this repo rebase-merges, which is the operation that failed.

## What this does instead

Sets `package.json` and `package-lock.json` to `1.9.5` via the repo's own `set-release-version.mjs` — the one thing main actually lacks. Two files, three lines.

Release is out: `v1.9.5` tagged at `afbfb7bb`, build green, artifacts published.

<!-- discord-thread-id:1537923560968814624 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the application version to 1.9.5.
  - Refreshed release packaging metadata to support the updated version.

No new user-facing features or behavioral changes are included in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->