### PR TITLE
fix(store): the option is --inputDirectory, and it takes a directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1007,7 +1007,7 @@ jobs:
 
       # `msstore publish` takes a PROJECT root, not a package: it detects the app
       # type there (Electron, via package.json) and only then accepts the built
-      # package through `--inputFile`. This job used to check nothing out, so
+      # package through `--inputDirectory`. This job used to check nothing out, so
       # there was no project to point it at. Checkout runs before the artifact
       # download on purpose — actions/checkout cleans the workspace, and would
       # delete the package if it ran after.
@@ -1058,8 +1058,11 @@ jobs:
           # The positional argument is the project root, NOT the package — passing
           # the .appx there is what failed the first real run of this job on
           # v1.9.5: "We could not find a project publisher for the project at
-          # ...Openscreen.Setup.1.9.5.appx". The package goes through --inputFile.
-          msstore publish . --inputFile $appx.FullName --appId $env:PRODUCT_ID
+          # ...Openscreen.Setup.1.9.5.appx". The package goes through the option
+          # below, which takes the DIRECTORY holding it — the CLI's own usage
+          # says `-i, --inputDirectory`, and rejects the `--inputFile` that
+          # Microsoft Learn documents. The binary wins.
+          msstore publish . --inputDirectory $appx.Directory.FullName --appId $env:PRODUCT_ID
 
       # Report what happened, not what was configured. Keyed off `enabled` alone
       # under always(), this claimed "Submitted to the Store" when `msstore

--- a/.github/workflows/publish-msstore.yml
+++ b/.github/workflows/publish-msstore.yml
@@ -188,9 +188,12 @@ jobs:
 
           # The positional argument is the project root, NOT the package: passing
           # the package there is what failed v1.9.5 ("could not find a project
-          # publisher"). The package goes through --inputFile.
+          # publisher"). The package goes through the option below, which takes
+          # the DIRECTORY holding it: the CLI's own usage says
+          # `-i, --inputDirectory`, and rejects the `--inputFile` that Microsoft
+          # Learn documents. The v1.9.5 dry run is what caught that.
           # Not $args: that is a PowerShell automatic variable.
-          $cmdArgs = @('publish', '.', '--inputFile', $pkg.FullName, '--appId', $env:PRODUCT_ID)
+          $cmdArgs = @('publish', '.', '--inputDirectory', $pkg.Directory.FullName, '--appId', $env:PRODUCT_ID)
           if ($env:DRY_RUN -eq 'true') {
             # Leaves the submission in draft instead of sending it to
             # certification: the only way to test this path without shipping.


### PR DESCRIPTION
The dry run from #380 paid for itself immediately.

## What it found

```
DRY RUN: submitting Openscreen.Setup.1.9.5.appx as a draft only
Unrecognized command or argument '--inputFile'.
```

The CLI then printed its usage, which **disagrees with the published documentation**:

```
-i, --inputDirectory <inputDirectory>   The directory where the '.msix' or
                                        '.msixupload' file to be used for the
                                        publishing command...
```

[Microsoft Learn](https://learn.microsoft.com/en-us/windows/apps/publish/msstore-dev-cli/commands) documents `-i, --inputFile`, *"the path to the '.msix' or '.msixupload' file"*. The binary that `microsoft/microsoft-store-apppublisher@v1.1` installs takes **`--inputDirectory`** and wants the **folder**. I wrote #379 from the documentation; the binary is what runs.

Corrected at both call sites — `build.yml` carried the same mistake, since that is where the first fix landed.

## Everything else on that run worked

Tag validated · configuration resolved · tag checked out · build run resolved **and matched by `head_sha`** · artifact downloaded · CLI configured · submission reached the point of parsing its own arguments. Only the option name was wrong.

So this is the last known unknown before the open `.appx` question — the usage text still says `.msix`/`.msixupload`, and we produce `.appx`. The next dry run answers it the same cheap way, in about ninety seconds, without putting anything in front of users.

## The point worth keeping

This is precisely the failure the dry run existed to absorb. Without it, the "fix" from #379 would have been discovered broken by the **next stable release** — after a full build, after the release was published, and with the same unusable retry story that started all of this.

Both workflows re-validated: YAML parses, all bash steps pass `bash -n`, `publish-msstore.yml`'s pwsh block parses clean. (`build.yml`'s submit block cannot be parsed standalone — it interpolates four `${{ secrets.* }}` into the script, which Actions substitutes before pwsh sees them.)

<!-- discord-thread-id:1537967654403444757 -->