### PR TITLE
ci(aur): say which key AUR refused, instead of just that it refused one

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -370,6 +370,28 @@ jobs:
             UserKnownHostsFile ~/.ssh/aur_known_hosts
           SSHCONF
 
+      # "Permission denied (publickey)" is the same message for three different
+      # problems: a secret that is not a readable key, a key nobody registered
+      # on AUR, and a key whose account is not a maintainer of this package.
+      # v1.9.1, v1.9.2 and v1.9.5 all died here and none of them said which.
+      # A public key is public, so printing it costs nothing and lets the value
+      # CI presents be compared against what is on the account; `ssh -T` is the
+      # decisive one, because AUR answers it by naming the user it authenticated.
+      - name: Identify the key AUR sees
+        if: steps.aur_secret.outputs.configured == 'true' && !inputs.dry_run
+        continue-on-error: true
+        run: |
+          if ! ssh-keygen -y -f ~/.ssh/aur_key > /tmp/aur_key.pub 2>/tmp/aur_key.err; then
+            echo "::error::AUR_SSH_PRIVATE_KEY is not a readable private key: $(cat /tmp/aur_key.err)"
+            exit 0
+          fi
+          echo "Public key this workflow presents:"
+          cat /tmp/aur_key.pub
+          ssh-keygen -lf /tmp/aur_key.pub || true
+          echo "--- what AUR says about it ---"
+          # Exits non-zero by design (interactive shell disabled); the message is the payload.
+          ssh -o BatchMode=yes -T aur@aur.archlinux.org 2>&1 || true
+
       - name: Commit and push
         if: steps.aur_secret.outputs.configured == 'true' && !inputs.dry_run
         working-directory: aur-repo

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -366,20 +366,33 @@ jobs:
             HostName aur.archlinux.org
             User aur
             IdentityFile ~/.ssh/aur_key
+            # Offer this key and nothing else. Without it ssh walks whatever
+            # else it can find first, and AUR can refuse on a key that is not
+            # the one being diagnosed -- so the probe below would be reporting
+            # on a different identity than the push. It is also the standard
+            # cause of "permission denied" against AUR with more than one key.
+            IdentitiesOnly yes
             StrictHostKeyChecking yes
             UserKnownHostsFile ~/.ssh/aur_known_hosts
           SSHCONF
 
       # "Permission denied (publickey)" is the same message for three different
       # problems: a secret that is not a readable key, a key nobody registered
-      # on AUR, and a key whose account is not a maintainer of this package.
-      # v1.9.1, v1.9.2 and v1.9.5 all died here and none of them said which.
-      # A public key is public, so printing it costs nothing and lets the value
-      # CI presents be compared against what is on the account; `ssh -T` is the
-      # decisive one, because AUR answers it by naming the user it authenticated.
+      # on AUR, and a key registered to an account that does not maintain this
+      # package. v1.9.1, v1.9.2 and v1.9.5 all died here and none said which.
+      #
+      # This narrows it by elimination rather than proving the last one. A
+      # public key is public, so printing it costs nothing and lets what CI
+      # presents be compared against what is on the account. `help` is the
+      # documented way to test AUR auth without pushing: if it answers, the key
+      # parses AND is registered, so only authorization for ${PACKAGE} is left.
+      # Its reply also enumerates the commands the account may run, which is
+      # where to look for a repo-listing one if this needs to go further.
       - name: Identify the key AUR sees
         if: steps.aur_secret.outputs.configured == 'true' && !inputs.dry_run
         continue-on-error: true
+        env:
+          PACKAGE: ${{ vars.AUR_PACKAGE_NAME }}
         run: |
           if ! ssh-keygen -y -f ~/.ssh/aur_key > /tmp/aur_key.pub 2>/tmp/aur_key.err; then
             echo "::error::AUR_SSH_PRIVATE_KEY is not a readable private key: $(cat /tmp/aur_key.err)"
@@ -388,9 +401,11 @@ jobs:
           echo "Public key this workflow presents:"
           cat /tmp/aur_key.pub
           ssh-keygen -lf /tmp/aur_key.pub || true
-          echo "--- what AUR says about it ---"
-          # Exits non-zero by design (interactive shell disabled); the message is the payload.
-          ssh -o BatchMode=yes -T aur@aur.archlinux.org 2>&1 || true
+          echo "--- what AUR says about it (auth only; NOT write access to ${PACKAGE}) ---"
+          # Bounded: a diagnostic must never be the thing that hangs a release.
+          # Exits non-zero by design; the message is the payload.
+          timeout -k 5 30 ssh -o BatchMode=yes -o ConnectTimeout=10 \
+            aur@aur.archlinux.org help 2>&1 || true
 
       - name: Commit and push
         if: steps.aur_secret.outputs.configured == 'true' && !inputs.dry_run


### PR DESCRIPTION
## The answer to "did AUR work?"

No. `v1.9.5` ran the workflow (the RCs were correctly skipped) and failed at the very last step:

```
[master 32875d1] Bump to 1.9.5
 2 files changed, 9 insertions(+), 9 deletions(-)
aur@aur.archlinux.org: Permission denied (publickey).
```

Everything before it worked: tag resolved · `.pacman` asset found · AUR repo cloned · PKGBUILD audited · version and every checksum recomputed · `.SRCINFO` regenerated · diff verified · commit created. The pipeline is correct. Only authentication fails — and `v1.9.1` and `v1.9.2` failed identically.

## Why we still cannot say more than that

`Permission denied (publickey)` is one message for three different problems:

1. `AUR_SSH_PRIVATE_KEY` is not a readable private key (wrong format, mangled newlines).
2. The key is fine but was never registered on the AUR account.
3. The key is registered, but that account is not a maintainer of `openscreen` and cannot write to it.

A public key was added upstream and this still fails, which makes the interesting question *"is the key CI presents the same one that was added?"* — and nothing in the workflow can answer it. There is no `ssh-keygen`, no fingerprint, no `-v` anywhere in the file.

## What this adds

One `continue-on-error` step, on the real path, after the existing key-touches-disk-last step:

- `ssh-keygen -y` on the secret — proves it parses, and prints the **public** key plus fingerprint. A public key is public; printing it is exactly how you compare what CI presents against what is on the account.
- `ssh -T aur@aur.archlinux.org` — the decisive probe. AUR answers by **naming the account it authenticated**, which separates case 3 from cases 1 and 2 in one line.

Deliberately **not** moved into `dry_run`: that mode never writes the key to disk and its summary says so, which is a property worth keeping. Re-running for real is safe anyway — a refused push does not touch AUR, and the commit is local to the runner.

## Next step

Merge, then dispatch `aur-publish.yml` with `tag: v1.9.5`. It will either push (if the key was fixed in the meantime) or fail again — but this time the log names the key and the account, which is what Dark needs to check the registration against.

<!-- discord-thread-id:1538122426146226287 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved package publishing diagnostics by displaying the deployment key’s public key and fingerprint.
  * Added a non-blocking authentication check to help verify publishing access before release.
  * Authentication troubleshooting details are now clearer without interrupting the publishing workflow when validation encounters an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->