### PR TITLE
fix(windows): recover HUD input forwarding after startup

### DIFF
--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -294,7 +294,17 @@ export function createHudOverlayWindow(): BrowserWindow {
 	// window is shown before its first paint.
 	win.once("ready-to-show", () => {
 		applyContentProtection(win, "HUD");
-		if (!HEADLESS) win.show();
+		if (!HEADLESS) {
+			win.show();
+			// Re-arm click-through after the window is visible. On Windows, the
+			// forwarded-mouse hook can be installed too early when the renderer's
+			// initial IPC request arrives while Chromium is still starting up. If
+			// that request is the only call, the HUD is painted but every control
+			// remains unreachable because no forwarded pointermove can turn input
+			// back on. A post-ready call runs after the native window is live and
+			// gives Electron a reliable chance to install the hook.
+			win.setIgnoreMouseEvents(true, { forward: true });
+		}
 	});
 
 	win.webContents.on("did-finish-load", () => {


### PR DESCRIPTION
## Summary

Re-arm the HUD's forwarded-mouse hook after the Electron window becomes visible. On Windows, the initial renderer IPC request can arrive before the native window is fully ready; if hook installation fails at that point, the HUD remains visible but all controls are unreachable.

## Related issue

Refs #385

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact

- [x] Patch
- [ ] Minor
- [ ] Major / breaking change
- [ ] No release note needed

## Desktop impact

- [x] Windows
- [ ] macOS
- [ ] Linux
- [x] Installer / packaging
- [ ] Not platform-specific

## Testing

- `npx tsc --noEmit` — passed
- `npx tsc -p tsconfig.test.json --noEmit` — passed
- `npx biome check --formatter-enabled=false electron/windows.ts src/components/launch/LaunchWindow.tsx src/components/launch/LaunchWindow.test.tsx` — passed
- `npx vitest --run src/components/launch/LaunchWindow.test.tsx` — 32 tests passed
- `npm run build-vite` — passed
- `npm run test` — 1,769 passed, 16 failed, 2 skipped. The 16 failures are pre-existing jsdom test failures under the local Node 25 environment (\`localStorage.clear/removeItem is not a function\` in four unrelated test suites); no Electron test suites failed after installing the Electron binary.
- Local macOS development smoke test — HUD rendered, the system-language notice was visible and dismissible, and the toolbar was reachable.

<!-- discord-thread-id:1538757346690469889 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HUD window initialization in headless mode.
  * Ensured click-through behavior is correctly reapplied after the window becomes visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->