### PR TITLE
chore(release): set main to 1.9.6

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -37,7 +37,7 @@ buildNpmPackage {
       );
     };
 
-  npmDepsHash = "sha256-1fer91zZlZxC5SoIj3F/bNcLoD+Q+QxLpCZF067Upko=";
+  npmDepsHash = "sha256-Vr6Sw/WKmX22eT4a22+Xr3/miMzZr2uAwiYx12toU/E=";
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "openscreen",
-	"version": "1.9.5",
+	"version": "1.9.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "openscreen",
-			"version": "1.9.5",
+			"version": "1.9.6",
 			"dependencies": {
 				"@fix-webm-duration/fix": "^1.0.1",
 				"@langchain/anthropic": "^1.3.26",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "openscreen",
 	"private": true,
-	"version": "1.9.5",
+	"version": "1.9.6",
 	"type": "module",
 	"packageManager": "npm@10.9.4",
 	"engines": {


### PR DESCRIPTION
## Summary

`v1.9.6` is tagged and building; `main` was still declaring `1.9.5`. This sets it to `1.9.6` — the same move as [`a0eca303`](https://github.com/getopenscreen/openscreen/commit/a0eca303) after the previous release, and written by the same script `promote.yml` itself uses (`.github/scripts/set-release-version.mjs`), so `package-lock.json` is updated alongside `package.json` instead of being left behind.

### Why this isn't just merging #392

`promote.yml` opened #392 (`release/v1.9.6-sync` → `main`) and failed to rebase-merge it after five attempts, with the advice "merge it by hand". **It should be closed, not merged.**

`release/v1.9.6` was cut from the **v1.9.5 tag**, whose content `main` already carries under different SHAs from the earlier rebase-merge. So the PR arrives with 39 commits, 23 of which are content-duplicates — which is why the rebase-merge could never land. And its net diff against `main` is a *reversion*:

```
electron/auto-updater.ts                     |  92 ------
electron/install-channel.ts                  | 146 ------
electron/update-checker.ts                   | 164 ------
scripts/mac-update-feed.mjs                  | 105 ------
.github/workflows/build.yml                  | 111 +-----
src/.../OpenProjectModal.test.tsx            |  79 ------
                46 files changed, 106 insertions(+), 1889 deletions(-)
```

That is the entire updater stack, the editor's delete-project test, and 111 lines of `build.yml` — everything that landed on `main` after v1.9.5 and was deliberately held out of the 1.9.6 patch release. The conflict was load-bearing; it stopped a silent revert.

The version bump is the only part of #392 that `main` actually wants, and it is here.

## Related issue

Refs #385

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation
- [x] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [ ] Patch
- [ ] Minor
- [ ] Major / breaking change
- [x] No release note needed

## Desktop impact
- [ ] Windows
- [ ] macOS
- [ ] Linux
- [ ] Installer / packaging
- [x] Not platform-specific

## Screenshots / video

n/a

## Testing

`node .github/scripts/set-release-version.mjs 1.9.6` — the script `promote.yml` runs. Verified all three version fields afterwards:

```
package.json          : 1.9.6
package-lock.json root: 1.9.6
package-lock packages[""]: 1.9.6
```

No source change, so no test run is meaningful beyond CI. Note the lockfile version change is exactly what invalidates `nix/package.nix`'s `npmDepsHash`; `bump-nix-package.yml` opens that fix against `main` on `release: published`, as it does for every release.

<!-- discord-thread-id:1539395842300059730 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the package to version 1.9.6.
  * Updated packaging metadata to reflect the current dependency set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->