### PR TITLE
fix(store): pin msstore-cli, whose v0.4.0 cancels every upload instantly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1168,7 +1168,11 @@ jobs:
           # below, which takes the DIRECTORY holding it — the CLI's own usage
           # says `-i, --inputDirectory`, and rejects the `--inputFile` that
           # Microsoft Learn documents. The binary wins.
-          msstore publish . --inputDirectory $appx.Directory.FullName --appId $env:PRODUCT_ID
+          # -v for the same reason as the retry workflow: without it an upload
+          # failure is the bare line "Error while uploading the application package."
+          # with no status code, no URL and no body. This is the path a real release
+          # takes, so it is the path that most needs to be diagnosable.
+          msstore publish . --inputDirectory $appx.Directory.FullName --appId $env:PRODUCT_ID -v
 
       # Report what happened, not what was configured. Keyed off `enabled` alone
       # under always(), this claimed "Submitted to the Store" when `msstore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1128,6 +1128,17 @@ jobs:
       - name: Configure Microsoft Store CLI
         if: steps.store.outputs.enabled == 'true'
         uses: microsoft/microsoft-store-apppublisher@v1.1
+        # PINNED, and it has to stay pinned. The action defaults to `latest`, and
+        # msstore-cli v0.4.0 (published 2026-08-18, the first release since v0.3.9
+        # in January) ships an Azure SDK client whose `ClientOptions.Retry.NetworkTimeout`
+        # is 0:00:00 — every blob upload is cancelled the instant it starts. The CLI
+        # reports that as "Error while uploading the application package.", so the
+        # submission is created and configured and then dies at "Uploading Bundle to
+        # Azure blob: 0%", six instant retries later. v1.9.6 hit it three times in a
+        # row; the same package and account had submitted fine on v0.3.9 three days
+        # earlier. Unpin only against a CLI release that fixes the timeout.
+        with:
+          version: v0.3.9
 
       - name: Submit the package to the Store
         id: submit

--- a/.github/workflows/publish-msstore.yml
+++ b/.github/workflows/publish-msstore.yml
@@ -193,7 +193,10 @@ jobs:
           # `-i, --inputDirectory`, and rejects the `--inputFile` that Microsoft
           # Learn documents. The v1.9.5 dry run is what caught that.
           # Not $args: that is a PowerShell automatic variable.
-          $cmdArgs = @('publish', '.', '--inputDirectory', $pkg.Directory.FullName, '--appId', $env:PRODUCT_ID)
+          # -v is not decoration: without it the CLI reports upload failures as the
+          # bare line 'Error while uploading the application package.' with no status
+          # code, no URL and no body, which is what made v1.9.6 undiagnosable.
+          $cmdArgs = @('publish', '.', '--inputDirectory', $pkg.Directory.FullName, '--appId', $env:PRODUCT_ID, '-v')
           if ($env:DRY_RUN -eq 'true') {
             # Leaves the submission in draft instead of sending it to
             # certification: the only way to test this path without shipping.

--- a/.github/workflows/publish-msstore.yml
+++ b/.github/workflows/publish-msstore.yml
@@ -159,6 +159,17 @@ jobs:
 
       - name: Configure Microsoft Store CLI
         uses: microsoft/microsoft-store-apppublisher@v1.1
+        # PINNED, and it has to stay pinned. The action defaults to `latest`, and
+        # msstore-cli v0.4.0 (published 2026-08-18, the first release since v0.3.9
+        # in January) ships an Azure SDK client whose `ClientOptions.Retry.NetworkTimeout`
+        # is 0:00:00 — every blob upload is cancelled the instant it starts. The CLI
+        # reports that as "Error while uploading the application package.", so the
+        # submission is created and configured and then dies at "Uploading Bundle to
+        # Azure blob: 0%", six instant retries later. v1.9.6 hit it three times in a
+        # row; the same package and account had submitted fine on v0.3.9 three days
+        # earlier. Unpin only against a CLI release that fixes the timeout.
+        with:
+          version: v0.3.9
 
       - name: Submit the package to the Store
         id: submit


### PR DESCRIPTION
## Summary

v1.9.6's Store submission failed three times in a row, always at the same place: submission created, bundle prepared, then `Uploading Bundle to Azure blob: 0%` and `Error while uploading the application package.` about 22 s later. Same `.appx` (335 MB — byte-for-byte the size that shipped for 1.9.5), same product, same command, and the identical submission had **succeeded on 2026-08-15**.

**Two commits: one makes the failure legible, one fixes it.**

### 1. `-v`, because the CLI otherwise tells you nothing

Without it the entire diagnosis is one unqualified sentence with no status code, no URL and no body. With it:

```
Retry failed after 6 tries.
The operation was cancelled because it exceeded the configured timeout of 0:00:00.
Network timeout can be adjusted in ClientOptions.Retry.NetworkTimeout.
```

`NetworkTimeout` is **zero**, so every request is cancelled the instant it starts. Six instant retries is the whole 22 seconds — nothing was ever put on the wire, which is why no HTTP status appears anywhere in the failure.

### 2. Pin the CLI

The variable was never ours. `microsoft/microsoft-store-apppublisher` defaults to `version: latest`, and **msstore-cli `v0.4.0` was published 2026-08-18T09:09Z** — the first release since `v0.3.9` in January, and hours before the first failure. The 15 August success ran `v0.3.9`.

Pinned to `v0.3.9` in **both** places that configure the CLI — `publish-msstore.yml` and `build.yml`'s `publish-msstore` job. Pinning only one would leave the release path broken while the retry path worked, which is the worst kind of half-fix to debug later.

## Related issue

Refs #385 — the reporter installed from the Store, so this is the last thing standing between that fix and them.

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [ ] Patch
- [ ] Minor
- [ ] Major / breaking change
- [x] No release note needed

## Desktop impact
- [ ] Windows
- [ ] macOS
- [ ] Linux
- [x] Installer / packaging
- [ ] Not platform-specific

## Screenshots / video

n/a — CI only.

## Testing

Proven end to end by dispatching `publish-msstore.yml` on this branch (`workflow_dispatch` takes any ref, so no merge was needed to test it) against the real `v1.9.6` tag with `dry_run=false`:

```
Uploading Bundle to Azure blob: 13%
Uploading Bundle to Azure blob: 76%
✅ Successfully uploaded the application package.
Submission Committed - Status=CommitStarted
Submission commit success!
SUBMIT: success
```

Run [32196525978](https://github.com/getopenscreen/openscreen/actions/runs/32196525978), 7m52s. **v1.9.6 is now submitted and in certification** — this PR is what stops the next release hitting the same wall.

The three failures for the record: [32190106274](https://github.com/getopenscreen/openscreen/actions/runs/32190106274) (in the release build), [32192781855](https://github.com/getopenscreen/openscreen/actions/runs/32192781855), [32194618175](https://github.com/getopenscreen/openscreen/actions/runs/32194618175).

<!-- discord-thread-id:1539416465550344324 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Microsoft Store package publishing reliability by using a verified publishing tool version.
  * Added detailed diagnostic output when uploads fail, including status information and service responses.

* **Chores**
  * Stabilized automated Microsoft Store release workflows with consistent publishing configuration.
  * Improved troubleshooting for failed package submissions by exposing more actionable upload details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->