### PR TITLE
fix(ai): restore the agent rollback a dead catch had silenced

### DIFF
--- a/src/components/ai-edition/LeftPanel.tsx
+++ b/src/components/ai-edition/LeftPanel.tsx
@@ -935,13 +935,23 @@ function ChatStripPanel() {
 						try {
 							return await applyDocument(options);
 						} catch (err) {
+							// Only `ensureDocument` still throws here -- the agent handed back
+							// something that is not a document. A failed WRITE does not reach this:
+							// the store reports it itself and `applyDocument` answers "save-failed".
 							toast.error(t("chat.applyEditsFailed"), {
 								description: err instanceof Error ? err.message : String(err),
 							});
-							return "conflict" as const;
+							return "malformed" as const;
 						}
 					};
-					if ((await applyEdits()) === "conflict") {
+					const applyResult = await applyEdits();
+					if (applyResult === "save-failed") {
+						// The store has already said WHY the write failed, with the native error.
+						// This says what it COST, without a description so the two do not repeat
+						// each other: the assistant's "done, I removed 14 silences" renders either
+						// way, so a bare save error next to it leaves the two unconnected.
+						toast.error(t("chat.applyEditsFailed"));
+					} else if (applyResult === "conflict") {
 						// The turn is not lost, it is just not automatically applied: the document
 						// is still in hand and the assistant's reply is about to be rendered as if
 						// the edits had landed. The thing that usually moves `revision` here is a

--- a/src/lib/ai-edition/store/agentDocumentApply.test.ts
+++ b/src/lib/ai-edition/store/agentDocumentApply.test.ts
@@ -51,18 +51,34 @@ describe("applyAgentDocumentIfCurrent", () => {
 		expect(useProjectStore.getState().document?.project.title).toBe("Manual edit");
 	});
 
-	it("puts the document back when the save fails", async () => {
+	it("puts the document back when the save fails, and does not call it applied", async () => {
 		// Without this the user is told the edits were rejected while looking at them, and
 		// `dirty` is left set -- so the next unrelated save writes the rejected document.
+		//
+		// `saveDocument` reports its own failures and resolves false rather than
+		// throwing. This was written against a `saveDocument` that threw, and the two
+		// changes landed minutes apart: a dead `catch` type-checks, so the rollback
+		// stopped firing and "applied" came back for a write that never happened.
 		const before = createEmptyDocument({ projectId: "project_1", title: "Before" });
 		const agentResult = { ...before, project: { ...before.project, title: "Agent edit" } };
 		useProjectStore.setState({ projectId: "project_1", document: before, revision: 4 });
 		saveMock.mockResolvedValue({ success: false, error: "EACCES" });
 
-		await expect(applyAgentDocumentIfCurrent(agentResult, 4)).rejects.toThrow("EACCES");
+		await expect(applyAgentDocumentIfCurrent(agentResult, 4)).resolves.toBe("save-failed");
 
 		expect(useProjectStore.getState().document?.project.title).toBe("Before");
 		expect(useProjectStore.getState().dirty).toBe(false);
+	});
+
+	it("still rejects when the agent hands back something that is not a document", async () => {
+		// The one throw left on this path, and the reason the caller keeps a try/catch.
+		const before = createEmptyDocument({ projectId: "project_1", title: "Before" });
+		useProjectStore.setState({ projectId: "project_1", document: before, revision: 4 });
+
+		await expect(applyAgentDocumentIfCurrent({ not: "a document" }, 4)).rejects.toThrow();
+
+		expect(useProjectStore.getState().document?.project.title).toBe("Before");
+		expect(saveMock).not.toHaveBeenCalled();
 	});
 
 	it("allows an explicit rewind to replace the current revision", async () => {

--- a/src/lib/ai-edition/store/agentDocumentApply.ts
+++ b/src/lib/ai-edition/store/agentDocumentApply.ts
@@ -2,7 +2,7 @@ import type { AxcutDocument } from "../schema";
 import { ensureDocument } from "../schema";
 import { useProjectStore } from "./projectStore";
 
-export type AgentDocumentApplyResult = "applied" | "conflict" | "no-live-document";
+export type AgentDocumentApplyResult = "applied" | "conflict" | "save-failed" | "no-live-document";
 
 /**
  * Apply a full document returned by the agent only if the live editor is still
@@ -29,22 +29,25 @@ export async function applyAgentDocumentIfCurrent(
 	// saveDocument, which sets `document` too" silently breaks Ctrl+Z after an agent edit.
 	// `saveDocument` is what reaches the disk.
 	store.setDocument(parsed);
-	try {
-		await store.saveDocument(parsed);
-	} catch (err) {
-		// The edits are on screen by now. Leaving them there while the caller toasts
-		// "could not apply the agent's edits" tells the user two opposite things at once,
-		// and worse: `dirty` is set, so the next unrelated save would quietly persist the
-		// document we just said was rejected.
-		//
-		// Restored through `setState` rather than `setDocument`, so the rejected document
-		// does not land on the undo stack. `revision` keeps the bump: it did move, and
-		// leaving it forward makes any in-flight guard read "conflict", which is the safe
-		// direction to be wrong in.
-		if (previous) useProjectStore.setState({ document: previous, dirty: previousDirty });
-		throw err;
-	}
-	return "applied";
+	if (await store.saveDocument(parsed)) return "applied";
+
+	// The edits are on screen by now. Leaving them there while the caller says they
+	// were not applied tells the user two opposite things at once, and worse: `dirty`
+	// is set, so the next unrelated save would quietly persist the document we just
+	// said was rejected.
+	//
+	// Restored through `setState` rather than `setDocument`, so the rejected document
+	// does not land on the undo stack. `revision` keeps the bump: it did move, and
+	// leaving it forward makes any in-flight guard read "conflict", which is the safe
+	// direction to be wrong in.
+	//
+	// A returned `false` and not a `catch`: `saveDocument` reports its own failures and
+	// never rejects. This was a `try`/`catch` when it was written, against a
+	// `saveDocument` that threw -- the two landed within minutes of each other, and a
+	// dead `catch` type-checks, so the rollback stopped firing and this returned
+	// "applied" for a write that never happened.
+	if (previous) useProjectStore.setState({ document: previous, dirty: previousDirty });
+	return "save-failed";
 }
 
 export interface AgentTurn<T> {


### PR DESCRIPTION
## Summary

`main` is red, and the failing test is pointing at a real regression.

#308 and #309 merged twelve seconds apart and their contracts disagree. #308 made `projectStore.saveDocument` return a boolean and never reject; #309 had wrapped that call in a `try`/`catch` to roll a rejected agent edit back. The `catch` is now unreachable. Nothing type-checks wrong, and neither PR's tests could see it — each was green against its own base.

What that shipped: an agent edit whose write fails stays on screen with `dirty` set, is never rolled back, and `applyAgentDocumentIfCurrent` returns `"applied"` for a write that never happened. The next unrelated save then persists the document the user was just told had been rejected — the exact failure #309 exists to prevent.

The check is on the returned `false` now, and **`"save-failed"` becomes its own result** rather than being folded into `"conflict"`. The two need different words: a conflict means the project moved and the turn is still in hand, so offering *Apply anyway* makes sense; a refused write means the disk said no, and retrying would just fail again.

`LeftPanel` says what it cost without repeating why — the store already toasted the native error — because the assistant's *"done, I removed 14 silences"* renders either way, and a bare save error next to it leaves the two unconnected. Its `catch` stays for the one throw left on this path (a malformed document from the agent) and no longer mislabels it a conflict.

I swept the rest of the tree for other catches the signature change left dead: this was the only one.

## Related issue

Refs #282, Refs #284 — the regression sits between the two PRs that closed them.

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [x] Patch
- [ ] Minor
- [ ] Major / breaking change
- [ ] No release note needed

## Desktop impact
- [ ] Windows
- [ ] macOS
- [ ] Linux
- [ ] Installer / packaging
- [x] Not platform-specific

## Screenshots / video

Not applicable — the visible change is a toast that names the agent's edits alongside the store's existing save-failure toast.

## Testing

- `npm run test` — 1889 passed, 5 skipped, 162 files (`main` is 1 failed / 1887 passed)
- `npx tsc --noEmit` and `npx tsc -p tsconfig.test.json --noEmit`
- `npx biome check src/ electron/` — 12 warnings, all pre-existing on `main`
- `npm run i18n:check`, `npm run docs:check`

Both halves are mutation-tested: removing the rollback fails the test, and returning `"applied"` without checking the boolean fails it too. A new case pins the one remaining throw — a malformed document from the agent still rejects, and does not reach `saveDocument`.

<!-- discord-thread-id:1539990288003633153 -->