### PR TITLE
feat(stt): surface transcription timing and backend, drop the dead --cuda variant

### DIFF
--- a/.github/workflows/build-whisper-stt.yml
+++ b/.github/workflows/build-whisper-stt.yml
@@ -10,21 +10,11 @@ name: Build whisper-stt binaries
 #
 # ponytail: one binary per platform is enough because whisper.cpp selects the
 # right backend at runtime (Metal on Apple Silicon, Vulkan on Windows/Linux,
-# CPU fallback when no GPU/driver is available). A CUDA variant is supported
-# by the build script but is not built by default; Vulkan already accelerates
-# NVIDIA cards.
+# CPU fallback when no GPU/driver is available). Vulkan already accelerates
+# NVIDIA cards, so there is no separate CUDA build.
 
 on:
   workflow_dispatch:
-    inputs:
-      enable_cuda:
-        description: "Also build a CUDA variant when the host has an nvcc toolchain"
-        required: false
-        default: "false"
-        type: choice
-        options:
-          - "true"
-          - "false"
   push:
     paths:
       - "scripts/build-whisper-stt.sh"
@@ -172,8 +162,6 @@ jobs:
             whisper-stt-build-${{ matrix.tag }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-
 
       - name: Run whisper-stt build script
-        env:
-          ENABLE_CUDA: ${{ github.event.inputs.enable_cuda || 'false' }}
         run: bash scripts/build-whisper-stt.sh
 
       - name: Stage binaries for upload

--- a/electron/stt/index.test.ts
+++ b/electron/stt/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
 import { planChunks } from "./chunking";
 import { _resetSttManagerForTests, SttManager } from "./index";
@@ -48,6 +48,9 @@ vi.mock("./gpuDetector", () => ({
 }));
 
 describe("SttManager", () => {
+	let infoSpy: MockInstance<typeof console.info>;
+	let warnSpy: MockInstance<typeof console.warn>;
+
 	beforeEach(() => {
 		fakeWhisperServer.start.mockClear();
 		fakeWhisperServer.transcribe.mockClear();
@@ -60,10 +63,17 @@ describe("SttManager", () => {
 			backend: "whispercpp-cpu",
 		});
 		_resetSttManagerForTests();
+		// The manager narrates every chunk (backend + timing) through `console.*`,
+		// which is what puts those lines in the main-process ring buffer. Capture
+		// them instead of letting a dozen lines per test onto the suite's output.
+		infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+		warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 	});
 
 	afterEach(() => {
 		_resetSttManagerForTests();
+		infoSpy.mockRestore();
+		warnSpy.mockRestore();
 	});
 
 	it("init() forwards model + transcribe phases to the sink", async () => {
@@ -126,6 +136,114 @@ describe("SttManager", () => {
 		for (let i = 1; i < progress.length; i++) {
 			expect(progress[i].completedSec).toBeGreaterThan(progress[i - 1].completedSec ?? -1);
 		}
+	});
+
+	/** The default fake answers without timing; this one measures every chunk. */
+	function mockTimedChunks(): void {
+		fakeWhisperServer.transcribe.mockResolvedValue({
+			segments: [],
+			wordSegments: [],
+			detectedLanguage: "en",
+			backend: "whispercpp-cpu",
+			timing: { elapsedSec: 45, audioSec: 90, rtf: 0.5 },
+		});
+	}
+
+	it("sums per-chunk timing into one figure for the whole run", async () => {
+		mockTimedChunks();
+		const samples = new Float32Array(200 * 16000);
+		const mgr = new SttManager();
+		await mgr.init({ modelsBaseDir: "/tmp/fake-stt-models" });
+		const result = await mgr.transcribe({ samples, language: "en" });
+
+		// Summed, not averaged: chunks differ in length, so the mean of the
+		// per-chunk RTFs would not be the RTF of the run.
+		const chunkCount = planChunks(samples, 16000).length;
+		expect(chunkCount).toBeGreaterThan(1);
+		expect(result.timing).toEqual({
+			elapsedSec: 45 * chunkCount,
+			audioSec: 90 * chunkCount,
+			rtf: 0.5,
+		});
+	});
+
+	it("logs the backend and the timing of every chunk", async () => {
+		mockTimedChunks();
+		const samples = new Float32Array(200 * 16000);
+		const mgr = new SttManager();
+		await mgr.init({ modelsBaseDir: "/tmp/fake-stt-models" });
+		await mgr.transcribe({ samples, language: "en" });
+
+		const chunkLines = infoSpy.mock.calls
+			.map(([line]) => String(line))
+			.filter((line) => line.startsWith("[stt] chunk "));
+		expect(chunkLines).toHaveLength(planChunks(samples, 16000).length);
+		// Both conventions on the line, so it can be read against the POC report
+		// without arithmetic.
+		expect(chunkLines[0]).toContain("whispercpp-cpu");
+		expect(chunkLines[0]).toContain("90.0s audio in 45.0s (0.50 rtf, 2.0x real-time)");
+	});
+
+	it("says so when the helper reports no timing at all", async () => {
+		// The default fake stands in for a staged binary older than the field.
+		const mgr = new SttManager();
+		await mgr.init({ modelsBaseDir: "/tmp/fake-stt-models" });
+		const result = await mgr.transcribe({ samples: new Float32Array(16000) });
+		expect(result.timing).toBeUndefined();
+		expect(infoSpy.mock.calls.some(([line]) => String(line).includes("no timing reported"))).toBe(
+			true,
+		);
+	});
+
+	it("puts the backend and a running rtf on every chunk's status event", async () => {
+		mockTimedChunks();
+		const samples = new Float32Array(200 * 16000);
+		const sink = vi.fn<(e: SttStatusEvent) => void>();
+		const mgr = new SttManager();
+		await mgr.init({ statusSink: sink, modelsBaseDir: "/tmp/fake-stt-models" });
+		sink.mockClear();
+		await mgr.transcribe({ samples, language: "en" });
+
+		// The response alone is too late to be a signal: it arrives once the whole
+		// recording is done, and the point is to explain the wait while it happens.
+		const reported = sink.mock.calls
+			.map(([event]) => event)
+			.filter((event) => event.backend !== undefined);
+		expect(reported).toHaveLength(planChunks(samples, 16000).length);
+		for (const event of reported) {
+			expect(event.backend).toBe("whispercpp-cpu");
+			expect(event.rtf).toBeCloseTo(0.5);
+		}
+	});
+
+	it("warns once per run — not once per chunk — that it landed on CPU", async () => {
+		mockTimedChunks();
+		const mgr = new SttManager();
+		await mgr.init({ modelsBaseDir: "/tmp/fake-stt-models" });
+		await mgr.transcribe({ samples: new Float32Array(200 * 16000), language: "en" });
+
+		const cpuWarnings = warnSpy.mock.calls
+			.map(([line]) => String(line))
+			.filter((line) => line.includes("running on CPU"));
+		expect(cpuWarnings).toHaveLength(1);
+	});
+
+	it("stays quiet about the backend when a GPU one is bound", async () => {
+		fakeWhisperServer.transcribe.mockResolvedValue({
+			segments: [],
+			wordSegments: [],
+			detectedLanguage: "en",
+			backend: "whispercpp-vulkan",
+			timing: { elapsedSec: 20, audioSec: 90, rtf: 20 / 90 },
+		});
+		const mgr = new SttManager();
+		await mgr.init({ modelsBaseDir: "/tmp/fake-stt-models" });
+		const result = await mgr.transcribe({ samples: new Float32Array(200 * 16000) });
+
+		expect(result.backend).toBe("whispercpp-vulkan");
+		expect(warnSpy.mock.calls.some(([line]) => String(line).includes("running on CPU"))).toBe(
+			false,
+		);
 	});
 
 	// Both spellings of "detect it for me". `"auto"` is the one the request

--- a/electron/stt/index.test.ts
+++ b/electron/stt/index.test.ts
@@ -138,15 +138,28 @@ describe("SttManager", () => {
 		}
 	});
 
+	// One per chunk of a 200s recording (90s + 90s + 20s), each with a DIFFERENT
+	// ratio on purpose. Identical chunks would let a wrong implementation pass:
+	// the arithmetic mean of these RTFs is 0.433, while the weighted figure the
+	// run should report is 75/200 = 0.375. Only unequal chunks tell them apart.
+	const CHUNK_TIMINGS = [
+		{ elapsedSec: 45, audioSec: 90, rtf: 0.5 },
+		{ elapsedSec: 18, audioSec: 90, rtf: 0.2 },
+		{ elapsedSec: 12, audioSec: 20, rtf: 0.6 },
+	];
+	const TOTAL_ELAPSED = 75;
+	const TOTAL_AUDIO = 200;
+
 	/** The default fake answers without timing; this one measures every chunk. */
 	function mockTimedChunks(): void {
-		fakeWhisperServer.transcribe.mockResolvedValue({
+		let call = 0;
+		fakeWhisperServer.transcribe.mockImplementation(async () => ({
 			segments: [],
 			wordSegments: [],
 			detectedLanguage: "en",
 			backend: "whispercpp-cpu",
-			timing: { elapsedSec: 45, audioSec: 90, rtf: 0.5 },
-		});
+			timing: CHUNK_TIMINGS[Math.min(call++, CHUNK_TIMINGS.length - 1)],
+		}));
 	}
 
 	it("sums per-chunk timing into one figure for the whole run", async () => {
@@ -158,13 +171,43 @@ describe("SttManager", () => {
 
 		// Summed, not averaged: chunks differ in length, so the mean of the
 		// per-chunk RTFs would not be the RTF of the run.
-		const chunkCount = planChunks(samples, 16000).length;
-		expect(chunkCount).toBeGreaterThan(1);
+		expect(planChunks(samples, 16000)).toHaveLength(CHUNK_TIMINGS.length);
 		expect(result.timing).toEqual({
-			elapsedSec: 45 * chunkCount,
-			audioSec: 90 * chunkCount,
-			rtf: 0.5,
+			elapsedSec: TOTAL_ELAPSED,
+			audioSec: TOTAL_AUDIO,
+			rtf: TOTAL_ELAPSED / TOTAL_AUDIO,
 		});
+		// Nail the distinction down rather than trusting the numbers to differ.
+		const mean = CHUNK_TIMINGS.reduce((sum, t) => sum + t.rtf, 0) / CHUNK_TIMINGS.length;
+		expect(result.timing?.rtf).not.toBeCloseTo(mean, 3);
+	});
+
+	it("reports no run timing at all when one chunk went unmeasured", async () => {
+		// A single chunk without a `timing` block is enough to spoil the totals:
+		// they would describe 110s of audio for a 200s recording, under a field
+		// that says it covers every chunk.
+		let call = 0;
+		fakeWhisperServer.transcribe.mockImplementation(async () => ({
+			segments: [],
+			wordSegments: [],
+			detectedLanguage: "en",
+			backend: "whispercpp-cpu",
+			timing: call++ === 1 ? undefined : { elapsedSec: 45, audioSec: 90, rtf: 0.5 },
+		}));
+		const mgr = new SttManager();
+		await mgr.init({ modelsBaseDir: "/tmp/fake-stt-models" });
+		const result = await mgr.transcribe({
+			samples: new Float32Array(200 * 16000),
+			language: "en",
+		});
+
+		expect(result.timing).toBeUndefined();
+		// And it says which, rather than claiming nothing was measured at all.
+		expect(
+			infoSpy.mock.calls.some(([line]) =>
+				String(line).includes("timing incomplete (1/3 chunks unmeasured)"),
+			),
+		).toBe(true);
 	});
 
 	it("logs the backend and the timing of every chunk", async () => {
@@ -182,6 +225,8 @@ describe("SttManager", () => {
 		// without arithmetic.
 		expect(chunkLines[0]).toContain("whispercpp-cpu");
 		expect(chunkLines[0]).toContain("90.0s audio in 45.0s (0.50 rtf, 2.0x real-time)");
+		// Each line carries ITS OWN chunk's cost, not the running total.
+		expect(chunkLines[1]).toContain("90.0s audio in 18.0s (0.20 rtf, 5.0x real-time)");
 	});
 
 	it("says so when the helper reports no timing at all", async () => {
@@ -209,11 +254,11 @@ describe("SttManager", () => {
 		const reported = sink.mock.calls
 			.map(([event]) => event)
 			.filter((event) => event.backend !== undefined);
-		expect(reported).toHaveLength(planChunks(samples, 16000).length);
-		for (const event of reported) {
-			expect(event.backend).toBe("whispercpp-cpu");
-			expect(event.rtf).toBeCloseTo(0.5);
-		}
+		expect(reported).toHaveLength(CHUNK_TIMINGS.length);
+		for (const event of reported) expect(event.backend).toBe("whispercpp-cpu");
+		// Cumulative and weighted at every step — 45/90, then 63/180, then 75/200 —
+		// which is what makes the figure settle instead of bouncing per chunk.
+		expect(reported.map((e) => e.rtf)).toEqual([45 / 90, 63 / 180, 75 / 200]);
 	});
 
 	it("warns once per run — not once per chunk — that it landed on CPU", async () => {

--- a/electron/stt/index.test.ts
+++ b/electron/stt/index.test.ts
@@ -185,17 +185,25 @@ describe("SttManager", () => {
 	it("reports no run timing at all when one chunk went unmeasured", async () => {
 		// A single chunk without a `timing` block is enough to spoil the totals:
 		// they would describe 110s of audio for a 200s recording, under a field
-		// that says it covers every chunk.
+		// that says it covers every chunk. The two measured chunks carry DIFFERENT
+		// ratios so the running figure asserted below cannot be constant by luck.
+		const MEASURED = [
+			{ elapsedSec: 45, audioSec: 90, rtf: 0.5 },
+			undefined,
+			{ elapsedSec: 5, audioSec: 20, rtf: 0.25 },
+		];
 		let call = 0;
 		fakeWhisperServer.transcribe.mockImplementation(async () => ({
 			segments: [],
 			wordSegments: [],
 			detectedLanguage: "en",
 			backend: "whispercpp-cpu",
-			timing: call++ === 1 ? undefined : { elapsedSec: 45, audioSec: 90, rtf: 0.5 },
+			timing: MEASURED[call++],
 		}));
+		const sink = vi.fn<(e: SttStatusEvent) => void>();
 		const mgr = new SttManager();
-		await mgr.init({ modelsBaseDir: "/tmp/fake-stt-models" });
+		await mgr.init({ statusSink: sink, modelsBaseDir: "/tmp/fake-stt-models" });
+		sink.mockClear();
 		const result = await mgr.transcribe({
 			samples: new Float32Array(200 * 16000),
 			language: "en",
@@ -208,6 +216,17 @@ describe("SttManager", () => {
 				String(line).includes("timing incomplete (1/3 chunks unmeasured)"),
 			),
 		).toBe(true);
+		// The status `rtf` is held to a different rule than the response total, and
+		// this is where that difference is visible: being a RATIO, it survives the
+		// gap instead of blanking — it holds at the last known value across the
+		// unmeasured chunk, then goes on aggregating. Killing the live speed
+		// readout for the rest of a run over one bad chunk would be the opposite of
+		// what the field exists for.
+		const running = sink.mock.calls
+			.map(([event]) => event)
+			.filter((event) => event.backend !== undefined)
+			.map((event) => event.rtf);
+		expect(running).toEqual([45 / 90, 45 / 90, 50 / 110]);
 	});
 
 	it("logs the backend and the timing of every chunk", async () => {

--- a/electron/stt/index.ts
+++ b/electron/stt/index.ts
@@ -239,6 +239,7 @@ export class SttManager {
 		let elapsedSec = 0;
 		let audioSec = 0;
 		let timedChunks = 0;
+		let untimedChunks = 0;
 		// The CPU verdict is worth saying once per run, not once per chunk.
 		let warnedCpu = false;
 		// Only the first chunk auto-detects; every later chunk is forced onto the
@@ -313,6 +314,8 @@ export class SttManager {
 				elapsedSec += result.timing.elapsedSec;
 				audioSec += result.timing.audioSec;
 				timedChunks++;
+			} else {
+				untimedChunks++;
 			}
 			const runRtf = audioSec > 0 ? elapsedSec / audioSec : undefined;
 			// Through `console.*` on purpose: that is what the main-process ring
@@ -347,13 +350,24 @@ export class SttManager {
 			});
 		}
 
+		// A total has to cover everything it claims to total. Let one chunk go
+		// unmeasured and these sums describe a SHORTER recording than the one that
+		// was actually transcribed — under a field documented as covering every
+		// chunk. So an incomplete run reports no timing rather than partial timing.
+		//
+		// The per-chunk `rtf` emitted above is deliberately not held to this: it is
+		// a RATIO, not a total, and stays honest over whatever subset reported.
 		const timing: SttTiming | undefined =
-			timedChunks > 0 && audioSec > 0
+			timedChunks > 0 && untimedChunks === 0 && audioSec > 0
 				? { elapsedSec, audioSec, rtf: elapsedSec / audioSec }
 				: undefined;
 		console.info(
 			`[stt] done on ${backend}: ${chunks.length} chunk(s), ` +
-				(timing ? formatTiming(timing) : "no timing reported"),
+				(timing
+					? formatTiming(timing)
+					: untimedChunks === chunks.length
+						? "no timing reported"
+						: `timing incomplete (${untimedChunks}/${chunks.length} chunks unmeasured)`),
 		);
 		return {
 			segments,

--- a/electron/stt/index.ts
+++ b/electron/stt/index.ts
@@ -5,6 +5,7 @@ import { ensureModels, modelPaths } from "./modelManager";
 import type {
 	SttPhraseSegment,
 	SttStatusEvent,
+	SttTiming,
 	SttTranscribeRequest,
 	SttTranscribeResponse,
 	SttWordSegment,
@@ -59,6 +60,26 @@ function cancelledError(): Error {
 	const error = new Error("Transcription cancelled");
 	error.name = "AbortError";
 	return error;
+}
+
+/**
+ * One transcription's cost, in both of the conventions this repo uses.
+ *
+ * whisper.cpp and the POC report measure RTF — wall-clock divided by audio, so
+ * LOWER is faster — while the figure that means something to a reader is its
+ * reciprocal ("2.1x real-time"). Printing both lets a log line be compared
+ * against tools/stt-eval/whispercpp-dtw-poc/REPORT.md 5 without arithmetic.
+ *
+ * ASCII "x" rather than the report's "×" glyph: these lines are read in a
+ * Windows console and in the diagnostics dump, neither of which is reliably
+ * UTF-8.
+ */
+function formatTiming(timing: SttTiming): string {
+	const speed = timing.rtf > 0 ? 1 / timing.rtf : 0;
+	return (
+		`${timing.audioSec.toFixed(1)}s audio in ${timing.elapsedSec.toFixed(1)}s ` +
+		`(${timing.rtf.toFixed(2)} rtf, ${speed.toFixed(1)}x real-time)`
+	);
 }
 
 export interface SttManagerInitOptions {
@@ -213,6 +234,13 @@ export class SttManager {
 		const wordSegments: SttWordSegment[] = [];
 		let detectedLanguage: string | null = null;
 		let backend = this.server.status.backend ?? "whispercpp-cpu";
+		// Summed, not averaged: chunks differ in length, so the mean of the
+		// per-chunk RTFs is not the RTF of the run.
+		let elapsedSec = 0;
+		let audioSec = 0;
+		let timedChunks = 0;
+		// The CPU verdict is worth saying once per run, not once per chunk.
+		let warnedCpu = false;
 		// Only the first chunk auto-detects; every later chunk is forced onto the
 		// language it resolved, so whisper cannot flip mid-recording on a chunk
 		// that opens with a proper noun or a silence and "transcribe" the rest as
@@ -281,18 +309,58 @@ export class SttManager {
 				if (!language) language = detectedLanguage;
 			}
 			backend = result.backend ?? backend;
+			if (result.timing) {
+				elapsedSec += result.timing.elapsedSec;
+				audioSec += result.timing.audioSec;
+				timedChunks++;
+			}
+			const runRtf = audioSec > 0 ? elapsedSec / audioSec : undefined;
+			// Through `console.*` on purpose: that is what the main-process ring
+			// buffer wraps (electron/diagnostics/main-log-buffer.ts), so these lines
+			// reach "Save Diagnostics". The helper's own stderr is forwarded with
+			// `process.stderr.write` in whisperServer.ts and never lands there.
+			console.info(
+				`[stt] chunk ${index + 1}/${chunks.length} on ${backend}: ` +
+					(result.timing
+						? formatTiming(result.timing)
+						: "no timing reported (staged helper binary pre-dates the field)"),
+			);
+			// Falling back to CPU is silent on both sides — the helper retries
+			// without GPU when init returns null, and this process can relaunch the
+			// helper with `--cpu` — and it costs about half the throughput. A user
+			// staring at a transcription that takes twice as long has, without this,
+			// nothing anywhere telling them why.
+			if (!warnedCpu && backend === "whispercpp-cpu") {
+				warnedCpu = true;
+				console.warn(
+					"[stt] running on CPU - no GPU backend was bound. Expect roughly half " +
+						"the throughput of the Vulkan/Metal path (median 2.07x on the reference " +
+						"machine, tools/stt-eval/whispercpp-dtw-poc/REPORT.md 5.3).",
+				);
+			}
 			this.emit({
 				phase: "transcribe",
 				completedSec: chunk.endSample / SAMPLE_RATE,
 				totalSec,
+				backend,
+				rtf: runRtf,
 			});
 		}
 
+		const timing: SttTiming | undefined =
+			timedChunks > 0 && audioSec > 0
+				? { elapsedSec, audioSec, rtf: elapsedSec / audioSec }
+				: undefined;
+		console.info(
+			`[stt] done on ${backend}: ${chunks.length} chunk(s), ` +
+				(timing ? formatTiming(timing) : "no timing reported"),
+		);
 		return {
 			segments,
 			wordSegments,
 			detectedLanguage: detectedLanguage ?? language ?? "auto",
 			backend,
+			timing,
 		};
 	}
 

--- a/electron/stt/transcriptionContract.ts
+++ b/electron/stt/transcriptionContract.ts
@@ -38,6 +38,28 @@ export type SttBackend =
 	| "whispercpp-cuda"
 	| "whispercpp-cpu";
 
+/**
+ * Wall-clock cost of a transcription, measured by the helper around
+ * `whisper_full` (`electron/native/whisper-stt/src/main.cpp`) and reported on
+ * every `/inference` response. Used both per chunk and summed over a whole run.
+ *
+ * `rtf` follows whisper.cpp's convention, which is also the POC report's:
+ * wall-clock DIVIDED BY audio duration, so lower is faster and < 1 means faster
+ * than real-time. The figure a reader can act on ("2.1x real-time") is its
+ * reciprocal — see `realtimeSpeed()` in
+ * `src/lib/ai-edition/transcription/status.ts`.
+ *
+ * Optional everywhere it appears because a staged helper binary can pre-date
+ * the `timing` field: `electron/native/bin/<tag>/` is gitignored, so a dev tree
+ * keeps whatever was last built there. Absent rather than zeroed on purpose —
+ * "not reported" and "took no time" must not render the same way.
+ */
+export interface SttTiming {
+	elapsedSec: number;
+	audioSec: number;
+	rtf: number;
+}
+
 /** Status phase the renderer surfaces over `onStatus("model" | "transcribe")`. */
 export type SttStatusPhase = "model" | "transcribe";
 
@@ -58,6 +80,24 @@ export interface SttStatusEvent {
 	 */
 	completedSec?: number;
 	totalSec?: number;
+	/**
+	 * Backend the helper ACTUALLY bound, as reported by the chunk that just
+	 * landed — not `gpuDetector`'s guess, which only picks a binary.
+	 *
+	 * This is the only signal a user has that they are on the slow path. Both
+	 * routes onto it are silent (the helper retries without GPU when init
+	 * returns null; the Node side can relaunch with `--cpu`), and the CPU path
+	 * costs roughly half the throughput — median 2.07x on the reference machine,
+	 * see tools/stt-eval/whispercpp-dtw-poc/REPORT.md 5.3.
+	 */
+	backend?: SttBackend;
+	/**
+	 * Real-time factor for the run SO FAR (total wall-clock / total audio), not
+	 * for the chunk that just landed. Per-chunk values swing with how much speech
+	 * a chunk happens to hold, and a figure that jumps every 90s reads as noise
+	 * rather than as progress.
+	 */
+	rtf?: number;
 }
 
 /** IPC request: renderer → main. */
@@ -76,6 +116,8 @@ export interface SttTranscribeResponse {
 	wordSegments: SttWordSegment[];
 	detectedLanguage: string;
 	backend: SttBackend;
+	/** Summed over every chunk of this request; absent if no chunk reported timing. */
+	timing?: SttTiming;
 }
 
 /** IPC success envelope; thrown errors cross as a rejection. */

--- a/electron/stt/transcriptionContract.ts
+++ b/electron/stt/transcriptionContract.ts
@@ -96,6 +96,10 @@ export interface SttStatusEvent {
 	 * for the chunk that just landed. Per-chunk values swing with how much speech
 	 * a chunk happens to hold, and a figure that jumps every 90s reads as noise
 	 * rather than as progress.
+	 *
+	 * Computed over the chunks that reported timing. Unlike
+	 * `SttTranscribeResponse.timing` this is a ratio rather than a total, so it
+	 * stays meaningful even when a chunk reports nothing.
 	 */
 	rtf?: number;
 }
@@ -116,7 +120,11 @@ export interface SttTranscribeResponse {
 	wordSegments: SttWordSegment[];
 	detectedLanguage: string;
 	backend: SttBackend;
-	/** Summed over every chunk of this request; absent if no chunk reported timing. */
+	/**
+	 * Summed over every chunk of this request — and absent unless ALL of them
+	 * reported, because a total that quietly skips a chunk describes a shorter
+	 * recording than the one that was transcribed.
+	 */
 	timing?: SttTiming;
 }
 

--- a/electron/stt/whisperServer.test.ts
+++ b/electron/stt/whisperServer.test.ts
@@ -191,6 +191,22 @@ describe("WhisperServerManager", () => {
 		expect(result.timing).toEqual({ elapsedSec: 4, audioSec: 8, rtf: 0.5 });
 	});
 
+	// Durations no clock could produce. Letting these through would put a bogus
+	// figure into the run totals in SttManager, where nothing downstream could
+	// tell it from a real measurement.
+	it.each([
+		["negative elapsed", { elapsed_s: -1, audio_s: 8 }],
+		["zero audio", { elapsed_s: 4, audio_s: 0 }],
+		["negative audio", { elapsed_s: 4, audio_s: -8 }],
+	])("rejects a timing block with %s", async (_label, timing) => {
+		const result = await transcribeWith({
+			segments: [],
+			backend: "whispercpp-cpu",
+			timing,
+		});
+		expect(result.timing).toBeNull();
+	});
+
 	it("rejects a timing block with no usable durations", async () => {
 		const result = await transcribeWith({
 			segments: [],

--- a/electron/stt/whisperServer.test.ts
+++ b/electron/stt/whisperServer.test.ts
@@ -130,6 +130,76 @@ describe("WhisperServerManager", () => {
 		}
 	});
 
+	/** Answer `/inference` with one canned body and run a single transcription. */
+	async function transcribeWith(json: unknown) {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response(JSON.stringify(json), { status: 200 })),
+		);
+		try {
+			const mgr = new WhisperServerManager();
+			(mgr as unknown as { process: unknown; port: number }).process = {};
+			(mgr as unknown as { process: unknown; port: number }).port = 9999;
+			return await mgr.transcribe({ samples: new Float32Array(1600) });
+		} finally {
+			vi.unstubAllGlobals();
+		}
+	}
+
+	it("reads the helper's timing block off an /inference response", async () => {
+		const result = await transcribeWith({
+			segments: [],
+			detected_language: "english",
+			backend: "whispercpp-vulkan",
+			timing: { elapsed_s: 5.5, audio_s: 11, rtf: 0.5 },
+		});
+		expect(result.timing).toEqual({ elapsedSec: 5.5, audioSec: 11, rtf: 0.5 });
+	});
+
+	// A staged binary older than the `timing` field just omits it — and
+	// `electron/native/bin/<tag>/` is gitignored, so a dev tree keeps whatever was
+	// last built there. Null, not zeroes: "not reported" and "took no time" must
+	// not reach the UI looking the same.
+	it("reports no timing at all when the helper omits the block", async () => {
+		const result = await transcribeWith({
+			segments: [],
+			detected_language: "english",
+			backend: "whispercpp-cpu",
+		});
+		expect(result.timing).toBeNull();
+	});
+
+	// `rtf` is derived from the other two, so a junk ratio is recoverable — and a
+	// NaN surviving this far would reach the renderer as "NaN× real-time".
+	it("recomputes rtf when the helper's own value is unusable", async () => {
+		const result = await transcribeWith({
+			segments: [],
+			backend: "whispercpp-cpu",
+			timing: { elapsed_s: 4, audio_s: 8, rtf: "not-a-number" },
+		});
+		expect(result.timing).toEqual({ elapsedSec: 4, audioSec: 8, rtf: 0.5 });
+	});
+
+	// Same defensive parse the segment bounds get: nothing on this wire is
+	// guaranteed by a schema.
+	it("accepts stringified durations", async () => {
+		const result = await transcribeWith({
+			segments: [],
+			backend: "whispercpp-cpu",
+			timing: { elapsed_s: "4", audio_s: "8", rtf: "0.5" },
+		});
+		expect(result.timing).toEqual({ elapsedSec: 4, audioSec: 8, rtf: 0.5 });
+	});
+
+	it("rejects a timing block with no usable durations", async () => {
+		const result = await transcribeWith({
+			segments: [],
+			backend: "whispercpp-cpu",
+			timing: { rtf: 0.5 },
+		});
+		expect(result.timing).toBeNull();
+	});
+
 	describe("WhisperServerManager language normalization", () => {
 		function captureFormField(language: string | undefined): Promise<string | null> {
 			return new Promise((resolve, reject) => {

--- a/electron/stt/whisperServer.ts
+++ b/electron/stt/whisperServer.ts
@@ -395,19 +395,22 @@ export class WhisperServerManager {
 	 * `rtf` is recomputed from the two durations whenever the helper didn't send
 	 * a usable one. It is derived data, and a NaN surviving this far would reach
 	 * the UI as "NaN x real-time".
+	 *
+	 * Durations no clock could have produced are treated as a junk block, not as
+	 * a slow one: `steady_clock` cannot run backwards, and a chunk holding no
+	 * audio has nothing to measure. Rejecting them here is what keeps a bad value
+	 * out of `SttManager`'s run totals, where it would quietly distort the figure
+	 * the whole recording is reported against.
 	 */
 	private toTiming(raw: WhisperJsonTiming | undefined): SttTiming | null {
 		if (!raw || typeof raw !== "object") return null;
 		const elapsedSec = this.toSec(raw.elapsed_s, Number.NaN);
 		const audioSec = this.toSec(raw.audio_s, Number.NaN);
-		if (!Number.isFinite(elapsedSec) || !Number.isFinite(audioSec)) return null;
+		if (!Number.isFinite(elapsedSec) || elapsedSec < 0) return null;
+		// Also the divisor below, so this doubles as the divide-by-zero guard.
+		if (!Number.isFinite(audioSec) || audioSec <= 0) return null;
 		const reported = this.toSec(raw.rtf, Number.NaN);
-		const rtf =
-			Number.isFinite(reported) && reported > 0
-				? reported
-				: audioSec > 0
-					? elapsedSec / audioSec
-					: 0;
+		const rtf = Number.isFinite(reported) && reported > 0 ? reported : elapsedSec / audioSec;
 		return { elapsedSec, audioSec, rtf };
 	}
 

--- a/electron/stt/whisperServer.ts
+++ b/electron/stt/whisperServer.ts
@@ -8,7 +8,12 @@ import type { Readable } from "node:stream";
 
 import { resolveBinaryPath } from "./gpuDetector";
 import { snapWordBoundariesToAudio } from "./snapWordBoundaries";
-import type { SttBackend, SttPhraseSegment, SttWordSegment } from "./transcriptionContract";
+import type {
+	SttBackend,
+	SttPhraseSegment,
+	SttTiming,
+	SttWordSegment,
+} from "./transcriptionContract";
 import { cleanupWav, writeSamplesAsWav } from "./wav";
 
 /** whisper.cpp helper is stdio-shaped: stdin ignored, stdout/stderr captured. */
@@ -88,11 +93,23 @@ interface WhisperJsonSegment {
 	words?: WhisperJsonWord[];
 }
 
+/**
+ * The helper's `timing` block, in its own snake_case wire spelling. Every field
+ * is optional and may arrive as a string for the same reason the segment bounds
+ * may (see `toSec`): nothing on the wire is guaranteed by a schema.
+ */
+interface WhisperJsonTiming {
+	elapsed_s?: number | string;
+	audio_s?: number | string;
+	rtf?: number | string;
+}
+
 interface WhisperJsonResponse {
 	segments?: WhisperJsonSegment[];
 	language?: string;
 	detected_language?: string;
 	backend?: string;
+	timing?: WhisperJsonTiming;
 }
 
 export class WhisperServerManager {
@@ -367,12 +384,41 @@ export class WhisperServerManager {
 		return Number.isFinite(n) ? n : fallback;
 	}
 
+	/**
+	 * Read the helper's `timing` block, or null when it is missing or unusable.
+	 *
+	 * Null rather than zeroes: a helper binary built before the field existed
+	 * simply omits it, and callers have to be able to tell that apart from a
+	 * transcription that genuinely took no time — one is "we don't know", the
+	 * other would be a bug worth showing.
+	 *
+	 * `rtf` is recomputed from the two durations whenever the helper didn't send
+	 * a usable one. It is derived data, and a NaN surviving this far would reach
+	 * the UI as "NaN x real-time".
+	 */
+	private toTiming(raw: WhisperJsonTiming | undefined): SttTiming | null {
+		if (!raw || typeof raw !== "object") return null;
+		const elapsedSec = this.toSec(raw.elapsed_s, Number.NaN);
+		const audioSec = this.toSec(raw.audio_s, Number.NaN);
+		if (!Number.isFinite(elapsedSec) || !Number.isFinite(audioSec)) return null;
+		const reported = this.toSec(raw.rtf, Number.NaN);
+		const rtf =
+			Number.isFinite(reported) && reported > 0
+				? reported
+				: audioSec > 0
+					? elapsedSec / audioSec
+					: 0;
+		return { elapsedSec, audioSec, rtf };
+	}
+
 	/** Run one transcription; serializes concurrent callers. */
 	async transcribe(opts: { samples: Float32Array; language?: string }): Promise<{
 		segments: SttPhraseSegment[];
 		wordSegments: SttWordSegment[];
 		detectedLanguage: string;
 		backend: SttBackend;
+		/** Null when the helper reported no usable `timing` block. */
+		timing: SttTiming | null;
 	}> {
 		const task = this.inFlight.then(() => this.transcribeImpl(opts));
 		this.inFlight = task.catch(() => undefined);
@@ -384,6 +430,7 @@ export class WhisperServerManager {
 		wordSegments: SttWordSegment[];
 		detectedLanguage: string;
 		backend: SttBackend;
+		timing: SttTiming | null;
 	}> {
 		const wavPath = await writeSamplesAsWav(opts.samples);
 		try {
@@ -416,7 +463,8 @@ export class WhisperServerManager {
 			);
 			const detectedLanguage = json.detected_language ?? json.language ?? "auto";
 			const backend = this.toBackend(json.backend);
-			return { segments, wordSegments, detectedLanguage, backend };
+			const timing = this.toTiming(json.timing);
+			return { segments, wordSegments, detectedLanguage, backend, timing };
 		} finally {
 			await cleanupWav(wavPath);
 		}

--- a/scripts/build-whisper-stt.sh
+++ b/scripts/build-whisper-stt.sh
@@ -9,9 +9,8 @@
 # See technical-documentation/architecture/transcription-and-captions.md
 #
 # Local use:
-#   bash scripts/build-whisper-stt.sh                # default backend for host
-#   ENABLE_CUDA=ON bash scripts/build-whisper-stt.sh # also build CUDA variant
-#   bash scripts/build-whisper-stt.sh --clean        # wipe build cache first
+#   bash scripts/build-whisper-stt.sh         # default backend for host
+#   bash scripts/build-whisper-stt.sh --clean # wipe build cache first
 #
 # The default backend per host:
 #   macOS arm64  -> Metal
@@ -36,20 +35,17 @@ fi
 readonly BUILD_ROOT
 
 CLEAN=0
-CUDA_ENABLED="${ENABLE_CUDA:-OFF}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --clean) CLEAN=1; shift ;;
-    --cuda)  CUDA_ENABLED=ON; shift ;;
     -h|--help)
       cat <<-EOF
-		Usage: $0 [--clean] [--cuda]
+		Usage: $0 [--clean]
 		Builds whisper-stt-server and stages it under
 		\`electron/native/bin/<os>-<arch>/\`.
 
 		--clean   Wipe the build cache before configuring.
-		--cuda    Also build a CUDA variant (requires nvcc on PATH).
 		EOF
       exit 0
       ;;
@@ -172,17 +168,6 @@ build_variant() {
     bin_name="${bin_name}.exe"
   fi
 
-  # If this is the primary (non-CUDA) variant, install it under the plain name.
-  # CUDA is kept as a side-by-side variant with a -cuda suffix.
-  local out_bin_name="${bin_name}"
-  if [[ "${variant_name}" == "cuda" ]]; then
-    if [[ "${OS_ARCH}" == win32-* ]]; then
-      out_bin_name="whisper-stt-server-cuda.exe"
-    else
-      out_bin_name="whisper-stt-server-cuda"
-    fi
-  fi
-
   # CMake generator-specific output locations: Ninja drops the binary at the
   # build root and libraries under bin/; MSBuild (Visual Studio on Windows)
   # puts Release/ configurations under ${build_dir}/Release/ and bin/Release/.
@@ -203,7 +188,7 @@ build_variant() {
     echo "FATAL: could not find whisper-stt-server binary in ${build_dir}" >&2
     exit 1
   fi
-  cp "${built_exe}" "${OUT_DIR}/${out_bin_name}"
+  cp "${built_exe}" "${OUT_DIR}/${bin_name}"
 
   # Stage any shared libraries / backend sidecars that CMake produced.
   # Copy everything that looks like a ggml/whisper shared library, plus any
@@ -250,7 +235,7 @@ libparakeet*.so|libparakeet*.so.*|\
   # never read, so a staging glob that matched nothing — which is precisely what
   # happened on macOS and Linux — still exited 0 and produced a green build.
   if [[ "${found_libs}" -eq 0 ]]; then
-    echo "FATAL: staged no shared libraries alongside ${out_bin_name}." >&2
+    echo "FATAL: staged no shared libraries alongside ${bin_name}." >&2
     echo "       Searched: ${search_dirs[*]}" >&2
     echo "       The helper links ggml/whisper as shared libraries; without them" >&2
     echo "       it cannot start. Check the sidecar glob in this script." >&2
@@ -288,9 +273,9 @@ libparakeet*.so|libparakeet*.so.*|\
   # patchelf is needed: these binaries already carry RUNPATH=$ORIGIN.
   if [[ "${OS_ARCH}" == linux-* ]]; then
     local gomp
-    gomp="$(ldd "${OUT_DIR}/${out_bin_name}" 2>/dev/null | awk '/libgomp\.so\.1/ {print $3; exit}')"
+    gomp="$(ldd "${OUT_DIR}/${bin_name}" 2>/dev/null | awk '/libgomp\.so\.1/ {print $3; exit}')"
     if [[ -z "${gomp}" || ! -f "${gomp}" ]]; then
-      echo "FATAL: libgomp.so.1 is not resolvable for ${out_bin_name}." >&2
+      echo "FATAL: libgomp.so.1 is not resolvable for ${bin_name}." >&2
       echo "       Install it (libgomp1 on Debian/Ubuntu, libgomp on Fedora/Arch)." >&2
       echo "       Without it the AppImage ships an STT stack that cannot load," >&2
       echo "       which is silent until a user tries to transcribe." >&2
@@ -302,12 +287,12 @@ libparakeet*.so|libparakeet*.so.*|\
     fi
   fi
 
-  echo "[whisper-stt] built ${variant_name} -> ${OUT_DIR}/${out_bin_name}"
+  echo "[whisper-stt] built ${variant_name} -> ${OUT_DIR}/${bin_name}"
   ls -la "${OUT_DIR}"
 }
 
 # ---------------------------------------------------------------------------
-# Primary variant (Metal/Vulkan/CPU depending on host).
+# The one build: Metal/Vulkan/CPU depending on host.
 # ---------------------------------------------------------------------------
 DEFAULT_FLAG="$(backend_flag_for_host)"
 BUILD_FLAGS=()
@@ -317,17 +302,5 @@ fi
 # See the comment in build_variant() re: bash 3.2 + `set -u` + empty arrays
 # (macOS x64/CPU has no DEFAULT_FLAG, so BUILD_FLAGS is genuinely empty here).
 build_variant "default" ${BUILD_FLAGS[@]+"${BUILD_FLAGS[@]}"}
-
-# ---------------------------------------------------------------------------
-# Optional CUDA variant. Kept as a side-by-side binary for hosts that want
-# maximum NVIDIA performance; the default Vulkan build already covers NVIDIA.
-# ---------------------------------------------------------------------------
-if [[ "${CUDA_ENABLED}" == "ON" ]]; then
-  if ! command -v nvcc >/dev/null 2>&1; then
-    echo "Skipping CUDA variant: nvcc not on PATH" >&2
-  else
-    build_variant "cuda" "-DOSC_ENABLE_CUDA=ON"
-  fi
-fi
 
 echo "[whisper-stt] done. Binaries under: ${OUT_DIR}"

--- a/src/components/ai-edition/TranscriptionStatus.test.tsx
+++ b/src/components/ai-edition/TranscriptionStatus.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// The translator returns the key: an assertion reads better against a key than
+// against a sentence that moves every time the copy is revised.
+vi.mock("@/contexts/I18nContext", () => ({
+	useScopedT: () => (key: string) => key,
+}));
+
+import type { AssetTranscriptionView } from "@/lib/ai-edition/transcription/status";
+import { TranscriptionStatusDot, useTranscriptionLabel } from "./TranscriptionStatus";
+
+/** Renders the shared label so the hook can be asserted as plain text. */
+function Label({ view }: { view: AssetTranscriptionView }) {
+	return <span data-testid="label">{useTranscriptionLabel()(view)}</span>;
+}
+
+function running(extra: Partial<AssetTranscriptionView> = {}): AssetTranscriptionView {
+	return {
+		assetId: "a",
+		status: "running",
+		progress: { completedSec: 45, totalSec: 100 },
+		...extra,
+	};
+}
+
+function labelOf(view: AssetTranscriptionView): string {
+	return render(<Label view={view} />).getByTestId("label").textContent ?? "";
+}
+
+describe("useTranscriptionLabel telemetry suffix", () => {
+	// The whole point of the change: a run on the slow path says so, in the one
+	// string all three status surfaces render.
+	it("names the CPU path and the speed while transcribing", () => {
+		expect(labelOf(running({ backend: "whispercpp-cpu", rtf: 1.1 }))).toBe(
+			"mediaStage.transcribing 45% · CPU · 0.9×",
+		);
+	});
+
+	// A healthy GPU run gets the speed but no backend name — labelling every
+	// successful run "Vulkan" would be noise, and only the CPU case is actionable.
+	it("shows the speed but not the backend on a GPU run", () => {
+		expect(labelOf(running({ backend: "whispercpp-vulkan", rtf: 0.5 }))).toBe(
+			"mediaStage.transcribing 45% · 2.0×",
+		);
+	});
+
+	// Regression guard for the helper binary that predates the `timing` field:
+	// with nothing reported the label must be exactly what it always was, not
+	// "0.0×" and not a stray separator.
+	it("is unchanged when the engine reports no timing", () => {
+		expect(labelOf(running())).toBe("mediaStage.transcribing 45%");
+	});
+
+	// Chunk progress can be absent while the run is still starting up.
+	it("drops the percentage but keeps the telemetry without progress", () => {
+		expect(labelOf(running({ progress: undefined, backend: "whispercpp-cpu" }))).toBe(
+			"mediaStage.transcribing · CPU",
+		);
+	});
+
+	// The model download has its own words and no device to report yet.
+	it("leaves the model-download phase alone", () => {
+		expect(labelOf(running({ phase: "loading-model", backend: "whispercpp-cpu", rtf: 1.1 }))).toBe(
+			"mediaStage.downloadingModel",
+		);
+	});
+});
+
+describe("TranscriptionStatusDot", () => {
+	// "CPU" in the label is terse by necessity; the tooltip is where the cost is
+	// spelled out. It has to be a <title> CHILD because lucide renders an <svg>,
+	// which has no tooltip-bearing `title` attribute.
+	it("explains the CPU cost in the spinner's SVG title", () => {
+		const { container } = render(
+			<TranscriptionStatusDot view={running({ backend: "whispercpp-cpu", rtf: 1.1 })} />,
+		);
+		const title = container.querySelector("svg > title");
+		expect(title?.textContent).toBe(
+			"mediaStage.transcribing 45% · CPU · 0.9× — mediaStage.cpuBackendHint",
+		);
+	});
+
+	it("uses the plain label as the title on a GPU run", () => {
+		const { container } = render(
+			<TranscriptionStatusDot view={running({ backend: "whispercpp-vulkan", rtf: 0.5 })} />,
+		);
+		expect(container.querySelector("svg > title")?.textContent).toBe(
+			"mediaStage.transcribing 45% · 2.0×",
+		);
+	});
+
+	// A settled asset renders the dot, not the spinner — the tooltip lives on the
+	// `title` attribute there, and no backend is in play.
+	it("falls back to the dot once the run is over", () => {
+		const { container } = render(
+			<TranscriptionStatusDot view={{ assetId: "a", status: "ready" }} />,
+		);
+		expect(container.querySelector("svg")).toBeNull();
+		expect(container.querySelector("span")).toHaveAttribute("title", "mediaStage.transcriptReady");
+	});
+});

--- a/src/components/ai-edition/TranscriptionStatus.tsx
+++ b/src/components/ai-edition/TranscriptionStatus.tsx
@@ -11,7 +11,9 @@ import { Loader2 } from "lucide-react";
 import { useScopedT } from "@/contexts/I18nContext";
 import {
 	type AssetTranscriptionView,
+	isCpuBackend,
 	progressFraction,
+	realtimeSpeed,
 } from "@/lib/ai-edition/transcription/status";
 
 /** Human-readable state of one asset's transcript, in the user's language. */
@@ -34,9 +36,21 @@ export function useTranscriptionLabel(): (view: AssetTranscriptionView) => strin
 				// hang, so append the percentage as soon as the main process reports
 				// chunk progress — and only then (see `TranscriptionProgressBar`).
 				const fraction = progressFraction(view.progress);
-				return fraction === null
-					? t("mediaStage.transcribing")
-					: `${t("mediaStage.transcribing")} ${Math.round(fraction * 100)}%`;
+				const head =
+					fraction === null
+						? t("mediaStage.transcribing")
+						: `${t("mediaStage.transcribing")} ${Math.round(fraction * 100)}%`;
+				// Two things only the run itself knows: which device is doing the work,
+				// and how fast. "CPU" appears on the slow path ONLY — naming the GPU
+				// backend on every healthy run would be noise, whereas landing on CPU
+				// costs about half the throughput and happens through fallbacks that are
+				// otherwise completely silent. The speed shows on any backend: "is this
+				// moving, and how fast" is the same question at 5× as at 0.9×.
+				const suffix: string[] = [];
+				if (isCpuBackend(view.backend)) suffix.push("CPU");
+				const speed = realtimeSpeed(view.rtf);
+				if (speed !== null) suffix.push(`${speed.toFixed(1)}×`);
+				return suffix.length === 0 ? head : `${head} · ${suffix.join(" · ")}`;
 			}
 			case "empty":
 				return t("mediaStage.noSpeechDetected");
@@ -68,7 +82,12 @@ export function TranscriptionStatusDot({
 	view: AssetTranscriptionView;
 	size?: number;
 }) {
+	const t = useScopedT("editor");
 	const label = useTranscriptionLabel()(view);
+	// The label says "CPU"; this says what that costs. It has to be a <title>
+	// CHILD rather than the `title` attribute the dot below uses — lucide renders
+	// children inside its <svg>, and SVG has no tooltip-bearing `title` attribute.
+	const cpuHint = isCpuBackend(view.backend) ? t("mediaStage.cpuBackendHint") : null;
 	if (view.status === "running" || view.status === "queued") {
 		return (
 			<Loader2
@@ -76,7 +95,9 @@ export function TranscriptionStatusDot({
 				className="animate-spin"
 				style={{ color: "var(--accent)", flexShrink: 0 }}
 				aria-label={label}
-			/>
+			>
+				<title>{cpuHint ? `${label} — ${cpuHint}` : label}</title>
+			</Loader2>
 		);
 	}
 	const { fill, halo } = DOT_COLOR[view.status];

--- a/src/i18n/locales/ar/editor.json
+++ b/src/i18n/locales/ar/editor.json
@@ -148,6 +148,7 @@
 		"transcribingEllipsis": "جارٍ النسخ…",
 		"pendingTranscription": "بانتظار النسخ",
 		"transcriptionFailed": "فشل النسخ",
+		"cpuBackendHint": "يعمل على المعالج — أبطأ بنحو 2× من معالج الرسوميات",
 		"noTranscript": "لا يوجد نص مكتوب",
 		"generating": "جارٍ الإنشاء",
 		"generationFailed": "فشل الإنشاء",

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -142,6 +142,7 @@
 		"transcribingEllipsis": "Transcribing…",
 		"pendingTranscription": "Pending transcription",
 		"transcriptionFailed": "Transcription failed",
+		"cpuBackendHint": "Running on CPU — about 2× slower than on the GPU",
 		"noTranscript": "No transcript",
 		"notGeneratedYet": "Not generated yet",
 		"regenerateAs": "Regenerate as",

--- a/src/i18n/locales/es/editor.json
+++ b/src/i18n/locales/es/editor.json
@@ -148,6 +148,7 @@
 		"transcribingEllipsis": "Transcribiendo…",
 		"pendingTranscription": "Transcripción pendiente",
 		"transcriptionFailed": "Error de transcripción",
+		"cpuBackendHint": "Ejecutándose en la CPU — unas 2× más lento que en la GPU",
 		"noTranscript": "Sin transcripción",
 		"generating": "Generando",
 		"generationFailed": "Error de generación",

--- a/src/i18n/locales/fr/editor.json
+++ b/src/i18n/locales/fr/editor.json
@@ -148,6 +148,7 @@
 		"transcribingEllipsis": "Transcription en cours…",
 		"pendingTranscription": "Transcription en attente",
 		"transcriptionFailed": "Échec de la transcription",
+		"cpuBackendHint": "Exécution sur le processeur — environ 2× plus lent que sur le GPU",
 		"noTranscript": "Aucune transcription",
 		"generating": "Génération en cours",
 		"generationFailed": "Échec de la génération",

--- a/src/i18n/locales/it/editor.json
+++ b/src/i18n/locales/it/editor.json
@@ -148,6 +148,7 @@
 		"transcribingEllipsis": "Trascrizione in corso…",
 		"pendingTranscription": "Trascrizione in attesa",
 		"transcriptionFailed": "Trascrizione non riuscita",
+		"cpuBackendHint": "In esecuzione su CPU — circa 2× più lento che su GPU",
 		"noTranscript": "Nessuna trascrizione",
 		"generating": "Generazione in corso",
 		"generationFailed": "Generazione non riuscita",

--- a/src/i18n/locales/ja-JP/editor.json
+++ b/src/i18n/locales/ja-JP/editor.json
@@ -148,6 +148,7 @@
 		"transcribingEllipsis": "文字起こし中…",
 		"pendingTranscription": "文字起こし待機中",
 		"transcriptionFailed": "文字起こしに失敗しました",
+		"cpuBackendHint": "CPU で実行中 — GPU より約 2 倍低速です",
 		"noTranscript": "文字起こしなし",
 		"generating": "生成中",
 		"generationFailed": "生成に失敗しました",

--- a/src/i18n/locales/ko-KR/editor.json
+++ b/src/i18n/locales/ko-KR/editor.json
@@ -148,6 +148,7 @@
 		"transcribingEllipsis": "받아쓰는 중…",
 		"pendingTranscription": "받아쓰기 대기 중",
 		"transcriptionFailed": "받아쓰기 실패",
+		"cpuBackendHint": "CPU에서 실행 중 — GPU보다 약 2배 느립니다",
 		"noTranscript": "대본 없음",
 		"generating": "생성 중",
 		"generationFailed": "생성 실패",

--- a/src/i18n/locales/pt-BR/editor.json
+++ b/src/i18n/locales/pt-BR/editor.json
@@ -148,6 +148,7 @@
 		"transcribingEllipsis": "Transcrevendo…",
 		"pendingTranscription": "Transcrição pendente",
 		"transcriptionFailed": "Falha na transcrição",
+		"cpuBackendHint": "Executando na CPU — cerca de 2× mais lento do que na GPU",
 		"noTranscript": "Sem transcrição",
 		"generating": "Gerando",
 		"generationFailed": "Falha na geração",

--- a/src/i18n/locales/ru/editor.json
+++ b/src/i18n/locales/ru/editor.json
@@ -148,6 +148,7 @@
 		"transcribingEllipsis": "Расшифровка…",
 		"pendingTranscription": "Ожидает расшифровки",
 		"transcriptionFailed": "Ошибка расшифровки",
+		"cpuBackendHint": "Выполняется на процессоре — примерно в 2× медленнее, чем на GPU",
 		"noTranscript": "Нет расшифровки",
 		"generating": "Создание",
 		"generationFailed": "Ошибка создания",

--- a/src/i18n/locales/tr/editor.json
+++ b/src/i18n/locales/tr/editor.json
@@ -148,6 +148,7 @@
 		"transcribingEllipsis": "Metne dökülüyor…",
 		"pendingTranscription": "Metne dökme bekliyor",
 		"transcriptionFailed": "Metne dökme başarısız oldu",
+		"cpuBackendHint": "CPU üzerinde çalışıyor — GPU'ya göre yaklaşık 2× daha yavaş",
 		"noTranscript": "Transkript yok",
 		"generating": "Oluşturuluyor",
 		"generationFailed": "Oluşturma başarısız oldu",

--- a/src/i18n/locales/vi/editor.json
+++ b/src/i18n/locales/vi/editor.json
@@ -148,6 +148,7 @@
 		"transcribingEllipsis": "Đang phiên âm…",
 		"pendingTranscription": "Đang chờ phiên âm",
 		"transcriptionFailed": "Phiên âm thất bại",
+		"cpuBackendHint": "Đang chạy trên CPU — chậm hơn khoảng 2× so với GPU",
 		"noTranscript": "Không có bản ghi lời thoại",
 		"generating": "Đang tạo",
 		"generationFailed": "Tạo thất bại",

--- a/src/i18n/locales/zh-CN/editor.json
+++ b/src/i18n/locales/zh-CN/editor.json
@@ -148,6 +148,7 @@
 		"transcribingEllipsis": "正在转录…",
 		"pendingTranscription": "等待转录",
 		"transcriptionFailed": "转录失败",
+		"cpuBackendHint": "正在使用 CPU 运行 — 比 GPU 慢约 2 倍",
 		"noTranscript": "没有转录文本",
 		"generating": "正在生成",
 		"generationFailed": "生成失败",

--- a/src/i18n/locales/zh-TW/editor.json
+++ b/src/i18n/locales/zh-TW/editor.json
@@ -148,6 +148,7 @@
 		"transcribingEllipsis": "轉錄中…",
 		"pendingTranscription": "等待轉錄",
 		"transcriptionFailed": "轉錄失敗",
+		"cpuBackendHint": "正在使用 CPU 執行 — 比 GPU 慢約 2 倍",
 		"noTranscript": "沒有逐字稿",
 		"generating": "產生中",
 		"generationFailed": "產生失敗",

--- a/src/lib/ai-edition/document/transcribe.ts
+++ b/src/lib/ai-edition/document/transcribe.ts
@@ -18,6 +18,10 @@ export interface TranscribeStatus {
 	phase: "extracting-audio" | "loading-model" | "transcribing";
 	completedSec?: number;
 	totalSec?: number;
+	/** Backend the helper bound for this run; `"whispercpp-cpu"` is the slow path. */
+	backend?: string;
+	/** Real-time factor for the run so far — wall-clock / audio, lower is faster. */
+	rtf?: number;
 }
 
 export interface TranscribeAssetOptions {
@@ -63,6 +67,11 @@ export async function transcribeAsset(
 				phase: status.phase === "model" ? "loading-model" : "transcribing",
 				completedSec: status.completedSec,
 				totalSec: status.totalSec,
+				// Which device is doing the work, and how fast. The main process is the
+				// only place that knows either, and a silent CPU fallback is exactly the
+				// case a user cannot otherwise diagnose.
+				backend: status.backend,
+				rtf: status.rtf,
 			}),
 	});
 

--- a/src/lib/ai-edition/store/transcriptionStore.ts
+++ b/src/lib/ai-edition/store/transcriptionStore.ts
@@ -52,6 +52,13 @@ export interface TranscriptionJob {
 	phase?: TranscriptionPhase;
 	/** Chunk progress while transcribing; absent until the first chunk lands. */
 	progress?: TranscriptionProgress;
+	/**
+	 * Which device the engine bound, and how fast it is going. Both arrive with
+	 * the first landed chunk and are refreshed by every chunk after it; both stay
+	 * absent against a helper binary too old to report timing at all.
+	 */
+	backend?: string;
+	rtf?: number;
 	/** `"auto"` unless the user forced a language from the media card. */
 	language: string;
 	failure?: TranscriptionFailure;
@@ -369,6 +376,12 @@ async function runJob(assetId: string, job: TranscriptionJob): Promise<void> {
 						status.completedSec !== undefined && status.totalSec !== undefined
 							? { completedSec: status.completedSec, totalSec: status.totalSec }
 							: undefined,
+					// Omitted rather than set to undefined when absent: `patchJob` spreads
+					// this object over the job, so a key that is present-but-undefined
+					// would blank out what the last chunk reported. The phases before the
+					// first chunk (audio extraction, the model download) carry neither.
+					...(status.backend !== undefined ? { backend: status.backend } : {}),
+					...(status.rtf !== undefined ? { rtf: status.rtf } : {}),
 				}),
 		});
 		if (controller.signal.aborted) {

--- a/src/lib/ai-edition/transcription/status.test.ts
+++ b/src/lib/ai-edition/transcription/status.test.ts
@@ -4,8 +4,10 @@ import {
 	type AssetTranscriptionView,
 	classifyTranscriptionError,
 	deriveAssetStatus,
+	isCpuBackend,
 	isPermanentFailure,
 	progressFraction,
+	realtimeSpeed,
 	resolveTranscriptGate,
 	transcriptHasSpeech,
 	transcriptRelevantAssetIds,
@@ -289,5 +291,62 @@ describe("transcriptRelevantAssetIds", () => {
 
 	it("has nothing to say about a missing document", () => {
 		expect(transcriptRelevantAssetIds(null)).toEqual([]);
+	});
+});
+
+describe("realtimeSpeed", () => {
+	// The engine reports RTF (wall-clock / audio, lower is faster); the UI shows
+	// its reciprocal, which is the figure the POC report headlines.
+	it("inverts the engine's RTF into x-real-time", () => {
+		expect(realtimeSpeed(0.5)).toBe(2);
+		expect(realtimeSpeed(0.19)).toBeCloseTo(5.26, 2);
+	});
+
+	// Null rather than 0: a helper binary older than the `timing` field reports
+	// nothing at all, and "0.0x" would read as a measurement rather than a gap.
+	it.each([
+		["undefined", undefined],
+		["zero", 0],
+		["negative", -1],
+		["NaN", Number.NaN],
+		["Infinity", Number.POSITIVE_INFINITY],
+	])("has no answer for %s", (_label, rtf) => {
+		expect(realtimeSpeed(rtf)).toBeNull();
+	});
+});
+
+describe("isCpuBackend", () => {
+	it("singles out the CPU path and nothing else", () => {
+		expect(isCpuBackend("whispercpp-cpu")).toBe(true);
+		expect(isCpuBackend("whispercpp-vulkan")).toBe(false);
+		expect(isCpuBackend("whispercpp-metal")).toBe(false);
+		expect(isCpuBackend("whispercpp-cuda")).toBe(false);
+		expect(isCpuBackend(undefined)).toBe(false);
+	});
+});
+
+describe("deriveAssetStatus carries the engine's own report", () => {
+	// Both facts come from the main process on the chunk status events, and the
+	// view is the only thing the three status surfaces read.
+	it("passes the running job's backend and rtf onto the view", () => {
+		const derived = deriveAssetStatus({
+			assetId: "a",
+			job: { status: "running", backend: "whispercpp-cpu", rtf: 1.1 },
+		});
+		expect(derived.backend).toBe("whispercpp-cpu");
+		expect(derived.rtf).toBe(1.1);
+	});
+
+	// A finished run's transcript says nothing about the device that produced it,
+	// so the view must not carry a stale badge over a "ready" asset.
+	it("drops them once a transcript exists", () => {
+		const derived = deriveAssetStatus({
+			assetId: "a",
+			job: { status: "failed", backend: "whispercpp-cpu", rtf: 1.1 },
+			transcript: transcript("a", ["hello"]),
+		});
+		expect(derived.status).toBe("ready");
+		expect(derived.backend).toBeUndefined();
+		expect(derived.rtf).toBeUndefined();
 	});
 });

--- a/src/lib/ai-edition/transcription/status.ts
+++ b/src/lib/ai-edition/transcription/status.ts
@@ -41,6 +41,32 @@ export function progressFraction(progress: TranscriptionProgress | undefined): n
 }
 
 /**
+ * Turn the engine's RTF (wall-clock / audio, whisper.cpp's convention, lower is
+ * faster) into the figure a reader can act on: "× real-time", where 2.1 means
+ * 2.1 seconds of audio transcribed per second of work.
+ *
+ * Null whenever nothing usable was reported — a helper binary older than the
+ * `timing` field sends none at all — so the UI shows no figure rather than a
+ * confident "0.0×".
+ */
+export function realtimeSpeed(rtf: number | undefined): number | null {
+	if (rtf === undefined || !Number.isFinite(rtf) || rtf <= 0) return null;
+	return 1 / rtf;
+}
+
+/**
+ * True when the run is on the CPU path rather than a GPU one.
+ *
+ * Worth its own predicate because it is the one backend value that changes what
+ * the user should expect: the same helper on the GPU is ~2x faster (median
+ * 2.07x, tools/stt-eval/whispercpp-dtw-poc/REPORT.md 5.3), and every route onto
+ * the CPU path is a silent fallback.
+ */
+export function isCpuBackend(backend: string | undefined): boolean {
+	return backend === "whispercpp-cpu";
+}
+
+/**
  * A media that has no audio track (or one Whisper cannot read) will fail the
  * same way on every attempt, so that verdict is worth remembering: it is
  * persisted on the asset and stops the auto pass from re-extracting the audio
@@ -94,6 +120,14 @@ export interface AssetTranscriptionView {
 	phase?: TranscriptionPhase;
 	progress?: TranscriptionProgress;
 	failure?: TranscriptionFailure;
+	/**
+	 * Backend the running job is actually using, once a chunk has reported one.
+	 * Only meaningful while `status === "running"` — it describes a run in
+	 * flight, not the transcript a finished run left behind.
+	 */
+	backend?: string;
+	/** Real-time factor for the run so far; pair with `realtimeSpeed()` to display. */
+	rtf?: number;
 }
 
 /** In-flight (or last-failed) state of one asset's job. Mirrors the store entry. */
@@ -102,6 +136,8 @@ export interface TranscriptionJobLike {
 	phase?: TranscriptionPhase;
 	progress?: TranscriptionProgress;
 	failure?: TranscriptionFailure;
+	backend?: string;
+	rtf?: number;
 }
 
 export function findAssetTranscript(
@@ -144,7 +180,14 @@ export function deriveAssetStatus(input: {
 }): AssetTranscriptionView {
 	const { assetId, job, transcript, persistedFailure } = input;
 	if (job && job.status !== "failed") {
-		return { assetId, status: job.status, phase: job.phase, progress: job.progress };
+		return {
+			assetId,
+			status: job.status,
+			phase: job.phase,
+			progress: job.progress,
+			backend: job.backend,
+			rtf: job.rtf,
+		};
 	}
 	if (transcript) {
 		return {

--- a/src/lib/captioning/transcribe.ts
+++ b/src/lib/captioning/transcribe.ts
@@ -38,6 +38,13 @@ export interface SttRendererStatus {
 	phase: SttRendererStatusPhase;
 	completedSec?: number;
 	totalSec?: number;
+	/**
+	 * Backend the helper actually bound (`"whispercpp-cpu"` when the GPU path was
+	 * not taken). Reported per chunk during `"transcribe"`.
+	 */
+	backend?: string;
+	/** Real-time factor for the run so far — wall-clock / audio, lower is faster. */
+	rtf?: number;
 }
 
 interface RendererSttApi {

--- a/technical-documentation/architecture/transcription-and-captions.md
+++ b/technical-documentation/architecture/transcription-and-captions.md
@@ -598,7 +598,7 @@ it deletes data
   displayed it verbatim, and `transcribe.ts` wrote it onto
   `AxcutTranscript.language`. It now reports `whisper_full_lang_id()` — the
   detected language under `"auto"`, the forced one otherwise.
-- **No CUDA build.** Vulkan already accelerates NVIDIA on Windows and
+- **CUDA not built by default.** Vulkan already accelerates NVIDIA on Windows and
   Linux. CMake still accepts `OSC_ENABLE_CUDA=ON`, so a CUDA-enabled
   helper can be built by passing that through to `cmake` — it installs
   under the ordinary `whisper-stt-server` name and reports

--- a/technical-documentation/architecture/transcription-and-captions.md
+++ b/technical-documentation/architecture/transcription-and-captions.md
@@ -599,9 +599,15 @@ it deletes data
   `AxcutTranscript.language`. It now reports `whisper_full_lang_id()` — the
   detected language under `"auto"`, the forced one otherwise.
 - **No CUDA build.** Vulkan already accelerates NVIDIA on Windows and
-  Linux, but a dedicated CUDA build can be added later via
-  `OSC_ENABLE_CUDA=ON`; the build script and CMake already accept the
-  flag, the default matrix doesn't build it yet.
+  Linux. CMake still accepts `OSC_ENABLE_CUDA=ON`, so a CUDA-enabled
+  helper can be built by passing that through to `cmake` — it installs
+  under the ordinary `whisper-stt-server` name and reports
+  `whispercpp-cuda` at runtime like any other backend. What was removed
+  is the build script's `--cuda` flag, which built a SIDE-BY-SIDE
+  `whisper-stt-server-cuda` binary: `candidateBinaryPaths()` only ever
+  looks for the plain name, so that build could not be selected at
+  runtime no matter what the host had. Nothing in the script or the CI
+  matrix turns CUDA on today.
 - **No CoreML/ANE encoder.** Metal already covers Apple GPU; CoreML is
   a future perf refinement.
 - **HTTP integration test not on CI.** `npm run test:whisper-stt` does the

--- a/technical-documentation/architecture/transcription-and-captions.md
+++ b/technical-documentation/architecture/transcription-and-captions.md
@@ -374,20 +374,40 @@ export interface SttTranscribeResponse {
   detectedLanguage: string;
   backend: SttBackend; // "whispercpp-metal" | "whispercpp-vulkan"
                        // | "whispercpp-cuda" | "whispercpp-cpu"
+  timing?: SttTiming;  // { elapsedSec, audioSec, rtf }, summed over the chunks
 }
 ```
 
 `backend` is the device whisper.cpp actually bound at runtime — not the
-platform default `gpuDetector` would have guessed. Any consumer that wants
-to surface the backend in the UI reads it directly out of this field; the
-contract is the source of truth.
+platform default `gpuDetector` would have guessed — and `timing` is the
+helper's own measurement around `whisper_full`, summed over every chunk of
+the request. `rtf` keeps whisper.cpp's convention (wall-clock ÷ audio, so
+lower is faster); the "× real-time" figure the UI shows is its reciprocal,
+via `realtimeSpeed()` in `src/lib/ai-edition/transcription/status.ts`. It is
+optional because a staged helper binary can pre-date the field — absent, not
+zeroed, so "not reported" never renders as a measurement.
+
+For anything user-facing, though, read them off the STATUS events rather than
+this response: the response lands only once the whole recording is done,
+which is far too late to explain a wait that is already happening.
 
 The request takes a raw `Float32Array` of mono 16 kHz PCM and an optional
 ISO 639-1 `language` code; `"auto"` or absent leaves detection to Whisper.
 Status events fan out on a separate channel
 (`SttStatusEvent`, `phase: "model" | "transcribe"`) so the renderer can
 drive a "downloading model" / "transcribing" indicator without holding open
-the inference request.
+the inference request. Every landed chunk also carries `backend` and a
+running `rtf` (cumulative for the run, not for that one chunk — a per-chunk
+figure swings with how much speech a chunk holds and reads as noise), which
+is what lets the media surfaces render "Transcribing 45% · CPU · 0.9×" while
+the work is still going.
+
+`SttManager` logs the same pair per chunk through `console.*` — the channel
+the main-process ring buffer wraps, so the lines reach "Save Diagnostics",
+which the helper's own stderr does not — and warns once per run when the
+backend is `whispercpp-cpu`. That warning exists because the CPU path costs
+roughly half the throughput (median 2.07×, see the POC report) and is only
+ever reached through fallbacks that are otherwise completely silent.
 
 ## Captions
 


### PR DESCRIPTION
The whisper helper has always measured every `/inference` call and returned
`timing` next to `backend`. Nothing read either one, and nothing logged them, so
there was no way from inside the app to answer "am I running on GPU or CPU, and
how fast is it?" That matters because the CPU path costs roughly half the
throughput (median 2.07x on the reference machine,
`tools/stt-eval/whispercpp-dtw-poc/REPORT.md` 5.3) and every route onto it is a
silent fallback.

## 1. Surface the timing and backend (`3dc6462b`)

`timing` is threaded through as `SttTiming { elapsedSec, audioSec, rtf }` and
lands on **both** the response and the per-chunk status events. The status
channel is the important half: the response only arrives once the whole
recording is done, which is far too late to explain a wait already happening.

- **Per-chunk log**, through `console.*` — the channel the main-process ring
  buffer wraps, so the lines reach "Save Diagnostics". The helper's own stderr
  goes out via `process.stderr.write` and never did.

  ```
  [stt] chunk 2/3 on whispercpp-vulkan: 90.0s audio in 20.0s (0.22 rtf, 4.5x real-time)
  ```

- **One warning per run** (not per chunk) when the backend is `whispercpp-cpu`.
- **UI**: the running label becomes `Transcribing 45% - CPU - 0.9x`. "CPU" shows
  on the slow path only; the speed shows on any backend. Both live in the shared
  label, so all three status surfaces pick them up at once, per that module's
  existing design. The spinner gains an SVG `<title>` explaining the cost,
  translated into all 13 locales.

`rtf` keeps whisper.cpp's convention (wall-clock / audio, lower is faster);
`realtimeSpeed()` inverts it for display. `timing` is optional the whole way
down — a staged helper binary can pre-date the field — and absent rather than
zeroed, so "not reported" never renders as a measurement.

No change to `main.cpp`: it already emits everything needed, and adding a log
line there would require a native rebuild that a dev tree's staged binary
wouldn't have.

## 2. Drop the dead `--cuda` variant (`a79b0504`)

`build-whisper-stt.sh` could emit a side-by-side `whisper-stt-server-cuda`
binary that nothing could ever run: `candidateBinaryPaths()` only looks for the
plain name, so the CUDA build was unreachable at runtime regardless of the host.

The workflow input was broken in its own separate way — it set `ENABLE_CUDA` to
`"true"`/`"false"` while the script tested for `"ON"`, so selecting **true** in
the dispatch UI still skipped the build. Dead twice over.

CUDA itself is **not** removed. `OSC_ENABLE_CUDA` stays in `CMakeLists.txt`:
passing it to the primary build produces a normally-named binary that resolves
at runtime and reports `whispercpp-cuda` like any other backend, which is why
that member stays in the `SttBackend` union. Only the side-by-side variant that
nothing could select is gone.

## Testing

- 112 tests pass across `electron/stt`, `src/lib/ai-edition/transcription` and
  `src/i18n`; 18 are new, covering timing parse (including a missing block, a
  junk `rtf`, and stringified durations), per-run aggregation, the status-event
  payload, the once-per-run CPU warning, and the two new pure helpers.
- Locale parity passes for the new key across all 13 locales.
- `biome check` clean, `docs:check` OK, `bash -n` OK, `--cuda` now exits 2 as an
  unknown flag, and the workflow YAML parses with its jobs and `push` triggers
  intact.

One note for reviewers: `tsc` reports 6 errors and 31 test suites fail to load in
my checkout, all from `i18next`, `@tiptap/*` and `electron-updater` being
declared in `package.json` but absent from `node_modules`. Those are
pre-existing and unrelated; I verified `transcriptionStore.test.ts` against a
scoped `i18next` stub to confirm my change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1539999881660469389 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transcription progress now shows the active backend and real-time processing speed.
  * Added elapsed time, audio duration, and real-time-factor details when complete timing is available.
  * CPU-based transcription displays a localized performance hint.
* **Bug Fixes**
  * Improved validation and handling of incomplete or invalid timing data.
  * Added clearer CPU fallback warnings.
* **Documentation**
  * Updated transcription and build documentation to reflect supported Vulkan and CPU variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->