### PR TITLE
fix(editor): lay the camera box out from the camera, not from a guess

### DIFF
--- a/src/cli/CliExportRunner.tsx
+++ b/src/cli/CliExportRunner.tsx
@@ -211,6 +211,34 @@ async function runExport(request: CliExportRequest): Promise<CliDoneResult> {
 		axcutDocument = applyProbedDuration(axcutDocument, primaryAssetId, probed.durationMs / 1000);
 	}
 
+	// The camera's dimensions decide the PiP's layout box, and this is the one caller the
+	// document cannot answer for: there is no editor session here to have probed and saved
+	// them, so without this the CLI lays the box out from a hardcoded 4:3 and a 16:9 camera
+	// exports framed differently from the same project opened in the app.
+	//
+	// Failure-tolerant on purpose, unlike the screen probe above which is allowed to reject:
+	// a camera file that has gone missing should cost the export its camera, not the export.
+	if (media.webcamVideoPath) {
+		const camera = await probeVideoDimensions(toFileUrl(media.webcamVideoPath)).catch(() => null);
+		if (camera) {
+			axcutDocument = {
+				...axcutDocument,
+				assets: axcutDocument.assets.map((asset) =>
+					asset.cameraTrack
+						? {
+								...asset,
+								cameraTrack: {
+									...asset.cameraTrack,
+									width: camera.width,
+									height: camera.height,
+								},
+							}
+						: asset,
+				),
+			};
+		}
+	}
+
 	if (request.autoZoom) {
 		const added = appendAutoZoomRanges(axcutDocument, cursorTelemetry, probed.durationMs);
 		window.electronAPI.cliLog("info", `Auto-zoom: added ${added} region(s) from cursor telemetry`);

--- a/src/lib/ai-edition/schema/index.ts
+++ b/src/lib/ai-edition/schema/index.ts
@@ -120,6 +120,17 @@ export const cameraTrackSchema = z
 		startMs: z.number().nonnegative().default(0),
 		offsetMs: z.number().int().default(0),
 		visible: z.boolean().default(true),
+		// The camera file's real pixel dimensions, the camera's answer to
+		// `assetVideoSchema.width/height` for the screen. The layout box for the PiP is
+		// derived from them, and without them it falls back to a hardcoded 4:3 — which is
+		// how a 16:9 camera came out framed one way in the preview (where a mounted
+		// <video> had reported its size) and another way in an export (where none had).
+		//
+		// Optional and absent on every document written before this, exactly like
+		// `transcriptionFailure` below: additive, so no schema-version bump, and an older
+		// build simply drops the key on save. The fallback stays for that window.
+		width: z.number().int().positive().optional(),
+		height: z.number().int().positive().optional(),
 	})
 	.nullable()
 	.default(null);

--- a/src/lib/ai-edition/store/projectStore.ts
+++ b/src/lib/ai-edition/store/projectStore.ts
@@ -1,5 +1,6 @@
 import { toast } from "sonner";
 import { create } from "zustand";
+import { toFileUrl } from "@/components/video-editor/projectPersistence";
 import { toastText } from "@/i18n/toastText";
 import { nativeBridgeClient } from "@/native/client";
 import {
@@ -8,6 +9,7 @@ import {
 	restoreFullTimeline as restoreFullTimelineOp,
 } from "../document/timeline";
 import { type AxcutAsset, type AxcutDocument, documentSchema } from "../schema";
+import { probeVideoDimensions } from "../timeline/duration";
 
 // ponytail: thin Zustand wrapper over the native-bridge client. Keeps the
 // current project + revision counter in renderer memory; mutations round-trip
@@ -157,6 +159,17 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 			try {
 				const camera = await window.electronAPI.findRecordingCamera(addedAsset.originalPath);
 				if (camera.success && camera.webcamVideoPath) {
+					// Stamp the camera's real dimensions at link time so a new recording never
+					// needs the backfill in `useTimeline`. They decide the PiP's layout box, and
+					// without them it falls back to a hardcoded 4:3 — which is how a 16:9 camera
+					// used to be framed one way in the preview and another in an export.
+					//
+					// Deliberately outside the shape below and deliberately non-fatal: a probe
+					// that fails must leave the link intact and let the backfill try again later,
+					// never take the `catch` that drops the camera from the recording entirely.
+					const camDims = await probeVideoDimensions(toFileUrl(camera.webcamVideoPath)).catch(
+						() => null,
+					);
 					const linked = {
 						sourcePath: camera.webcamVideoPath,
 						startMs: 0,
@@ -174,6 +187,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 						// the way IN rather than only at the recorder.
 						offsetMs: Math.round(camera.offsetMs ?? 0),
 						visible: true,
+						...(camDims ?? {}),
 					};
 					const next: AxcutDocument = {
 						...document,

--- a/src/lib/ai-edition/store/useTimeline.ts
+++ b/src/lib/ai-edition/store/useTimeline.ts
@@ -144,21 +144,41 @@ export function useTimeline() {
 	useEffect(() => {
 		if (!document) return;
 		const usedAssetIds = new Set(document.timeline.clips.map((c) => c.assetId));
+		type Asset = (typeof document.assets)[number];
+		const needsScreen = (a: Asset) =>
+			Boolean(a.originalPath) && (!a.video || !a.video.width || !a.video.height);
+		// The camera is backfilled the same way and for the same reason. The PiP's layout
+		// box is derived from these dimensions, so an asset that never carried them was
+		// laid out from a hardcoded 4:3 — and differently depending on who was asking: the
+		// preview had a mounted <video> reporting the real size, an export had nothing, so
+		// a 16:9 camera came out framed one way on screen and another in the file.
+		const needsCamera = (a: Asset) =>
+			Boolean(a.cameraTrack?.sourcePath) && (!a.cameraTrack?.width || !a.cameraTrack?.height);
 		const missing = document.assets.filter(
 			(a) =>
 				usedAssetIds.has(a.id) &&
-				a.originalPath &&
-				(!a.video || !a.video.width || !a.video.height) &&
+				(needsScreen(a) || needsCamera(a)) &&
 				!probedAssetIdsRef.current.has(a.id),
 		);
 		if (missing.length === 0) return;
 		let cancelled = false;
 		void (async () => {
-			const probed: Record<string, { width: number; height: number }> = {};
+			type Dims = { width: number; height: number };
+			const probed: Record<string, { video?: Dims; camera?: Dims }> = {};
 			for (const a of missing) {
 				probedAssetIdsRef.current.add(a.id);
-				const dims = await probeVideoDimensions(toFileUrl(a.originalPath));
-				if (dims) probed[a.id] = dims;
+				const entry: { video?: Dims; camera?: Dims } = {};
+				if (needsScreen(a)) {
+					const dims = await probeVideoDimensions(toFileUrl(a.originalPath));
+					if (dims) entry.video = dims;
+				}
+				// Probed independently of the screen: one file being unreadable must not cost
+				// the other its dimensions, and a camera-less asset simply skips this.
+				if (a.cameraTrack && needsCamera(a)) {
+					const dims = await probeVideoDimensions(toFileUrl(a.cameraTrack.sourcePath));
+					if (dims) entry.camera = dims;
+				}
+				if (entry.video || entry.camera) probed[a.id] = entry;
 			}
 			if (cancelled || Object.keys(probed).length === 0) return;
 			// Re-read fresh state so a concurrent edit made while probing isn't stomped.
@@ -166,11 +186,19 @@ export function useTimeline() {
 			if (!current) return;
 			await useProjectStore.getState().saveDocument({
 				...current,
-				assets: current.assets.map((a) =>
-					probed[a.id]
-						? { ...a, video: { codec: "unknown", fps: 0, ...a.video, ...probed[a.id] } }
-						: a,
-				),
+				assets: current.assets.map((a) => {
+					const found = probed[a.id];
+					if (!found) return a;
+					return {
+						...a,
+						...(found.video
+							? { video: { codec: "unknown", fps: 0, ...a.video, ...found.video } }
+							: {}),
+						...(found.camera && a.cameraTrack
+							? { cameraTrack: { ...a.cameraTrack, ...found.camera } }
+							: {}),
+					};
+				}),
 			});
 		})();
 		return () => {

--- a/src/native/sceneDescription.test.ts
+++ b/src/native/sceneDescription.test.ts
@@ -939,6 +939,56 @@ describe("buildSceneDescription.settings mapping", () => {
 		expect(pixelWidth / pixelHeight).toBeCloseTo(4 / 3, 1);
 	});
 
+	it("lays the camera box out from the camera's own dimensions, with no second argument", () => {
+		// The parity claim, and the reason `cameraTrack` carries dimensions at all.
+		//
+		// The case above passes a cameraTrack WITHOUT dimensions and gets 4:3 — the fallback,
+		// which is correct for a document written before the field existed. This one carries
+		// them, and must get 16:9 from the ARGUMENT-FREE call, because that is the call every
+		// export makes: `ExportDialog` and the CLI runner both invoke
+		// `buildSceneDescription(document)` with nothing else.
+		//
+		// Before the camera's size lived in the document, only the preview could supply it —
+		// through the optional second argument, filled from a mounted <video>'s reported size.
+		// So the same project framed a 16:9 camera 16:9 on screen and 4:3 in the file, and
+		// `cover_uv_rect` (Rust) trimmed the authored crop to that wrong box. This test fails
+		// on any version where the box depends on who is asking.
+		const asset = makeAsset({
+			id: "a",
+			originalPath: "/a.mp4",
+			video: { codec: "h264", width: 1920, height: 1080, fps: 30 },
+			cameraTrack: {
+				sourcePath: "/a-webcam.mp4",
+				startMs: 0,
+				offsetMs: 0,
+				visible: true,
+				width: 1280,
+				height: 720,
+			},
+		});
+		const doc = makeDoc({
+			assets: [asset],
+			clips: [
+				makeClip({
+					id: "c1",
+					assetId: "a",
+					sourceStartSec: 0,
+					sourceEndSec: 1,
+					timelineStartSec: 0,
+					timelineEndSec: 1,
+				}),
+			],
+			legacyEditor: { webcamSizePreset: 25 },
+		});
+		const scene = buildSceneDescription(doc);
+		const rect = scene.layout.webcamRect;
+		expect(rect).not.toBeNull();
+		// Pixel ratio, not fraction ratio — see the neighbouring case for why.
+		const pixelWidth = rect!.width * scene.output.width;
+		const pixelHeight = rect!.height * scene.output.height;
+		expect(pixelWidth / pixelHeight).toBeCloseTo(16 / 9, 1);
+	});
+
 	it("layout.webcamRect is null when no-webcam preset is selected", () => {
 		const doc = makeDoc({
 			legacyEditor: { webcamLayoutPreset: "no-webcam" },

--- a/src/native/sceneDescription.ts
+++ b/src/native/sceneDescription.ts
@@ -620,13 +620,39 @@ export function buildSceneDescription(
 	 * screen squeezed into its half with nothing beside it. `has_webcam` (native) only
 	 * gates the camera's own draw — it cannot give the screen its frame back.
 	 */
-	const croppedWebcamSize = webcamSourceSize
-		? {
-				width: Math.max(1, webcamSourceSize.width * settings.webcamCropRegion.width),
-				height: Math.max(1, webcamSourceSize.height * settings.webcamCropRegion.height),
-			}
-		: null;
-	const layoutForClip = (screenSize: { width: number; height: number }, hasCamera: boolean) => {
+	/**
+	 * The camera source SHAPE of a clip, resolved the same way and for the same reasons
+	 * as `screenSourceSizeOf` above: per clip, because two clips need not have been
+	 * recorded with the same camera.
+	 *
+	 * The order matters. `cameraTrack.width/height` comes FIRST because it is the only
+	 * source every caller has: it is in the document, so the export dialog and the CLI
+	 * runner read it exactly as the preview does. `webcamSourceSize` is second, as a
+	 * fresher-than-disk override for the window before the backfill has written the
+	 * dimensions — it is what a mounted <video> just reported, and only the preview can
+	 * ever supply it. The hardcoded 4:3 is last and is now only reached for a document
+	 * that predates the field, opened somewhere with no camera element mounted.
+	 *
+	 * That ordering is the fix: the box used to depend on WHO was asking rather than on
+	 * what was recorded, so a 16:9 camera was framed 16:9 in the preview and 4:3 in the
+	 * export. Everything below reads the same answer now.
+	 */
+	const webcamSourceSizeOf = (clip: AxcutClip) => {
+		const camera = assetById.get(clip.assetId)?.cameraTrack;
+		const source =
+			camera?.width && camera?.height
+				? { width: camera.width, height: camera.height }
+				: (webcamSourceSize ?? { width: 960, height: 720 });
+		return {
+			width: Math.max(1, Math.round(source.width * settings.webcamCropRegion.width)),
+			height: Math.max(1, Math.round(source.height * settings.webcamCropRegion.height)),
+		};
+	};
+	const layoutForClip = (
+		screenSize: { width: number; height: number },
+		hasCamera: boolean,
+		camSize: { width: number; height: number },
+	) => {
 		const preset = resolveWebcamLayoutPreset(settings.webcamLayoutPreset, hasCamera);
 		return computeCompositeLayout({
 			canvasSize: outputDims,
@@ -635,8 +661,7 @@ export function buildSceneDescription(
 				height: Math.round(outputDims.height * paddingFit),
 			},
 			screenSize,
-			webcamSize:
-				preset === "no-webcam" ? null : (croppedWebcamSize ?? { width: 960, height: 720 }),
+			webcamSize: preset === "no-webcam" ? null : camSize,
 			layoutPreset: preset,
 			webcamSizePreset: settings.webcamSizePreset,
 			webcamPosition: preset === "picture-in-picture" ? settings.webcamPosition : null,
@@ -672,12 +697,18 @@ export function buildSceneDescription(
 	// `for_clip_window` (Rust) selects the entry for the clip being composed, so the
 	// draw path keeps reading a single `layout` and needs no per-clip branch of its own.
 	const layoutByClip = visibleClips.map((clip, index) =>
-		resolvedLayoutOf(layoutForClip(screenSourceSizeOf(clip, index), clipHasCamera(clip))),
+		resolvedLayoutOf(
+			layoutForClip(screenSourceSizeOf(clip, index), clipHasCamera(clip), webcamSourceSizeOf(clip)),
+		),
 	);
 	// Scalar fields stay the FIRST clip's layout: they are the fallback for a payload
 	// without `layoutByClip`, and the value native starts from before any clip is active.
 	const computedLayout = visibleClips[0]
-		? layoutForClip(screenSourceSizeOf(visibleClips[0], 0), clipHasCamera(visibleClips[0]))
+		? layoutForClip(
+				screenSourceSizeOf(visibleClips[0], 0),
+				clipHasCamera(visibleClips[0]),
+				webcamSourceSizeOf(visibleClips[0]),
+			)
 		: null;
 	const webcamRect = computedLayout?.webcamRect
 		? toFrameFractions(computedLayout.webcamRect)


### PR DESCRIPTION
## Summary

A 16:9 webcam is framed one way in the preview and another in the export — the exported rectangle taller than the one on screen. Reported from the running app and reproduced there.

`buildSceneDescription(document, webcamSourceSize = null)` sizes the PiP box from `webcamSourceSize ?? { width: 960, height: 720 }`, and only one of its three callers passes that argument:

| caller | passes the camera size? | box laid out from |
|---|---|---|
| `NativeCompositorOverlay` (preview) | **yes** | the real camera — 1280×720 → 16:9 |
| `ExportDialog` | **no** | hardcoded `{960, 720}` → 4:3 |
| `CliExportRunner` | **no** | hardcoded `{960, 720}` → 4:3 |

Native then trims the camera to whatever box it was handed: `cover_uv_rect` keeps full height and cuts the width for a 16:9 source in a 4:3 box — 12.5% off each side.

So the box depended on **who was asking** rather than on what was recorded. The preview had a mounted `<video>` to ask, filling a module-scope `Map` from `WebcamOverlay`'s `loadedmetadata` handler; an export has no DOM, and the CLI has no renderer, so neither could ever have filled that `Map`. `sceneDescription.ts`'s own comment already describes this failure — *"a 16:9 webcam shipped to a 4:3 box"* — but the fix was only ever wired into the preview.

## The fix

The screen never had this problem, and how it avoids it is the fix. `asset.video` carries the screen's real dimensions **in the document**, which is why `buildSceneDescription(document)` with no second argument is already correct for the screen at all three call sites. The camera was simply never given the same treatment.

- **`cameraTrackSchema` gains optional `width`/`height`**, beside the `sourcePath` they describe. Additive and absent on every older document, so no schema-version bump and no migration — an older build drops the key on save.
- **`sceneDescription` resolves the camera size per clip**, as the screen already did: the cameraTrack's dimensions first, then the `webcamSourceSize` argument, then the 4:3. Per clip because two clips need not have been recorded with the same camera. The argument stays, as a fresher-than-disk override for the window before the backfill lands — only the preview can ever supply it.
- **`projectStore` probes and stamps at camera-link time**, so a new recording never needs the backfill. Non-fatal on purpose: a failed probe must not take the `catch` that drops the camera from the recording entirely.
- **`useTimeline`'s once-per-session backfill heals already-saved projects**, probing the two files independently so one unreadable file cannot cost the other its dimensions.
- **`CliExportRunner` probes the camera itself** — the one caller the document cannot answer for. Unlike its screen probe, this one tolerates failure: a missing camera file should cost the export its camera, not the export.

`ExportDialog` is untouched, and that is the point: the divergence closes at the source rather than by asking every caller to remember a second argument.

## Related issue

None — found while reviewing [#344](https://github.com/getopenscreen/openscreen/pull/344), but pre-existing and independent of it: the three call sites are byte-identical before and after that PR. #344 made it visible by giving the user a crop to author inside that box.

## Type of change
- [x] Bug fix

## Release impact
- [x] Patch

## Desktop impact
- [x] Windows
- [x] macOS
- [x] Linux

## Screenshots / video

No new UI. The visible change is that the camera rectangle in an export now matches the one in the preview.

## Testing

- New case in `sceneDescription.test.ts`: a cameraTrack carrying 1280×720, an **argument-free** call, and a `webcamRect` whose pixel ratio must be 16/9. It reads 1.33 without the cameraTrack lookup — verified by removing it.
- The existing 4:3 case passes untouched. Its fixture carries no dimensions, so it now covers the fallback path rather than the only path.
- `tsc`, `tsc -p tsconfig.test.json`, `biome check .` pass. Full Vitest suite green: 166 files, 1939 passed, 4 skipped.

## Not addressed here

`PreviewCanvas` still hardcodes the same `{960, 720}` for the DOM webcam slot's drag hitbox, so that rectangle can differ from the drawn PiP whenever the camera is not 4:3. It is a third consumer of the same constant, and the document can now answer for it too.

<!-- discord-thread-id:1540008852223819848 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Camera video dimensions are now detected and saved when available.
  * Picture-in-picture layouts now reflect the webcam’s actual aspect ratio, with a 4:3 fallback when dimensions are unavailable.
  * Exported projects preserve camera dimensions for more accurate scene layouts.

* **Bug Fixes**
  * Webcam detection failures no longer interrupt exports or camera linking.
  * Screen video dimensions are still captured even when camera metadata cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->