### PR TITLE
fix(editor): keep the webcam pan when the zoom passes through 100%

### DIFF
--- a/src/components/ai-edition/RightPanes.layout.test.tsx
+++ b/src/components/ai-edition/RightPanes.layout.test.tsx
@@ -5,7 +5,7 @@
 // the saved preference is left untouched on disk and the help popover says so.
 
 import "@testing-library/jest-dom";
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { I18nProvider } from "@/contexts/I18nContext";
@@ -125,5 +125,67 @@ describe("LayoutPane camera availability", () => {
 		// The camera-less hint must not leak into the normal case.
 		await user.click(screen.getByRole("button", { name: "Help" }));
 		expect(screen.getByRole("note")).not.toHaveTextContent(/saved layout is kept/i);
+	});
+});
+
+// #412. The pan used to be read back out of the crop rect, which cannot hold it: at 100%
+// zoom the crop IS the frame, so its offset is 0 for every pan the user could have chosen.
+// A trip down to 100% therefore erased the framing rather than suspending it.
+describe("LayoutPane webcam crop pan", () => {
+	const zoom = () => screen.getByRole("slider", { name: "Zoom" });
+	const panX = () => screen.getByRole("slider", { name: "Pan horizontally" });
+	const set = (slider: HTMLElement, value: number) =>
+		fireEvent.change(slider, { target: { value: String(value) } });
+
+	it("keeps the pan across a round trip through 100% zoom", () => {
+		renderLayout(seedProject(true));
+
+		set(zoom(), 200);
+		set(panX(), 75);
+		expect(panX()).toHaveValue("75");
+
+		set(zoom(), 100);
+		// Nowhere to pan at full frame, so the control is correctly out of reach...
+		expect(panX()).toBeDisabled();
+
+		set(zoom(), 200);
+		// ...but the intent survived the trip.
+		expect(panX()).toHaveValue("75");
+	});
+
+	it("does not move the pan while the zoom slider is dragged", () => {
+		// The old clamp squeezed the rect's offset toward the near edge as the window grew,
+		// so the pan slider crept upward on its own while the picture stayed put.
+		renderLayout(seedProject(true));
+
+		set(zoom(), 200);
+		set(panX(), 75);
+
+		for (const pct of [180, 150, 120, 110, 101]) {
+			set(zoom(), pct);
+			expect(panX()).toHaveValue("75");
+		}
+	});
+
+	it("puts the crop where the pan says, at any zoom", () => {
+		renderLayout(seedProject(true));
+
+		set(zoom(), 200);
+		set(panX(), 100);
+		// Hard against the right edge: a half-width window starts halfway across.
+		let crop = useProjectStore.getState().document?.legacyEditor?.webcamCropRegion as unknown as {
+			x: number;
+			width: number;
+		};
+		expect(crop.width).toBeCloseTo(0.5);
+		expect(crop.x).toBeCloseTo(0.5);
+
+		set(zoom(), 400);
+		// Clamped to the slider's 300% ceiling, so a third of the frame, still hard right.
+		crop = useProjectStore.getState().document?.legacyEditor?.webcamCropRegion as unknown as {
+			x: number;
+			width: number;
+		};
+		expect(crop.x).toBeCloseTo(1 - crop.width);
 	});
 });

--- a/src/components/ai-edition/RightPanes.layout.test.tsx
+++ b/src/components/ai-edition/RightPanes.layout.test.tsx
@@ -134,8 +134,14 @@ describe("LayoutPane camera availability", () => {
 describe("LayoutPane webcam crop pan", () => {
 	const zoom = () => screen.getByRole("slider", { name: "Zoom" });
 	const panX = () => screen.getByRole("slider", { name: "Pan horizontally" });
+	const panY = () => screen.getByRole("slider", { name: "Pan vertically" });
 	const set = (slider: HTMLElement, value: number) =>
 		fireEvent.change(slider, { target: { value: String(value) } });
+	const storedCrop = () =>
+		useProjectStore.getState().document?.legacyEditor as unknown as {
+			webcamCropRegion: { x: number; y: number; width: number; height: number };
+			webcamCropPan: { x: number; y: number };
+		};
 
 	it("keeps the pan across a round trip through 100% zoom", () => {
 		renderLayout(seedProject(true));
@@ -165,6 +171,22 @@ describe("LayoutPane webcam crop pan", () => {
 			set(zoom(), pct);
 			expect(panX()).toHaveValue("75");
 		}
+	});
+
+	it("wires the vertical slider to the vertical axis", () => {
+		// The two sliders differ by one character in the handler they call. Without this,
+		// a Y slider wired to "x" would pass every other test in this block.
+		renderLayout(seedProject(true));
+
+		set(zoom(), 200);
+		set(panY(), 80);
+
+		expect(panY()).toHaveValue("80");
+		expect(storedCrop().webcamCropPan.y).toBeCloseTo(0.8);
+		expect(storedCrop().webcamCropRegion.y).toBeCloseTo(0.4);
+		// ...and it left the horizontal axis alone.
+		expect(panX()).toHaveValue("50");
+		expect(storedCrop().webcamCropRegion.x).toBeCloseTo(0.25);
 	});
 
 	it("puts the crop where the pan says, at any zoom", () => {

--- a/src/components/ai-edition/RightPanes.tsx
+++ b/src/components/ai-edition/RightPanes.tsx
@@ -1542,20 +1542,30 @@ export function LayoutPane() {
 	const helpText = hasDocument && !hasAnyCamera ? ts("layout.helpNoWebcam") : ts("layout.help");
 	const webcamCrop = settings.webcamCropRegion;
 	const cropZoomPct = Math.round(100 / webcamCrop.width);
-	const cropPanX = webcamCrop.width >= 0.999 ? 50 : (webcamCrop.x / (1 - webcamCrop.width)) * 100;
-	const cropPanY = webcamCrop.height >= 0.999 ? 50 : (webcamCrop.y / (1 - webcamCrop.height)) * 100;
+	// Read straight off the pan, not back out of the rect. The rect cannot answer at 100%
+	// zoom — it is the whole frame, so its offset is 0 whatever the user chose — and it gave
+	// a drifting answer on the way there, because the offset gets squeezed toward the near
+	// edge as the window grows while the picture itself does not move.
+	const cropPan = settings.webcamCropPan;
+	const cropPanX = cropPan.x * 100;
+	const cropPanY = cropPan.y * 100;
+	/** Rect from zoom and pan. `pan * (1 - size)` cannot leave the frame, so nothing clamps. */
+	const cropRegionFor = (size: number, pan: { x: number; y: number }) => ({
+		x: pan.x * (1 - size),
+		y: pan.y * (1 - size),
+		width: size,
+		height: size,
+	});
 	const setCropZoom = (zoomPct: number) => {
 		const size = 100 / Math.max(100, zoomPct);
-		const centerX = webcamCrop.x + webcamCrop.width / 2;
-		const centerY = webcamCrop.y + webcamCrop.height / 2;
-		setLive({
-			webcamCropRegion: {
-				x: Math.min(1 - size, Math.max(0, centerX - size / 2)),
-				y: Math.min(1 - size, Math.max(0, centerY - size / 2)),
-				width: size,
-				height: size,
-			},
-		});
+		// A pure function of (pan, size): the pan is never re-derived from the rect this
+		// writes, so dragging the zoom back and forth returns the framing it started from.
+		setLive({ webcamCropRegion: cropRegionFor(size, cropPan) });
+	};
+	const setCropPan = (axis: "x" | "y", valuePct: number) => {
+		const pan = { ...cropPan, [axis]: valuePct / 100 };
+		// One patch for both, so a half-written pair can never reach disk.
+		setLive({ webcamCropPan: pan, webcamCropRegion: cropRegionFor(webcamCrop.width, pan) });
 	};
 	return (
 		<Pane title={ts("layout.title")} icon={<LayoutIcon size={14} />} helpText={helpText}>
@@ -1710,11 +1720,7 @@ export function LayoutPane() {
 					max={100}
 					suffix="%"
 					disabled={layoutControlsDisabled || webcamCrop.width >= 0.999}
-					onChange={(value) =>
-						setLive({
-							webcamCropRegion: { ...webcamCrop, x: (value / 100) * (1 - webcamCrop.width) },
-						})
-					}
+					onChange={(value) => setCropPan("x", value)}
 					onCommit={() => void commit()}
 				/>
 				<SliderCell
@@ -1724,11 +1730,7 @@ export function LayoutPane() {
 					max={100}
 					suffix="%"
 					disabled={layoutControlsDisabled || webcamCrop.height >= 0.999}
-					onChange={(value) =>
-						setLive({
-							webcamCropRegion: { ...webcamCrop, y: (value / 100) * (1 - webcamCrop.height) },
-						})
-					}
+					onChange={(value) => setCropPan("y", value)}
 					onCommit={() => void commit()}
 				/>
 			</div>

--- a/src/lib/ai-edition/store/editorSettings.test.ts
+++ b/src/lib/ai-edition/store/editorSettings.test.ts
@@ -156,4 +156,49 @@ describe("patchEditorSettings", () => {
 		expect(crop.width).toBeCloseTo(0.01);
 		expect(crop.height).toBeCloseTo(0.01);
 	});
+
+	// Every project on disk today carries a crop rect and no pan, because the pan did not
+	// exist when they were saved. Recovering it from the rect is what keeps opening one a
+	// no-op; defaulting to centred would quietly reframe all of them.
+	it("recovers the pan of a crop authored before the pan was stored", () => {
+		const doc: AxcutDocument = {
+			...baseDoc,
+			legacyEditor: { webcamCropRegion: { x: 0.375, y: 0, width: 0.5, height: 0.5 } },
+		};
+
+		const snap = getEditorSettings(doc);
+		// 0.375 of the 0.5 the crop leaves free is three quarters of the way across.
+		expect(snap.webcamCropPan.x).toBeCloseTo(0.75);
+		expect(snap.webcamCropPan.y).toBeCloseTo(0);
+		// And the rect comes back exactly as it went in — this is the identity that makes
+		// the change invisible to an existing document.
+		expect(snap.webcamCropRegion.x).toBeCloseTo(0.375);
+		expect(snap.webcamCropRegion.y).toBeCloseTo(0);
+	});
+
+	it("reads a full-frame crop as centred, since it has no room to sit in", () => {
+		const doc: AxcutDocument = {
+			...baseDoc,
+			legacyEditor: { webcamCropRegion: { x: 0, y: 0, width: 1, height: 1 } },
+		};
+
+		expect(getEditorSettings(doc).webcamCropPan).toEqual({ x: 0.5, y: 0.5 });
+	});
+
+	it("rebuilds the crop's offset from the pan when the two disagree on disk", () => {
+		// The pan is authoritative: a rect whose offset contradicts it is a half-written
+		// pair, and the pan is the half that carries intent.
+		const doc: AxcutDocument = {
+			...baseDoc,
+			legacyEditor: {
+				webcamCropRegion: { x: 0, y: 0, width: 0.5, height: 0.5 },
+				webcamCropPan: { x: 1, y: 0.5 },
+			},
+		};
+
+		const crop = getEditorSettings(doc).webcamCropRegion;
+		expect(crop.x).toBeCloseTo(0.5);
+		expect(crop.y).toBeCloseTo(0.25);
+		expect(crop.width).toBeCloseTo(0.5);
+	});
 });

--- a/src/lib/ai-edition/store/editorSettings.test.ts
+++ b/src/lib/ai-edition/store/editorSettings.test.ts
@@ -201,4 +201,42 @@ describe("patchEditorSettings", () => {
 		expect(crop.y).toBeCloseTo(0.25);
 		expect(crop.width).toBeCloseTo(0.5);
 	});
+
+	it("clamps a stored pan that is out of range", () => {
+		const doc: AxcutDocument = {
+			...baseDoc,
+			legacyEditor: {
+				webcamCropRegion: { x: 0, y: 0, width: 0.5, height: 0.5 },
+				webcamCropPan: { x: 5, y: -2 },
+			},
+		};
+
+		const snap = getEditorSettings(doc);
+		expect(snap.webcamCropPan).toEqual({ x: 1, y: 0 });
+		// And the rect that follows from it still sits inside the frame.
+		expect(snap.webcamCropRegion.x).toBeCloseTo(0.5);
+		expect(snap.webcamCropRegion.y).toBeCloseTo(0);
+	});
+
+	it("falls back per axis when only one of the pan's coordinates is usable", () => {
+		// A half-written or hand-edited pan must not drag the good axis down with it: each
+		// coordinate recovers from the rect on its own.
+		const doc: AxcutDocument = {
+			...baseDoc,
+			legacyEditor: {
+				webcamCropRegion: { x: 0.375, y: 0.125, width: 0.5, height: 0.5 },
+				webcamCropPan: { x: "left", y: 0.9 } as unknown as { x: number; y: number },
+			},
+		};
+
+		const snap = getEditorSettings(doc);
+		// x is unusable, so it comes back from the rect: 0.375 of the 0.5 free is 0.75.
+		expect(snap.webcamCropPan.x).toBeCloseTo(0.75);
+		// y is a number, so it is kept — and 0.9 is deliberately NOT what the rect implies
+		// (0.125 of 0.5 free would be 0.25), so this fails if the axes are not independent.
+		expect(snap.webcamCropPan.y).toBeCloseTo(0.9);
+		// The rect then follows each axis from its own resolved pan.
+		expect(snap.webcamCropRegion.x).toBeCloseTo(0.375);
+		expect(snap.webcamCropRegion.y).toBeCloseTo(0.45);
+	});
 });

--- a/src/lib/ai-edition/store/editorSettings.ts
+++ b/src/lib/ai-edition/store/editorSettings.ts
@@ -58,6 +58,26 @@ export function audioGainScalar(gainDb: number): number {
 	return 10 ** (gainDb / 20);
 }
 
+/**
+ * Where the webcam crop window sits inside the room its zoom leaves, 0..1 per axis:
+ * 0 hard against one edge, 1 against the other, 0.5 centred.
+ *
+ * Stored because the rect cannot hold it. At 100% zoom the crop IS the frame, so `x` and `y`
+ * are necessarily 0 and the pan they used to be read back from is gone — which meant a trip
+ * down to 100% and back erased the framing the user had set. Expressed as a fraction of the
+ * available room, the pan survives every zoom, including the one where it does not apply.
+ *
+ * This never leaves the app. `webcamCropRegion` remains the only thing the scene carries to
+ * the compositor, so the preview and the export see exactly what they saw before.
+ */
+export interface CropPan {
+	x: number;
+	y: number;
+}
+
+/** Centred: the crop window sits in the middle of whatever room the zoom leaves. */
+const DEFAULT_CROP_PAN: CropPan = { x: 0.5, y: 0.5 };
+
 export interface EditorSettingsSnapshot {
 	wallpaper: string;
 	aspectRatio: AspectRatio;
@@ -74,6 +94,9 @@ export interface EditorSettingsSnapshot {
 	webcamSizePreset: WebcamSizePreset;
 	webcamPosition: WebcamPosition | null;
 	webcamCropRegion: CropRegion;
+	/** Where the crop window sits in the room the zoom leaves it, 0..1 per axis.
+	 *  Authoritative: `webcamCropRegion.x/y` are rebuilt from it on read. */
+	webcamCropPan: CropPan;
 	audioGainDb: number;
 	cursor: CursorVisualSettings;
 	cursorShow: boolean;
@@ -102,6 +125,7 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettingsSnapshot = {
 	webcamSizePreset: DEFAULT_WEBCAM_SIZE_PRESET,
 	webcamPosition: DEFAULT_WEBCAM_POSITION,
 	webcamCropRegion: DEFAULT_CROP_REGION,
+	webcamCropPan: DEFAULT_CROP_PAN,
 	audioGainDb: 0,
 	cursor: {
 		size: DEFAULT_CURSOR_SIZE,
@@ -131,6 +155,7 @@ interface LegacyShape {
 	webcamSizePreset?: WebcamSizePreset;
 	webcamPosition?: WebcamPosition | null;
 	webcamCropRegion?: CropRegion;
+	webcamCropPan?: CropPan;
 	audioGainDb?: number;
 	cursorSize?: number;
 	cursorSmoothing?: number;
@@ -168,6 +193,19 @@ export function getEditorSettings(doc: AxcutDocument | null | undefined): Editor
 		clickBounce: num(legacy?.cursorClickBounce, DEFAULT_EDITOR_SETTINGS.cursor.clickBounce),
 		clipToBounds: bool(legacy?.cursorClipToBounds, DEFAULT_EDITOR_SETTINGS.cursor.clipToBounds),
 	};
+
+	// The pan is authoritative and the rect's offset is rebuilt from it, so the two cannot
+	// drift apart — on disk, or in a patch that wrote one and not the other. Only the SIZE
+	// survives from the stored rect; `pan * (1 - size)` is a position that cannot leave the
+	// frame, which is why nothing here clamps it.
+	const storedCrop = normaliseCropRegion(legacy?.webcamCropRegion);
+	const webcamCropPan = normaliseCropPan(legacy?.webcamCropPan, storedCrop);
+	const webcamCrop: CropRegion = {
+		...storedCrop,
+		x: webcamCropPan.x * (1 - storedCrop.width),
+		y: webcamCropPan.y * (1 - storedCrop.height),
+	};
+
 	return {
 		wallpaper: str(legacy?.wallpaper, DEFAULT_EDITOR_SETTINGS.wallpaper),
 		aspectRatio: legacy?.aspectRatio ?? DEFAULT_EDITOR_SETTINGS.aspectRatio,
@@ -186,7 +224,8 @@ export function getEditorSettings(doc: AxcutDocument | null | undefined): Editor
 		),
 		webcamSizePreset: num(legacy?.webcamSizePreset, DEFAULT_EDITOR_SETTINGS.webcamSizePreset),
 		webcamPosition: normaliseWebcamPosition(legacy?.webcamPosition),
-		webcamCropRegion: normaliseCropRegion(legacy?.webcamCropRegion),
+		webcamCropRegion: webcamCrop,
+		webcamCropPan: webcamCropPan,
 		// Same bound the slider offers and the native `finish_audio` clamps to. Two
 		// different ranges for one value is how a project ends up exporting a gain the
 		// UI cannot display.
@@ -216,6 +255,7 @@ export interface EditorSettingsPatch {
 	webcamSizePreset?: WebcamSizePreset;
 	webcamPosition?: WebcamPosition | null;
 	webcamCropRegion?: CropRegion;
+	webcamCropPan?: CropPan;
 	audioGainDb?: number;
 	cursor?: Partial<CursorVisualSettings> & { theme?: string; show?: boolean };
 	autoFocusAll?: boolean;
@@ -271,6 +311,36 @@ function normaliseWebcamPosition(value: unknown): WebcamPosition | null {
 }
 
 const MIN_CROP_SIZE = 0.01;
+
+/**
+ * Recovers the pan of a crop rect authored before the pan was stored.
+ *
+ * `x / (1 - width)` is the expression the pane used to derive the slider's value from the
+ * rect on every render, and it has to stay that expression: every project on disk today has
+ * a rect and no pan, so anything else here would silently reframe them on first open. A
+ * full-frame crop has no room to sit in, so it reports centred — the one case where the
+ * answer is arbitrary, and the one case where nothing depends on it.
+ */
+function panOfCropRegion(crop: CropRegion): CropPan {
+	// Guarded at 1 and not at some epsilon below it: the zoom slider is integer percent, so
+	// the smallest window short of full frame is 100/101 and leaves ~0.0099 of room — a
+	// perfectly ordinary divisor that a wider guard would throw away as if it were centred.
+	// `normaliseCropRegion` keeps `x + width <= 1`, so the quotient is in range by
+	// construction; the clamp is for a hand-edited document that got there another way.
+	const axis = (offset: number, size: number) =>
+		size >= 1 ? 0.5 : Math.min(1, Math.max(0, offset / (1 - size)));
+	return { x: axis(crop.x, crop.width), y: axis(crop.y, crop.height) };
+}
+
+function normaliseCropPan(value: unknown, crop: CropRegion): CropPan {
+	if (!value || typeof value !== "object") return panOfCropRegion(crop);
+	const candidate = value as Record<string, unknown>;
+	const fallback = panOfCropRegion(crop);
+	return {
+		x: isNumber(candidate.x) ? Math.min(1, Math.max(0, candidate.x)) : fallback.x,
+		y: isNumber(candidate.y) ? Math.min(1, Math.max(0, candidate.y)) : fallback.y,
+	};
+}
 
 function normaliseCropRegion(value: unknown): CropRegion {
 	if (!value || typeof value !== "object") return DEFAULT_CROP_REGION;


### PR DESCRIPTION
## Summary

Fixes #412: the webcam framing controls lost the pan whenever the zoom passed through 100%.

The pan was never stored. It was derived from the crop rect on every render — `x / (1 - width)` — and `setCropZoom` wrote the rect back from the current centre, clamped into the frame. That clamp is the bug, and it bites twice:

- **At 100%** the window *is* the frame, so `1 - size` is 0 and `x` is forced to 0 for every centre. With the rect as the only record, pinning it erased the only trace of where the user had put the frame. Coming back up, the crop re-centred.
- **On the way down**, the same clamp squeezed the offset toward the near edge as the window grew, so the slider labelled **Pan horizontally** crept upward on its own while the picture did not move. The centre was being held, so nothing on screen justified the number changing.

Now the pan is a stored intent of its own — a 0..1 fraction of whatever room the zoom leaves — and the rect's offset is rebuilt from it in `getEditorSettings` rather than the other way round. `pan * (1 - size)` cannot leave the frame, so the clamp is **gone** rather than worked around, and `setCropZoom` becomes a pure function of `(pan, size)`: it never re-reads the rect it just wrote, which is what makes dragging reversible.

## Two things worth checking in review

**The default for an existing document is derived from its rect, not centred.** Every project on disk has a crop rect and no pan key, because the pan did not exist when they were saved. Defaulting to `0.5` would have silently reframed all of them on first open. `panOfCropRegion` is deliberately the same expression the pane used to compute on every render, so reading an existing document is an identity — `pan * (1 - width)` gives back exactly the `x` that was stored. There is a test for precisely that.

**Nothing new crosses to the compositor.** `webcamCropPan` never reaches `sceneDescription`; `webcamCrop: settings.webcamCropRegion` still ships the same UV sub-rect to `webcam_source_rect`, and the Rust side is untouched. This changes how the value is *authored*, not what is drawn — the preview and the export see exactly what they saw before, which is the property the crop was built on.

No schema change either: `legacyEditor` is a passthrough envelope, so there is no version bump and no migration.

## Related issue

Fixes #412

## Type of change
- [x] Bug fix

## Release impact
- [x] Patch

## Desktop impact
- [x] Not platform-specific

## Screenshots / video

**Layout** pane → **Webcam crop**. To see the old behaviour: zoom to 200%, pan off centre, zoom to 100%, zoom back to 200% — the framing returns centred on `main`, and holds here.

## Testing

`tsc`, `tsc -p tsconfig.test.json`, `biome check .` and `npm run i18n:check` pass. Full Vitest suite: **167 files, 1976 passed, 5 skipped**.

Six new tests, where this control had none:

- `editorSettings.test.ts` — a rect with no pan reads back its original framing (the regression that would have reframed every shipped project); a full-frame crop reads as centred; a rect and a pan that disagree on disk resolve to the pan.
- `RightPanes.layout.test.tsx` — zoom 200 → pan 75 → zoom 100 → zoom 200 still reads 75; the pan holds while the zoom is dragged across five intermediate values; and the crop lands hard against the edge the pan asks for, at any zoom.

All three of the UI cases fail against the previous implementation — the first one on `expected 0.5833 to be close to 0.6667`, which is the drift described above.

## Not in conflict with #411

#411 is fixing the camera *box* aspect (the preview lays it out from the probed camera size, the export from a hardcoded 4:3). Different defect, same area. It touches `sceneDescription.ts`, `schema/index.ts`, `projectStore.ts`, `useTimeline.ts`, `CliExportRunner.tsx` and `sceneDescription.test.ts`; this touches `editorSettings.ts`, `RightPanes.tsx` and their tests. **Zero files in common** — verified with `comm` over both changed-file lists.

<!-- discord-thread-id:1540034248273166437 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved webcam crop framing so pan position remains stable when changing zoom levels.
  - Preserved crop positioning across 100% zoom round trips.
  - Corrected crop alignment at different zoom levels.
  - Improved compatibility with existing projects and invalid or missing crop-position data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->