### PR TITLE
test(e2e): drop the two stale checklist tests, clean their leftovers

### DIFF
--- a/src/components/ai-edition/EditorEmptyState.tsx
+++ b/src/components/ai-edition/EditorEmptyState.tsx
@@ -1,17 +1,14 @@
-// Empty state for the new editor's preview.
+// Empty state for the editor's preview.
 //
-// Mirrors the legacy `EditorEmptyState` (import video + load project + drag
-// drop) but on top of the project store: a "no project" branch offers
-// `createProject` + `loadProject`, and a "has project, no asset" branch offers
-// the file picker + load (for the rare user who already has a .openscreen
-// project without media attached).
+// Import video + load project + drag/drop on top of the project store: a
+// "no project" branch offers `createProject` + `loadProject`, and a
+// "has project, no asset" branch offers the file picker + load (for the rare
+// user who already has a .openscreen project without media attached).
 //
-// ponytail: keeps the existing copy from the legacy component and the same
-// drag/drop affordance, but the actions map to project-store operations
-// rather than the legacy `nativeBridgeClient.project.*` ones. The two editor
-// shells will collapse once we have a single render path; until then the
-// "open screen" feature lives here in the new UX and in the legacy
-// `EditorEmptyState.tsx` for the deprecated editor.
+// ponytail: the actions map to project-store operations rather than the
+// `nativeBridgeClient.project.*` ones, which this shell no longer uses. The
+// deprecated editor and its own `EditorEmptyState` were deleted in 1320121d,
+// so this is the single render path for the feature.
 
 import { AlertCircle, Film, FolderOpen, Upload, X } from "lucide-react";
 import { useCallback, useRef, useState } from "react";

--- a/src/i18n/locales/ar/launch.json
+++ b/src/i18n/locales/ar/launch.json
@@ -6,8 +6,6 @@
 		"cancelRecording": "إلغاء التسجيل",
 		"pauseRecording": "إيقاف التسجيل مؤقتاً",
 		"resumeRecording": "استئناف التسجيل",
-		"openVideoFile": "فتح ملف فيديو",
-		"openProject": "فتح مشروع",
 		"useVerticalTray": "استخدام الشريط العمودي",
 		"useHorizontalTray": "استخدام الشريط الأفقي",
 		"openStudio": "فتح الاستوديو",

--- a/src/i18n/locales/en/launch.json
+++ b/src/i18n/locales/en/launch.json
@@ -6,8 +6,6 @@
 		"cancelRecording": "Cancel recording",
 		"pauseRecording": "Pause recording",
 		"resumeRecording": "Resume recording",
-		"openVideoFile": "Open video file",
-		"openProject": "Open project",
 		"useVerticalTray": "Use vertical tray",
 		"useHorizontalTray": "Use horizontal tray",
 		"openStudio": "Open Studio",

--- a/src/i18n/locales/es/launch.json
+++ b/src/i18n/locales/es/launch.json
@@ -6,8 +6,6 @@
 		"cancelRecording": "Cancelar grabación",
 		"pauseRecording": "Pausar grabación",
 		"resumeRecording": "Reanudar grabación",
-		"openVideoFile": "Abrir archivo de video",
-		"openProject": "Abrir proyecto",
 		"useVerticalTray": "Usar bandeja vertical",
 		"useHorizontalTray": "Usar bandeja horizontal",
 		"openStudio": "Abrir Studio",

--- a/src/i18n/locales/fr/launch.json
+++ b/src/i18n/locales/fr/launch.json
@@ -6,8 +6,6 @@
 		"cancelRecording": "Annuler l'enregistrement",
 		"pauseRecording": "Mettre en pause l'enregistrement",
 		"resumeRecording": "Reprendre l'enregistrement",
-		"openVideoFile": "Ouvrir un fichier vidéo",
-		"openProject": "Ouvrir un projet",
 		"useVerticalTray": "Utiliser la barre verticale",
 		"useHorizontalTray": "Utiliser la barre horizontale",
 		"openStudio": "Ouvrir le Studio",

--- a/src/i18n/locales/it/launch.json
+++ b/src/i18n/locales/it/launch.json
@@ -6,8 +6,6 @@
 		"cancelRecording": "Annulla registrazione",
 		"pauseRecording": "Metti in pausa registrazione",
 		"resumeRecording": "Riprendi registrazione",
-		"openVideoFile": "Apri file video",
-		"openProject": "Apri progetto",
 		"useVerticalTray": "Usa barra verticale",
 		"useHorizontalTray": "Usa barra orizzontale",
 		"openStudio": "Apri Studio",

--- a/src/i18n/locales/ja-JP/launch.json
+++ b/src/i18n/locales/ja-JP/launch.json
@@ -6,8 +6,6 @@
 		"cancelRecording": "録画をキャンセル",
 		"pauseRecording": "録画を一時停止",
 		"resumeRecording": "録画を再開",
-		"openVideoFile": "動画ファイルを開く",
-		"openProject": "プロジェクトを開く",
 		"useVerticalTray": "縦型トレイを使用",
 		"useHorizontalTray": "横型トレイを使用",
 		"openStudio": "スタジオを開く",

--- a/src/i18n/locales/ko-KR/launch.json
+++ b/src/i18n/locales/ko-KR/launch.json
@@ -6,8 +6,6 @@
 		"cancelRecording": "녹화 취소",
 		"pauseRecording": "녹화 일시정지",
 		"resumeRecording": "녹화 재개",
-		"openVideoFile": "비디오 파일 열기",
-		"openProject": "프로젝트 열기",
 		"useVerticalTray": "세로 트레이 사용",
 		"useHorizontalTray": "가로 트레이 사용",
 		"openStudio": "스튜디오 열기",

--- a/src/i18n/locales/pt-BR/launch.json
+++ b/src/i18n/locales/pt-BR/launch.json
@@ -6,8 +6,6 @@
 		"cancelRecording": "Cancelar gravação",
 		"pauseRecording": "Pausar gravação",
 		"resumeRecording": "Retomar gravação",
-		"openVideoFile": "Abrir arquivo de vídeo",
-		"openProject": "Abrir projeto",
 		"useVerticalTray": "Usar bandeja vertical",
 		"useHorizontalTray": "Usar bandeja horizontal",
 		"openStudio": "Abrir Studio",

--- a/src/i18n/locales/ru/launch.json
+++ b/src/i18n/locales/ru/launch.json
@@ -6,8 +6,6 @@
 		"cancelRecording": "Отменить запись",
 		"pauseRecording": "Приостановить запись",
 		"resumeRecording": "Возобновить запись",
-		"openVideoFile": "Открыть видеофайл",
-		"openProject": "Открыть проект",
 		"useVerticalTray": "Использовать вертикальную панель",
 		"useHorizontalTray": "Использовать горизонтальную панель",
 		"openStudio": "Открыть студию",

--- a/src/i18n/locales/tr/launch.json
+++ b/src/i18n/locales/tr/launch.json
@@ -6,8 +6,6 @@
 		"cancelRecording": "Kaydı iptal et",
 		"pauseRecording": "Kaydı duraklat",
 		"resumeRecording": "Kayda devam et",
-		"openVideoFile": "Video dosyası aç",
-		"openProject": "Proje aç",
 		"useVerticalTray": "Dikey araç çubuğunu kullan",
 		"useHorizontalTray": "Yatay araç çubuğunu kullan",
 		"openStudio": "Stüdyoyu aç",

--- a/src/i18n/locales/vi/launch.json
+++ b/src/i18n/locales/vi/launch.json
@@ -6,8 +6,6 @@
 		"cancelRecording": "Hủy ghi hình",
 		"pauseRecording": "Tạm dừng ghi hình",
 		"resumeRecording": "Tiếp tục ghi hình",
-		"openVideoFile": "Mở tệp video",
-		"openProject": "Mở dự án",
 		"useVerticalTray": "Dùng khay dọc",
 		"useHorizontalTray": "Dùng khay ngang",
 		"openStudio": "Mở Studio",

--- a/src/i18n/locales/zh-CN/launch.json
+++ b/src/i18n/locales/zh-CN/launch.json
@@ -6,8 +6,6 @@
 		"cancelRecording": "取消录制",
 		"pauseRecording": "暂停录制",
 		"resumeRecording": "继续录制",
-		"openVideoFile": "打开视频文件",
-		"openProject": "打开项目",
 		"useVerticalTray": "使用竖向托盘",
 		"useHorizontalTray": "使用横向托盘",
 		"openStudio": "打开工作室",

--- a/src/i18n/locales/zh-TW/launch.json
+++ b/src/i18n/locales/zh-TW/launch.json
@@ -6,8 +6,6 @@
 		"cancelRecording": "取消錄製",
 		"pauseRecording": "暫停錄製",
 		"resumeRecording": "繼續錄製",
-		"openVideoFile": "開啟影片檔案",
-		"openProject": "開啟專案",
 		"useVerticalTray": "使用直向托盤",
 		"useHorizontalTray": "使用橫向托盤",
 		"openStudio": "開啟工作室",

--- a/tests/e2e/windows-native-checklist.spec.ts
+++ b/tests/e2e/windows-native-checklist.spec.ts
@@ -5,12 +5,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Page } from "@playwright/test";
 import { _electron as electron, expect, test } from "@playwright/test";
-import { NATIVE_BRIDGE_CHANNEL, NATIVE_BRIDGE_VERSION } from "../../src/native/contracts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, "../..");
 const MAIN_JS = path.join(ROOT, "dist-electron/main.js");
-const TEST_VIDEO = path.join(__dirname, "../fixtures/sample.webm");
 
 async function launchApp() {
 	const testUserDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "openscreen-e2e-"));
@@ -77,17 +75,6 @@ async function closeApp(app: ElectronApplication) {
 			retryDelay: 100,
 		});
 	}
-}
-
-async function copyFixtureToRecordings(app: ElectronApplication, fileName: string) {
-	const userDataDir = await app.evaluate(({ app: electronApp }) => {
-		return electronApp.getPath("userData");
-	});
-	const recordingsDir = path.join(userDataDir, "recordings");
-	const targetPath = path.join(recordingsDir, fileName);
-	fs.mkdirSync(recordingsDir, { recursive: true });
-	fs.copyFileSync(TEST_VIDEO, targetPath);
-	return targetPath;
 }
 
 async function dismissLanguagePrompt(page: Page) {
@@ -165,161 +152,6 @@ test.describe("Windows native checklist smoke tests", () => {
 		}
 	});
 
-	test("launch window opens an existing video into the editor and playback controls respond", async () => {
-		const app = await launchApp();
-		let testVideoInRecordings = "";
-
-		try {
-			const hudWindow = await app.firstWindow({ timeout: 60_000 });
-			await hudWindow.waitForLoadState("domcontentloaded");
-			await dismissLanguagePrompt(hudWindow);
-			testVideoInRecordings = await copyFixtureToRecordings(app, "checklist-sample.webm");
-
-			await app.evaluate(({ ipcMain }, videoPath) => {
-				ipcMain.removeHandler("open-video-file-picker");
-				ipcMain.handle("open-video-file-picker", () => ({
-					success: true,
-					path: videoPath,
-				}));
-			}, testVideoInRecordings);
-
-			await hudWindow.getByTestId("launch-open-video-button").click();
-			const editorWindow = await app.waitForEvent("window", {
-				predicate: (w) => w.url().includes("windowType=editor"),
-				timeout: 15_000,
-			});
-			await editorWindow.waitForLoadState("domcontentloaded");
-			await expect(editorWindow.getByText("Loading video...")).not.toBeVisible({ timeout: 20_000 });
-
-			const playButton = editorWindow.locator(
-				'button[aria-label="Play"], button[aria-label="Lire"]',
-			);
-			await expect(playButton).toBeVisible({ timeout: 10_000 });
-			await playButton.click();
-
-			const seekInput = editorWindow.locator('input[type="range"]').first();
-			await expect(seekInput).toBeVisible();
-			await seekInput.evaluate((input) => {
-				const range = input as HTMLInputElement;
-				range.value = "0.25";
-				range.dispatchEvent(new Event("input", { bubbles: true }));
-				range.dispatchEvent(new Event("change", { bubbles: true }));
-			});
-			await expect.poll(() => seekInput.inputValue(), { timeout: 10_000 }).not.toBe("0");
-
-			await expect(
-				editorWindow.getByText("Background").or(editorWindow.getByText("Arrière-plan")),
-			).toBeVisible();
-			await expect(editorWindow.getByRole("button", { name: "Export", exact: true })).toBeVisible();
-		} finally {
-			await closeApp(app);
-			if (testVideoInRecordings && fs.existsSync(testVideoInRecordings)) {
-				fs.unlinkSync(testVideoInRecordings);
-			}
-		}
-	});
-
-	test("launch window opens an existing project into the editor", async () => {
-		const app = await launchApp();
-		let testVideoInRecordings = "";
-		let projectPath = "";
-
-		try {
-			const hudWindow = await app.firstWindow({ timeout: 60_000 });
-			await hudWindow.waitForLoadState("domcontentloaded");
-			await dismissLanguagePrompt(hudWindow);
-			testVideoInRecordings = await copyFixtureToRecordings(app, "checklist-project-sample.webm");
-			projectPath = path.join(os.tmpdir(), `openscreen-checklist-${Date.now()}.openscreen`);
-			const project = {
-				version: 2,
-				videoPath: testVideoInRecordings,
-				editor: {},
-			};
-			fs.writeFileSync(projectPath, JSON.stringify(project), "utf-8");
-
-			await app.evaluate(
-				({ ipcMain }, payload) => {
-					ipcMain.removeHandler(payload.nativeBridgeChannel);
-					ipcMain.handle(payload.nativeBridgeChannel, (_event, request) => {
-						const success = (data: unknown) => ({
-							ok: true,
-							data,
-							meta: {
-								version: payload.nativeBridgeVersion,
-								requestId: request.requestId ?? "checklist-project-load",
-								timestampMs: Date.now(),
-							},
-						});
-
-						if (request.domain === "project" && request.action === "loadProjectFile") {
-							return success({
-								success: true,
-								path: payload.projectPath,
-								project: payload.project,
-							});
-						}
-						if (request.domain === "project" && request.action === "loadCurrentProjectFile") {
-							return success({ success: false, canceled: true });
-						}
-						if (request.domain === "project" && request.action === "getCurrentVideoPath") {
-							return success({ success: true, path: payload.videoPath });
-						}
-						if (request.domain === "system" && request.action === "getPlatform") {
-							return success("win32");
-						}
-						if (request.domain === "system" && request.action === "getAssetBasePath") {
-							return success(null);
-						}
-						if (request.domain === "cursor" && request.action === "getRecordingData") {
-							return success({ version: 2, provider: "none", samples: [], assets: [] });
-						}
-						if (request.domain === "cursor" && request.action === "getTelemetry") {
-							return success([]);
-						}
-
-						return {
-							ok: false,
-							error: {
-								code: "UNSUPPORTED_ACTION",
-								message: `Unexpected native bridge request in test: ${request.domain}.${request.action}`,
-								retryable: false,
-							},
-							meta: {
-								version: payload.nativeBridgeVersion,
-								requestId: request.requestId ?? "checklist-project-load",
-								timestampMs: Date.now(),
-							},
-						};
-					});
-				},
-				{
-					projectPath,
-					project,
-					videoPath: testVideoInRecordings,
-					nativeBridgeChannel: NATIVE_BRIDGE_CHANNEL,
-					nativeBridgeVersion: NATIVE_BRIDGE_VERSION,
-				},
-			);
-
-			await hudWindow.getByTestId("launch-open-project-button").click();
-			const editorWindow = await app.waitForEvent("window", {
-				predicate: (w) => w.url().includes("windowType=editor"),
-				timeout: 15_000,
-			});
-			await editorWindow.waitForLoadState("domcontentloaded");
-			await expect(editorWindow.getByText("Loading video...")).not.toBeVisible({ timeout: 20_000 });
-			await expect(editorWindow.getByRole("button", { name: "Export", exact: true })).toBeVisible();
-		} finally {
-			await closeApp(app);
-			if (testVideoInRecordings && fs.existsSync(testVideoInRecordings)) {
-				fs.unlinkSync(testVideoInRecordings);
-			}
-			if (projectPath && fs.existsSync(projectPath)) {
-				fs.unlinkSync(projectPath);
-			}
-		}
-	});
-
 	// The HUD must reach click-through by *asking* for it from the renderer, never
 	// by being born that way: a window born input-transparent whose renderer never
 	// mounts can never be clicked again, which is what bricked the app in issue #266.
@@ -336,8 +168,8 @@ test.describe("Windows native checklist smoke tests", () => {
 	// Note what this test therefore cannot do, and what no test in this file can.
 	// Only a real OS cursor move drives a WH_MOUSE_LL hook; CDP-injected input
 	// arrives below the OS hit-test, so Playwright's own `.click()` on a HUD testid
-	// — above, and in the source-selector step of the checklist test — reaches the
-	// DOM handler whether or not click-through is installed, or even working. Those
+	// — as in the source-selector test above — reaches the DOM handler whether or
+	// not click-through is installed, or even working. Those
 	// clicks assert renderer wiring and nothing else. The failure #266 actually shipped
 	// (a painted, permanently inert HUD) is invisible to injected input by construction,
 	// so it belongs on the manual computer-use checklist and cannot be regression-tested


### PR DESCRIPTION
## Summary

Removes the two `windows-native-checklist.spec.ts` tests that reference testids deleted in `00191c47`, instead of repairing them, and clears the other leftovers from that same removal.

Both tests died at their first step on `launch-open-video-button` / `launch-open-project-button`. Repairing the locators is the obvious move and is the wrong one, for two reasons:

1. **It doesn't get them to a working state.** Test 1 fails again two lines further down — `button[aria-label="Play"]` never matches, since `TransportBar.tsx:149` sets `aria-label={te("transport.playPause")}` = `"Play / Pause"`. Test 2 is worse: `EditorEmptyState`'s load-project handler calls `window.electronAPI.loadProjectFile()` → `ipcRenderer.invoke("load-project-file")` (`preload.ts:316`), a plain channel the spec's `NATIVE_BRIDGE_CHANNEL` fake never intercepts, so the real `dialog.showOpenDialog` runs. Its two remaining assertions can't fail either — `"Loading video..."` (`editor.loadingVideo`) is rendered by no component, and the Export button is always mounted with only `disabled={!canExport}`.

2. **This file's remit is narrower than those tests assume.** Per `AGENTS.md`: "`tests/e2e/windows-native-checklist.spec.ts` does click HUD test IDs and stays green for exactly that reason; it proves renderer wiring, not reachability." The HUD→editor open flows are covered for real by the computer-use pass in `technical-documentation/testing/manual-e2e-checklist.md`, which asserts the editor opens with the expected project and asset and carries a dated sign-off log. Repairing these two would rebuild assertions that duplicate that coverage while proving less.

What goes, beyond the two tests: `copyFixtureToRecordings`, the `TEST_VIDEO` constant, the `NATIVE_BRIDGE_*` import, and the fake `project.*` bridge whose surface the editor no longer calls. The source-selector and HUD click-through tests are untouched.

Two other leftovers from `00191c47` are cleared: `launch.tooltips.openVideoFile` / `openProject`, orphaned in all 13 locales, and `EditorEmptyState`'s header comment, which still described a legacy twin deleted in `1320121d`.

**Not addressed here:** the recurrence mechanism. Nothing links `getByTestId("x")` literals in `tests/` to `data-testid="x"` in `src/`, and no CI job runs Playwright — the drift this issue reports can happen again. That deserves its own issue; a shared `src/testids.ts` imported by both sides would turn a rename into a failure of the existing `typecheck-tests` job.

## Related issue

Fixes #130

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Enhancement
- [x] Documentation
- [x] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [ ] Patch
- [ ] Minor
- [ ] Major / breaking change
- [x] No release note needed

## Desktop impact
- [ ] Windows
- [ ] macOS
- [ ] Linux
- [ ] Installer / packaging
- [x] Not platform-specific

No product behaviour changes on any platform. The removed tests were `win32`-gated; the removed i18n keys had no consumer.

## Screenshots / video

Not applicable — no UI change.

## Testing

Run locally on this branch, all clean:

| Check | Result |
|---|---|
| `npm run lint` (biome) | exit 0 — 12 warnings, all pre-existing, none in the touched files |
| `npx tsc --noEmit` | exit 0 |
| `npx tsc -p tsconfig.test.json --noEmit` | exit 0 |
| `npm run test` (vitest) | 167 files, 1982 passed / 2 skipped |
| `npm run docs:check` | OK (31 files) |
| `npm run i18n:check` | PASSED — 12 locales match `en` across 7 namespaces |

`npm run test:e2e:windows-native-checklist` was not run: it is `win32`-gated and this branch was prepared on Linux. The change only deletes tests from that file, so the remaining two are byte-identical to what is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FcDr9XaTcNabUw5r7ZwXg

---
_Generated by [Claude Code](https://claude.ai/code/session_012FcDr9XaTcNabUw5r7ZwXg)_

<!-- discord-thread-id:1540050544423600251 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **User Interface**
  - Removed launch-screen tooltips for opening video files and projects across supported languages.

- **Documentation**
  - Updated editor documentation comments to reflect the current editor behavior.

- **Tests**
  - Updated end-to-end coverage and clarified validation notes for native window interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->