### PR TITLE
test(app): pin the copyright the bundle and the About box share

### DIFF
--- a/electron/about.test.ts
+++ b/electron/about.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
 	type AboutFacts,
@@ -46,6 +47,19 @@ describe("formatAboutDetail", () => {
 		expect(
 			formatAboutDetail(facts({ platform: "linux", arch: "x64", channel: "appimage" })),
 		).toContain("linux x64 · appimage");
+	});
+});
+
+// Both about.ts and electron-builder.json5 state in prose that these two must stay
+// byte-identical, and within one commit's lifetime they already came apart: the string moved
+// here while the config key was still missing, which is precisely the second attribution on the
+// binary — Get Info and the Windows file properties falling back to package.json's `author` —
+// that declaring the key exists to prevent. A comment in two files cannot hold that; this can.
+describe("COPYRIGHT", () => {
+	it("matches the copyright electron-builder stamps into the bundle", () => {
+		const config = readFileSync(new URL("../electron-builder.json5", import.meta.url), "utf8");
+		const declared = config.match(/["']?copyright["']?\s*:\s*["']([^"']*)["']/)?.[1];
+		expect(declared).toBe(COPYRIGHT);
 	});
 });
 


### PR DESCRIPTION
## Summary

`electron/about.ts` and `electron-builder.json5` each state, in prose, that their two copyright strings must stay byte-identical. During #414 they came apart for the length of a commit: the string was updated in `about.ts` while the config key was still absent, which is exactly the second attribution on the binary — Get Info and the Windows file properties falling back to `package.json`'s `author` — that declaring the key exists to prevent.

That state never shipped; it was caught and fixed before the merge. But what held the invariant that day was a person reading both files, not the comments claiming it. This is the check that holds it: it reads `electron-builder.json5`, extracts its `copyright` key, and compares it to `COPYRIGHT`.

One file, +14 lines, no production code.

## Related issue

Refs #414 — follow-up to the About box work, which is already merged.

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation
- [x] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [ ] Patch
- [ ] Minor
- [ ] Major / breaking change
- [x] No release note needed

## Desktop impact
- [ ] Windows
- [ ] macOS
- [ ] Linux
- [ ] Installer / packaging
- [x] Not platform-specific

## Screenshots / video

None — test-only, nothing visual changes.

## Testing

- `npm run test` — 2005 passed, 2 skipped, 168 files.
- `npx tsc -p tsconfig.test.json --noEmit` and `npm run lint` clean.
- Verified against a mutant in both directions: editing the `copyright` value in `electron-builder.json5`, and removing the key outright, each fail the new test. It therefore catches a drift on either side, not just an absent key.

The regex accepts quoted or unquoted keys and either quote style, so it does not break if the JSON5 is reformatted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBBSbefJoW4g76V78m6vrd)_

<!-- discord-thread-id:1540100668931571953 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated verification to ensure the displayed copyright information matches the application’s configured copyright value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->