### PR TITLE
feat(editor): reach the AI provider settings from the app menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { SourceSelector } from "./components/launch/SourceSelector";
 import { Toaster } from "./components/ui/sonner";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { useScopedT } from "./contexts/I18nContext";
+import { ProviderSettingsProvider } from "./contexts/ProviderSettingsContext";
 import { ShortcutsProvider } from "./contexts/ShortcutsContext";
 import { loadAllCustomFonts } from "./lib/customFonts";
 
@@ -27,6 +28,11 @@ const CliCaptionsRunner = lazy(() => import("./cli/CliCaptionsRunner"));
 const ShortcutsConfigDialog = lazy(() =>
 	import("./components/video-editor/ShortcutsConfigDialog").then((module) => ({
 		default: module.ShortcutsConfigDialog,
+	})),
+);
+const ProviderSettingsDialog = lazy(() =>
+	import("./components/ai-edition/ProviderSettings").then((module) => ({
+		default: module.ProviderSettingsDialog,
 	})),
 );
 
@@ -107,38 +113,41 @@ export default function App() {
 			case "editor":
 				return (
 					<ShortcutsProvider>
-						<Suspense
-							fallback={
-								<div className="flex flex-col items-center justify-center gap-3 h-screen bg-[#09090b]">
-									<svg
-										className="animate-spin text-[#34B27B]"
-										xmlns="http://www.w3.org/2000/svg"
-										fill="none"
-										viewBox="0 0 24 24"
-										width={28}
-										height={28}
-									>
-										<circle
-											className="opacity-25"
-											cx="12"
-											cy="12"
-											r="10"
-											stroke="currentColor"
-											strokeWidth="4"
-										/>
-										<path
-											className="opacity-75"
-											fill="currentColor"
-											d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-										/>
-									</svg>
-									<span className="text-white/50 text-sm">{tEditor("loadingEditor")}</span>
-								</div>
-							}
-						>
-							<VideoEditorEntry />
-							<ShortcutsConfigDialog />
-						</Suspense>
+						<ProviderSettingsProvider>
+							<Suspense
+								fallback={
+									<div className="flex flex-col items-center justify-center gap-3 h-screen bg-[#09090b]">
+										<svg
+											className="animate-spin text-[#34B27B]"
+											xmlns="http://www.w3.org/2000/svg"
+											fill="none"
+											viewBox="0 0 24 24"
+											width={28}
+											height={28}
+										>
+											<circle
+												className="opacity-25"
+												cx="12"
+												cy="12"
+												r="10"
+												stroke="currentColor"
+												strokeWidth="4"
+											/>
+											<path
+												className="opacity-75"
+												fill="currentColor"
+												d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+											/>
+										</svg>
+										<span className="text-white/50 text-sm">{tEditor("loadingEditor")}</span>
+									</div>
+								}
+							>
+								<VideoEditorEntry />
+								<ShortcutsConfigDialog />
+								<ProviderSettingsDialog />
+							</Suspense>
+						</ProviderSettingsProvider>
 					</ShortcutsProvider>
 				);
 			default:

--- a/src/components/ai-edition/LeftPanel.tsx
+++ b/src/components/ai-edition/LeftPanel.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { toast } from "sonner";
 import { useScopedT } from "@/contexts/I18nContext";
+import { useProviderSettings } from "@/contexts/ProviderSettingsContext";
 import type { AxcutAsset } from "@/lib/ai-edition/schema";
 import {
 	applyAgentDocumentIfCurrent,
@@ -33,7 +34,6 @@ import { ChatWelcome } from "./ChatWelcome";
 import { canSendChat } from "./chatAvailability";
 import { ChatHistoryModal, SourceTranscriptModal } from "./Modals";
 import styles from "./NewEditorShell.module.css";
-import { ProviderSettings } from "./ProviderSettings";
 import { TranscriptionStatusDot } from "./TranscriptionStatus";
 import { useChatBudget } from "./useChatBudget";
 
@@ -737,7 +737,9 @@ function ChatStripPanel() {
 	const [input, setInput] = useState("");
 	const [busy, setBusy] = useState(false);
 	const [llmConfig, setLlmConfig] = useState<AiEditionLlmConfig | null>(null);
-	const [settingsOpen, setSettingsOpen] = useState(false);
+	// The dialog itself is mounted in App.tsx so the app menu can reach it from every mode
+	// (issue #420); this panel only asks for it to be opened.
+	const { isProviderSettingsOpen, openProviderSettings } = useProviderSettings();
 	const [chatsOpen, setChatsOpen] = useState(false);
 	const [sessions, setSessions] = useState<
 		Array<{ id: string; title: string; messageCount: number; createdAt: string }>
@@ -813,6 +815,16 @@ function ChatStripPanel() {
 		void refreshLlm();
 	}, [refreshLlm]);
 
+	// Re-read after the dialog closes. Connecting a provider there is what makes the composer
+	// usable here, and the dialog no longer hangs off this component, so there is no onClose to
+	// do it from — the falling edge of the lifted state is the same event.
+	const providerSettingsWasOpen = useRef(isProviderSettingsOpen);
+	useEffect(() => {
+		const wasOpen = providerSettingsWasOpen.current;
+		providerSettingsWasOpen.current = isProviderSettingsOpen;
+		if (wasOpen && !isProviderSettingsOpen) void refreshLlm();
+	}, [isProviderSettingsOpen, refreshLlm]);
+
 	// ponytail: subscribe to streamed chat events so the reasoning trace (and
 	// any future streaming text deltas) lands live instead of arriving all at
 	// once when chatRun resolves. We only act on `thinking` here — text deltas
@@ -881,7 +893,7 @@ function ChatStripPanel() {
 		// but Auto-enhance calls send() directly and Enter can slip through.
 		if (!canChat) {
 			toast.error(t("chat.composerDisabledNoProvider"));
-			setSettingsOpen(true);
+			openProviderSettings();
 			return;
 		}
 		setInput("");
@@ -1143,7 +1155,7 @@ function ChatStripPanel() {
 		// full settings modal (the "providers" screen) instead of toggling a
 		// popover that would render empty.
 		if (!llmConfig) {
-			setSettingsOpen(true);
+			openProviderSettings();
 			return;
 		}
 		setModelPopoverOpen((wasOpen) => {
@@ -1163,7 +1175,7 @@ function ChatStripPanel() {
 			}
 			return !wasOpen;
 		});
-	}, [llmConfig]);
+	}, [llmConfig, openProviderSettings]);
 
 	// Prefer the main process's estimate of the windowed history it actually sends, so
 	// manual compaction can shrink this meter while the complete transcript remains
@@ -1333,7 +1345,7 @@ function ChatStripPanel() {
 								type="button"
 								title={t("chat.aiSettings")}
 								aria-label={t("chat.aiSettings")}
-								onClick={() => setSettingsOpen(true)}
+								onClick={openProviderSettings}
 							>
 								<svg
 									width={14}
@@ -1532,7 +1544,7 @@ function ChatStripPanel() {
 
 			<div className={styles.panelBody} ref={scrollRef}>
 				{!canChat && messages.length === 0 ? (
-					<ChatWelcome onOpenProviderSettings={() => setSettingsOpen(true)} />
+					<ChatWelcome onOpenProviderSettings={openProviderSettings} />
 				) : messages.length === 0 ? (
 					<p
 						style={{
@@ -1853,7 +1865,7 @@ function ChatStripPanel() {
 							connectedProviders={connectedProviders ?? []}
 							onClose={() => setModelPopoverOpen(false)}
 							onConfigChange={() => void refreshLlm()}
-							onOpenFullSettings={() => setSettingsOpen(true)}
+							onOpenFullSettings={openProviderSettings}
 						/>
 					) : null}
 					<button
@@ -1880,13 +1892,6 @@ function ChatStripPanel() {
 					</button>
 				</div>
 			</div>
-			<ProviderSettings
-				open={settingsOpen}
-				onClose={() => {
-					setSettingsOpen(false);
-					void refreshLlm();
-				}}
-			/>
 			<ChatHistoryModal
 				open={chatsOpen}
 				onClose={() => setChatsOpen(false)}

--- a/src/components/ai-edition/NewEditorShell.tsx
+++ b/src/components/ai-edition/NewEditorShell.tsx
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 import type { EditorProjectData } from "@/components/video-editor/projectPersistence";
 import { toFileUrl } from "@/components/video-editor/projectPersistence";
 import { useScopedT } from "@/contexts/I18nContext";
+import { useProviderSettings } from "@/contexts/ProviderSettingsContext";
 import { useShortcuts } from "@/contexts/ShortcutsContext";
 import {
 	migrateProjectDataToAxcutDocument,
@@ -130,6 +131,7 @@ export function NewEditorShell() {
 		resolve: (choice: UnsavedChoice) => void;
 	} | null>(null);
 	const { shortcuts, isMac, openConfig: openShortcutsConfig } = useShortcuts();
+	const { openProviderSettings } = useProviderSettings();
 	// Transcription is local and every transcript-driven feature (Smart cuts,
 	// captions, the transcript pane) needs one, so the editor produces them by
 	// itself instead of waiting for the user to find the button. This hook is
@@ -1136,6 +1138,7 @@ export function NewEditorShell() {
 					openSettings: handleOpenSettings,
 					renameProject: handleRenameProject,
 					toggleChat: () => setChatOpen((v) => !v),
+					openProviderSettings,
 					showAbout: handleShowAbout,
 					checkForUpdates: handleCheckForUpdates,
 				}}

--- a/src/components/ai-edition/ProviderSettings.test.tsx
+++ b/src/components/ai-edition/ProviderSettings.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+// Issue #420: the AI provider dialog used to be a `useState` inside LeftPanel's chat strip, so
+// it existed only in Edit mode with the chat panel expanded and nothing else could open it. It
+// is mounted once now, above the mode switch, and driven by ProviderSettingsContext.
+//
+// These tests are about *reach*, not about the dialog's own screens: that the app menu's row
+// really opens it, that it opens in Media and Rec too, and that the row and the heading are one
+// string rather than two that can drift apart.
+
+import "@testing-library/jest-dom";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { I18nProvider } from "@/contexts/I18nContext";
+import { ProviderSettingsProvider, useProviderSettings } from "@/contexts/ProviderSettingsContext";
+import { LOCALE_STORAGE_KEY } from "@/i18n/config";
+import { type EditorMode, EditorTopBar } from "./v4/EditorTopBar";
+
+// The dialog reads a provider snapshot over the native bridge the moment it opens. Answer with
+// an empty one: which providers exist is the registry's business, and this file's is the door.
+vi.mock("@/native/client", () => ({
+	nativeBridgeClient: {
+		aiEdition: {
+			llmGetSnapshot: () =>
+				Promise.resolve({
+					config: null,
+					connectedProviders: [],
+					availableProviders: [],
+					credentialSummary: [],
+				}),
+			llmListProviderModels: () => Promise.resolve({ models: [] }),
+		},
+	},
+}));
+
+import { ProviderSettingsDialog } from "./ProviderSettings";
+
+const noop = () => {};
+
+/** The top bar as NewEditorShell builds it: the menu row's action is the context's opener, and
+ *  nothing else in `actions` matters here. */
+function TopBar({ mode }: { mode: EditorMode }) {
+	const { openProviderSettings } = useProviderSettings();
+	return (
+		<EditorTopBar
+			mode={mode}
+			onModeChange={noop}
+			projectTitle="Demo Project"
+			dirty={false}
+			canExport={false}
+			chatOpen={false}
+			actions={{
+				openProject: noop,
+				newProject: noop,
+				save: noop,
+				export: noop,
+				openSettings: noop,
+				renameProject: noop,
+				toggleChat: noop,
+				openProviderSettings,
+				showAbout: noop,
+				checkForUpdates: noop,
+			}}
+		/>
+	);
+}
+
+/** The App.tsx shape, minus the editor body: one provider, one dialog mount, and the top bar
+ *  that has to reach it. Rendered with the real translations — the drift assertion below is
+ *  only worth anything against real strings. */
+function renderEditorChrome(locale: string, mode: EditorMode = "edit") {
+	localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+	return render(
+		<I18nProvider>
+			<ProviderSettingsProvider>
+				<TopBar mode={mode} />
+				<ProviderSettingsDialog />
+			</ProviderSettingsProvider>
+		</I18nProvider>,
+	);
+}
+
+/** Open the app menu (the wordmark) and click its AI settings row. */
+function openAiSettingsFromAppMenu() {
+	fireEvent.click(screen.getByRole("button", { name: /OpenScreen/ }));
+	fireEvent.click(screen.getByRole("menuitem", { name: /ai settings/i }));
+}
+
+beforeEach(() => {
+	localStorage.clear();
+});
+
+afterEach(() => {
+	cleanup();
+	localStorage.clear();
+});
+
+describe("ProviderSettings, reached from the app menu", () => {
+	it("is absent until the menu row is clicked, then mounted as a dialog", () => {
+		renderEditorChrome("en");
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+		openAiSettingsFromAppMenu();
+
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		expect(screen.getByRole("heading", { name: /ai settings/i })).toBeInTheDocument();
+	});
+
+	it.each<EditorMode>([
+		"media",
+		"rec",
+	])("opens in %s mode, where the chat panel that used to own it does not exist", (mode) => {
+		// The reason the state was lifted. LeftPanel renders only under `mode === "edit" &&
+		// chatOpen`, so before this change the row would have been dead in both of these.
+		renderEditorChrome("en", mode);
+
+		openAiSettingsFromAppMenu();
+
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+	});
+
+	it("labels the menu row with the dialog's own heading, so the two cannot drift", () => {
+		// Both read `editor.providerSettings.title`. A menu-only key would be free to say
+		// something else after a copy edit, and the menu would start lying about where it goes.
+		// Compared as text rather than asserted against a literal, so a copy edit moves both.
+		renderEditorChrome("en");
+		fireEvent.click(screen.getByRole("button", { name: /OpenScreen/ }));
+		const rowLabel = screen.getByRole("menuitem", { name: /ai settings/i }).textContent;
+
+		fireEvent.click(screen.getByRole("menuitem", { name: /ai settings/i }));
+
+		expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(rowLabel ?? "");
+	});
+
+	it("closes again from the dialog's own close button", () => {
+		renderEditorChrome("en");
+		openAiSettingsFromAppMenu();
+
+		fireEvent.click(screen.getByRole("button", { name: /close/i }));
+
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+	});
+
+	it("translates the row with the dialog, not separately", () => {
+		renderEditorChrome("fr");
+		fireEvent.click(screen.getByRole("button", { name: /OpenScreen/ }));
+		const row = screen.getByRole("menuitem", { name: /paramètres ia/i });
+
+		fireEvent.click(row);
+
+		expect(screen.getByRole("heading", { name: /paramètres ia/i })).toBeInTheDocument();
+	});
+});

--- a/src/components/ai-edition/ProviderSettings.tsx
+++ b/src/components/ai-edition/ProviderSettings.tsx
@@ -20,6 +20,7 @@ import { AlertCircle, Check, Loader2, Unplug, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useScopedT } from "@/contexts/I18nContext";
+import { useProviderSettings } from "@/contexts/ProviderSettingsContext";
 import { nativeBridgeClient } from "@/native/client";
 import type { AiEditionLlmConfig, AiEditionLlmSnapshot } from "@/native/contracts";
 import {
@@ -201,6 +202,20 @@ export function ProviderSettings({
 			) : null}
 		</ModalShell>
 	);
+}
+
+/**
+ * The one mount of {@link ProviderSettings} in the editor window, bound to the context that
+ * carries its open state.
+ *
+ * It sits beside `ShortcutsConfigDialog` in `App.tsx` rather than inside the chat panel, so the
+ * app menu can offer it in every mode (issue #420). The dialog above stays a plain
+ * `open` / `onClose` component: the settings unification this is the first step of will render
+ * it as a section of a larger dialog, which is not a thing that can mount itself.
+ */
+export function ProviderSettingsDialog() {
+	const { isProviderSettingsOpen, closeProviderSettings } = useProviderSettings();
+	return <ProviderSettings open={isProviderSettingsOpen} onClose={closeProviderSettings} />;
 }
 
 function ProviderList({

--- a/src/components/ai-edition/v4/EditorTopBar.test.tsx
+++ b/src/components/ai-edition/v4/EditorTopBar.test.tsx
@@ -24,6 +24,7 @@ function renderTopBar(projectTitle: string | null) {
 	const onShowAbout = vi.fn();
 	const onCheckForUpdates = vi.fn();
 	const onOpenSettings = vi.fn();
+	const onOpenProviderSettings = vi.fn();
 	render(
 		<EditorTopBar
 			mode="edit"
@@ -40,12 +41,13 @@ function renderTopBar(projectTitle: string | null) {
 				openSettings: onOpenSettings,
 				renameProject: onRename,
 				toggleChat: noop,
+				openProviderSettings: onOpenProviderSettings,
 				showAbout: onShowAbout,
 				checkForUpdates: onCheckForUpdates,
 			}}
 		/>,
 	);
-	return { onRename, onShowAbout, onCheckForUpdates, onOpenSettings };
+	return { onRename, onShowAbout, onCheckForUpdates, onOpenSettings, onOpenProviderSettings };
 }
 
 /** The menu reads two separate channels, and they answer different questions: `getAppInfo` for
@@ -161,12 +163,28 @@ describe("AppMenu", () => {
 		expect(trigger.getAttribute("style") ?? "").not.toMatch(/all\s*:\s*unset/);
 	});
 
-	it("opens on click and offers shortcuts and about", () => {
+	it("opens on click and offers shortcuts, AI settings and about", () => {
 		renderTopBar("Demo Project");
 		fireEvent.click(screen.getByRole("button", { name: /OpenScreen/ }));
 		expect(screen.getByRole("menu")).toBeInTheDocument();
-		expect(screen.getByRole("menuitem", { name: /title/ })).toBeInTheDocument();
+		// Exact names: the translator echoes keys, and both settings rows are labelled with a
+		// `…title` key, so a /title/ match would hit two items and pin neither.
+		expect(screen.getByRole("menuitem", { name: "title" })).toBeInTheDocument();
+		expect(screen.getByRole("menuitem", { name: "providerSettings.title" })).toBeInTheDocument();
 		expect(screen.getByRole("menuitem", { name: /actions\.about/ })).toBeInTheDocument();
+	});
+
+	// Issue #420: the AI dialog used to be openable only from the chat panel, which mounts in
+	// Edit mode with the panel expanded. The row is unconditional here — its dialog is mounted
+	// in App.tsx, above every mode — so the menu does not lie in Media and Rec.
+	it("opens the AI settings dialog and closes behind itself", () => {
+		const { onOpenProviderSettings, onOpenSettings } = renderTopBar("Demo Project");
+		fireEvent.click(screen.getByRole("button", { name: /OpenScreen/ }));
+		fireEvent.click(screen.getByRole("menuitem", { name: "providerSettings.title" }));
+		expect(onOpenProviderSettings).toHaveBeenCalledTimes(1);
+		// Distinct from the shortcuts row above it, which is the dialog it would be confused with.
+		expect(onOpenSettings).not.toHaveBeenCalled();
+		expect(screen.queryByRole("menu")).not.toBeInTheDocument();
 	});
 
 	it("routes About to the main process and closes behind itself", () => {

--- a/src/components/ai-edition/v4/EditorTopBar.tsx
+++ b/src/components/ai-edition/v4/EditorTopBar.tsx
@@ -11,6 +11,7 @@ import {
 	RefreshCw,
 	Save,
 	Settings,
+	Sparkles,
 	Sun,
 } from "lucide-react";
 import { type KeyboardEvent as ReactKeyboardEvent, useEffect, useRef, useState } from "react";
@@ -30,6 +31,7 @@ export interface TopBarActions {
 	openSettings: () => void;
 	renameProject: (title: string) => void;
 	toggleChat: () => void;
+	openProviderSettings: () => void;
 	showAbout: () => void;
 	checkForUpdates: () => void;
 }
@@ -293,6 +295,7 @@ async function readUpdateVeto(cancelled: () => boolean, apply: (allowed: boolean
 
 function AppMenu({ actions }: { actions: TopBarActions }) {
 	const tCommon = useScopedT("common");
+	const tEditor = useScopedT("editor");
 	const tShortcuts = useScopedT("shortcuts");
 	const [open, setOpen] = useState(false);
 	const [version, setVersion] = useState<string | null>(null);
@@ -406,6 +409,19 @@ function AppMenu({ actions }: { actions: TopBarActions }) {
 					>
 						<Keyboard size={15} />
 						{tShortcuts("title")}
+					</button>
+					{/* Settings surfaces together, above the separator. Both rows are labelled with the
+					    title of the dialog they open, so neither can drift from it — and unlike the AI
+					    panel's own entry points, this one is reachable in Media and Rec too, which is
+					    the whole reason the dialog's open state was lifted out of LeftPanel (#420). */}
+					<button
+						type="button"
+						role="menuitem"
+						className={styles.appMenuRow}
+						onClick={run(actions.openProviderSettings)}
+					>
+						<Sparkles size={15} />
+						{tEditor("providerSettings.title")}
 					</button>
 					<div className={styles.appMenuSep} aria-hidden />
 					{/* Only the PERMANENT half of the veto is applied here. A Store/Flathub/Snap/Nix

--- a/src/contexts/ProviderSettingsContext.tsx
+++ b/src/contexts/ProviderSettingsContext.tsx
@@ -1,0 +1,41 @@
+import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from "react";
+
+// Open/close state for the AI provider settings dialog, lifted out of the chat panel.
+//
+// It used to be a `useState` inside `LeftPanel`'s `ChatStripPanel`, which mounts only in Edit
+// mode with the chat panel expanded. Nothing outside that component could open the dialog, so
+// the app menu had no way to offer it (issue #420). The state lives here for the same reason
+// `ShortcutsContext` owns `isConfigOpen`: the surfaces that open a dialog and the place it is
+// mounted are on different branches of the tree.
+//
+// Deliberately just the three members. Everything the dialog itself needs — the provider
+// snapshot, the credentials, the save — it reads over the native bridge on open.
+interface ProviderSettingsContextValue {
+	isProviderSettingsOpen: boolean;
+	openProviderSettings: () => void;
+	closeProviderSettings: () => void;
+}
+
+const ProviderSettingsContext = createContext<ProviderSettingsContextValue | null>(null);
+
+export function useProviderSettings(): ProviderSettingsContextValue {
+	const ctx = useContext(ProviderSettingsContext);
+	if (!ctx) throw new Error("useProviderSettings must be used within <ProviderSettingsProvider>");
+	return ctx;
+}
+
+export function ProviderSettingsProvider({ children }: { children: ReactNode }) {
+	const [isProviderSettingsOpen, setIsProviderSettingsOpen] = useState(false);
+
+	const openProviderSettings = useCallback(() => setIsProviderSettingsOpen(true), []);
+	const closeProviderSettings = useCallback(() => setIsProviderSettingsOpen(false), []);
+
+	const value = useMemo<ProviderSettingsContextValue>(
+		() => ({ isProviderSettingsOpen, openProviderSettings, closeProviderSettings }),
+		[isProviderSettingsOpen, openProviderSettings, closeProviderSettings],
+	);
+
+	return (
+		<ProviderSettingsContext.Provider value={value}>{children}</ProviderSettingsContext.Provider>
+	);
+}

--- a/technical-documentation/architecture/llm-providers.md
+++ b/technical-documentation/architecture/llm-providers.md
@@ -10,7 +10,14 @@ The provider layer defines model metadata, protects credentials, discovers model
 | [`electron/ai-edition/deep-agent/chat-model.ts`](../../electron/ai-edition/deep-agent/chat-model.ts) | `createOpenScreenChatModel` — the single transport. Picks a `@langchain/*` chat model class per provider. |
 | [`electron/ai-edition/deep-agent/chat-model.ts`](../../electron/ai-edition/deep-agent/chat-model.ts) | Per-provider reasoning-effort capability and its LangChain wire options. |
 | [`electron/native-bridge/services/aiEditionService.ts`](../../electron/native-bridge/services/aiEditionService.ts) | IPC surface: connect / disconnect, snapshot, `llmListProviderModels`. |
-| [`src/components/ai-edition/ProviderSettings.tsx`](../../src/components/ai-edition/ProviderSettings.tsx) | Renders cards and forms directly from `PROVIDER_DEFINITIONS`. |
+| [`src/components/ai-edition/ProviderSettings.tsx`](../../src/components/ai-edition/ProviderSettings.tsx) | Renders cards and forms directly from `PROVIDER_DEFINITIONS`. `ProviderSettingsDialog`, in the same file, is its one mount — `App.tsx`, beside `ShortcutsConfigDialog`. |
+| [`src/contexts/ProviderSettingsContext.tsx`](../../src/contexts/ProviderSettingsContext.tsx) | Open state for that dialog, so every entry point opens the same one. |
+
+> **Two doors, one dialog.** The settings dialog is opened from the AI panel — its gear, the
+> welcome card's CTA, the model pill with nothing configured, and a send attempt with no
+> provider — and from the app menu under the wordmark. Its open state lives in a context rather
+> than in `LeftPanel` because that panel mounts only in Edit mode with the chat panel expanded,
+> which would have left the menu item dead in Media and Rec (issue #420).
 
 > **There is one transport.** `llm-call.ts` (`streamLlm` / `callLlm`) and
 > `codex-session.ts` were deleted in 1.8.0 along with the two account-backed

--- a/technical-documentation/testing/manual-e2e-checklist.md
+++ b/technical-documentation/testing/manual-e2e-checklist.md
@@ -328,12 +328,15 @@ The agent may only call the fixed tool set in [ai-agent.md](../architecture/ai-a
 - [ ] On macOS, open the application menu and confirm About OpenScreen is followed by Check for Updates.
 - [ ] On Windows and Linux, right-click the tray icon and confirm it lists Check for Updates and About OpenScreen. Outside the editor the tray is the only surface reachable by default there: the HUD is frameless and the editor and notes windows auto-hide their menu bar, so the Help menu appears only while Alt is held over one of those two windows.
 - [ ] On Windows and Linux, open the editor, hold Alt, and confirm the Help menu lists Check for Updates and About OpenScreen.
-- [ ] In the editor, click the OpenScreen wordmark in the top bar and confirm it opens a menu listing Keyboard Shortcuts, Check for Updates and About OpenScreen. This is the discoverable path on Windows and Linux, where the two above are not.
+- [ ] In the editor, click the OpenScreen wordmark in the top bar and confirm it opens a menu listing Keyboard Shortcuts, AI settings, Check for Updates and About OpenScreen. This is the discoverable path on Windows and Linux, where the two above are not.
 - [ ] Confirm the About row in that menu shows the running version, and that it matches what the About box then reports.
 - [ ] Open the wordmark menu and pick Keyboard Shortcuts; confirm it opens the same dialog the top bar's gear does, and that only one dialog appears.
+- [ ] Open the wordmark menu and pick AI settings; confirm it opens the same provider dialog the AI panel's gear does, and that only one dialog appears.
+- [ ] Repeat that in Media mode, in Rec mode, and in Edit mode with the chat panel collapsed — the three states in which the dialog had no owner before, and the reason the row must not be Edit-only.
+- [ ] Connect or disconnect a provider from the menu's dialog while the chat panel is open behind it, close the dialog, and confirm the composer and the model pill follow without reopening the panel.
 - [ ] Open the wordmark menu, then press Escape, click elsewhere in the top bar, and click the wordmark again — confirm each closes it and that the window does not start dragging instead of registering the click.
 - [ ] With the wordmark menu open, walk it with the Down and Up arrows and confirm focus wraps at both ends.
-- [ ] Switch the app language and confirm the wordmark menu's three labels follow, matching the wording the macOS app menu and the tray use.
+- [ ] Switch the app language and confirm the wordmark menu's four labels follow — the first two matching the dialogs they open, the last two the wording the macOS app menu and the tray use.
 - [ ] Open About and confirm it names the running version, the Electron/Chromium/Node versions, and the install channel.
 - [ ] Confirm the About box opens in front of the HUD rather than behind it.
 - [ ] On Windows and Linux, press Copy in the About box and confirm the clipboard holds that same block.


### PR DESCRIPTION
## Summary

The app menu added in #414 lists Keyboard Shortcuts, Check for Updates and About OpenScreen, and deliberately left out the AI provider settings — the app's other settings surface, and the obvious place to look for it. It was left out because it could not have worked: `ProviderSettings` was mounted inside `LeftPanel`'s chat strip, whose open state was a plain `useState` there, and that panel renders only under `mode === "edit" && chatOpen`. A menu row would have been dead in Media, dead in Rec, and dead in Edit with the chat panel collapsed — worse than no row, because the user learns the menu lies.

So the dialog is lifted the way the shortcuts dialog already was:

- **`src/contexts/ProviderSettingsContext.tsx`** owns `isProviderSettingsOpen` / `openProviderSettings` / `closeProviderSettings`, mirroring `ShortcutsContext`'s `isConfigOpen` / `openConfig` / `closeConfig`.
- **`ProviderSettingsDialog`** — in `ProviderSettings.tsx`, next to the dialog it binds — is the one mount, in `App.tsx` beside `ShortcutsConfigDialog`, lazily, above the mode switch. The dialog itself stays a plain `open` / `onClose` component rather than mounting itself: the settings unification this is step one of will want to render it as a *section* of a larger dialog, and a self-mounting dialog cannot be one.
- The panel's five call sites — the composer's gear, the welcome card's CTA, the model pill with nothing configured, the quick-pick popover's "full settings", and a send attempt with no provider — call the context's opener instead of a local setter.

**The panel's own entry points stay.** Two doors to one room is right here: configuring the AI where you use it is good UX, and the menu row is the discoverable path, not a replacement.

**The label is `editor.providerSettings.title` — the dialog's own heading**, not a new key. That is the rule the rest of the menu follows (its three current labels are all pre-existing `common.actions` / `shortcuts` keys shared with the native menu in `electron/main.ts`), and it is what stops the menu from drifting from what it opens after a copy edit. All 13 locales already carry it, so no translation files change.

One behavioural detail moved with the dialog. Its old `onClose` also ran `refreshLlm()` — connecting a provider is what makes the composer usable and what fills the model pill, and the panel reads that over the bridge. There is no `onClose` to hang that off any more, so the panel watches the falling edge of the lifted state, which is the same event. It is a `useRef` comparison rather than a bare effect on `[isProviderSettingsOpen]`, so it does not also fire on mount.

## Related issue

Fixes #420

The issue's "Bigger picture" — one Settings dialog with a sidebar of sections (General / Shortcuts / AI / Devices / About) — is deliberately **not** in here. This is its prerequisite either way, and the PR is scoped to the four steps the issue asks for.

## Type of change
- [ ] Bug fix
- [x] Feature
- [x] Enhancement
- [x] Documentation
- [ ] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [ ] Patch
- [x] Minor
- [ ] Major / breaking change
- [ ] No release note needed

## Desktop impact
- [ ] Windows
- [ ] macOS
- [ ] Linux
- [ ] Installer / packaging
- [x] Not platform-specific

## Screenshots / video

No screenshot: the browser pane in this session would not composite frames, so the run below was read back through the accessibility tree and the DOM instead. The app menu, in the editor:

```
Keyboard Shortcuts
AI settings              <- new
-----------------
About OpenScreen  0.0.0-browser
```

Check for Updates is absent there because the browser shim answers the update veto `false` — the same branch a Store/Flathub/Snap/Nix build takes.

## Testing

- `npm run test` — 2008 passed, 5 skipped, 169 files.
- `npm run lint`, `npx tsc --noEmit`, `npx tsc -p tsconfig.test.json --noEmit`, `npm run i18n:check` (13 locales), `npm run docs:check`.
- `src/components/ai-edition/ProviderSettings.test.tsx` is new and is about *reach*, not about the dialog's screens: it renders the App.tsx shape (provider + dialog mount + top bar) with the **real** translations, and pins that the menu row opens the dialog, that it opens in Media and Rec, that the row's text and the dialog's heading are compared to each other rather than to a literal (so a copy edit moves both or fails), and that the same holds in French.
- `EditorTopBar.test.tsx` gains the row's presence and its routing, and its "offers shortcuts and about" case is now an exact-name match: the echoing translator renders both settings rows as a `…title` key, so the old `/title/` regex would have matched two items and pinned neither.
- Drove the real renderer at `?windowType=editor` (`npm run dev`, browser-shim mode) and read the DOM back at each step: the row opens the dialog (`#modal-title` = "AI settings", full provider grid) in **Media**, in **Rec**, and in **Edit with the chat panel collapsed** — the three states where it would have been dead — with `[aria-label="AI editor"]` absent in each, confirming the panel that used to own it was not mounted. Then, with the panel open: the panel's gear and the welcome card's CTA both still open it, `document.querySelectorAll('[role="dialog"]').length` is **1** (one mount, not two), and the dialog's own close button returns it to 0.

**Not verified:** the `refreshLlm` path on close, which needs a provider actually connected — the browser shim has no credential store. `technical-documentation/testing/manual-e2e-checklist.md` covers it, along with the three modes and the "only one dialog appears" case.

Docs: `llm-providers.md` gains the context row and a note that the dialog now has two doors and one mount; the manual checklist's app-menu section counts four rows instead of three.

<!-- discord-thread-id:1540101584485351455 -->