### PR TITLE
fix(recording): count the tap's catch-up apart from audio it lost

### DIFF
--- a/electron/native/screencapturekit/Sources/OpenScreenCaptureCore/AudioTrackMixer.swift
+++ b/electron/native/screencapturekit/Sources/OpenScreenCaptureCore/AudioTrackMixer.swift
@@ -263,19 +263,38 @@ public final class AudioTrackMixer {
 
 	/// Reports what each source actually delivered against the finished track.
 	///
-	/// Not diagnostics for their own sake: nothing in the tree recorded whether
-	/// ScreenCaptureKit's system-audio output goes silent-but-delivering or stops delivering
-	/// altogether while nothing is playing, and the answer decides how much of the timeline the
-	/// clock is carrying on its own. One take with system audio enabled and nothing playing
-	/// settles it — `undeliveredSeconds` comes back as the whole track if the tap is gapped the
-	/// way WASAPI loopback is, and near zero if it streams silence. `longestHoleSeconds`
-	/// separates the two shapes a gapped tap can have: one long outage, or a steady stutter.
+	/// Not diagnostics for their own sake: how much of the timeline the clock carries on its own
+	/// depends on whether ScreenCaptureKit's system-audio output goes silent-but-delivering or
+	/// stops delivering altogether while nothing is playing, and nothing in the tree recorded
+	/// which until a take was run against the real API.
+	///
+	/// It has been now, and the tap **streams silence**. It does not gap it the way the WASAPI
+	/// loopback tap does. A 12.05 s take on an M1 Mac mini (macOS 26.5) with system audio
+	/// enabled and nothing playing at all reported `undeliveredSeconds` of 0.07 — 0.6 % of the
+	/// track — as a single hole at the head while the tap came up, `longestHoleSeconds` being
+	/// equal to it. A gapped tap would have reported close to the whole track instead. So on
+	/// macOS the clock only has to carry the take's edges, where under Windows it carries the
+	/// whole quiet stretch as well.
+	///
+	/// `npm run test:sck-audio-timeline:mac` prints these numbers whether it passes or fails,
+	/// so the measurement can be repeated. `longestHoleSeconds` is what would tell the two
+	/// shapes of a gapped tap apart — one long outage, or a steady stutter — should this ever
+	/// change.
 	///
 	/// `droppedSeconds` is the cost side of the same ledger, and it should be zero. It counts
 	/// audio a source delivered describing a span the cursor had already emitted, which cannot
 	/// be placed any more. That happens only when a source went quiet for longer than
 	/// `emissionGraceFrames` and then handed over the period it was quiet for, so anything above
 	/// zero here says the grace is too short for that capture path.
+	///
+	/// `trimmedSeconds` is deliberately not part of that number, though it is discarded by the
+	/// same code. It counts what was cut while a source was still catching up to a cursor that
+	/// had already started moving — the origin staying anchored to the video rather than
+	/// anything going wrong. Every real take carries some: against a live ScreenCaptureKit the
+	/// track starts before the system-audio tap has said anything, and about 40 ms of what it
+	/// first hands over describes time the cursor has already crossed. Counting the two
+	/// together, as this did until the split, made "dropped is zero" unsatisfiable on real
+	/// hardware and cost the check the only thing it was for.
 	private func emitTimelineSummary() {
 		var fields: [String: Any] = [
 			"event": "audio-timeline",
@@ -288,6 +307,7 @@ public final class AudioTrackMixer {
 				"undeliveredSeconds": report.undeliveredSeconds,
 				"longestHoleSeconds": report.longestHoleSeconds,
 				"droppedSeconds": report.droppedSeconds,
+				"trimmedSeconds": report.trimmedSeconds,
 			]
 		}
 		emit(fields)
@@ -300,6 +320,7 @@ public final class AudioTrackMixer {
 		public let undeliveredSeconds: Double
 		public let longestHoleSeconds: Double
 		public let droppedSeconds: Double
+		public let trimmedSeconds: Double
 	}
 
 	public func deliveryReport(for source: Source) -> DeliveryReport {
@@ -307,7 +328,8 @@ public final class AudioTrackMixer {
 			trackSeconds: seconds(cursor),
 			undeliveredSeconds: seconds(undeliveredFrames[source.rawValue]),
 			longestHoleSeconds: seconds(longestHoleFrames[source.rawValue]),
-			droppedSeconds: seconds(sources[source.rawValue].droppedFrames)
+			droppedSeconds: seconds(sources[source.rawValue].droppedFrames),
+			trimmedSeconds: seconds(sources[source.rawValue].trimmedFrames)
 		)
 	}
 
@@ -701,8 +723,15 @@ public final class AudioTrackMixer {
 		/// Where the clock stood at this source's most recent delivery, in absolute frames.
 		/// The mixer sets it, because only the mixer holds the clock.
 		var lastDeliveryFrame: Int64 = 0
+		/// Whether any of this source's audio has actually reached the mix. Until it has, the
+		/// source is not yet established on the timeline and cannot be "late" — see
+		/// `discardFrames(before:)`.
+		private(set) var hasPlaced = false
 		/// Captured audio that arrived too late to be placed. See `discardFrames(before:)`.
 		private(set) var droppedFrames: Int64 = 0
+		/// Captured audio discarded while this source was still catching up to the cursor. Also
+		/// `discardFrames(before:)`, but the benign half of it — see there for why they differ.
+		private(set) var trimmedFrames: Int64 = 0
 
 		var endFrame: Int64 { startFrame + Int64(samples.count / MixFormat.channelCount) }
 
@@ -763,28 +792,47 @@ public final class AudioTrackMixer {
 			for index in 0..<(usableFrames * MixFormat.channelCount) {
 				mix[base + index] += samples[index]
 			}
+			hasPlaced = true
 			samples.removeFirst(usableFrames * MixFormat.channelCount)
 			startFrame += Int64(usableFrames)
 		}
 
-		/// Discards samples the mixer has already emitted past — a buffer that arrived after
-		/// its chunk went out cannot be placed any more.
+		/// Discards samples the mixer has already emitted past, counting them by cause.
 		///
-		/// This is the one path that loses captured audio, so it keeps a count. It costs
-		/// nothing while a source delivers steadily, however far behind the clock it runs; it
-		/// bites only when one went quiet for longer than `emissionGraceFrames`, had silence
-		/// emitted in its place, and then handed over the period it was quiet for.
+		/// Two different things land here and only one of them is a fault. What separates them
+		/// is whether this source had established itself on the timeline yet, which is what
+		/// `hasPlaced` records — not where the frames sit, which was the tempting answer and the
+		/// wrong one.
+		///
+		/// Before a source has placed anything, it is still catching up and cannot be late.
+		/// `beginTimeline` opens the writer session on the first video frame, and a source only
+		/// joins the quorum that can hold the cursor back once it `hasDelivered`, so the track
+		/// starts moving before the audio tap has said anything at all. Whatever the tap then
+		/// hands over first describes a span the cursor has already crossed — a few tens of
+		/// milliseconds of it against a live ScreenCaptureKit, and all of a take's audio if the
+		/// tap opened before the session did. Cutting that is how the origin stays anchored to
+		/// the video instead of drifting back to meet the first sample. It is `trimmedFrames`,
+		/// and it is the design working.
+		///
+		/// Once a source has placed audio, a discard means it went quiet for longer than
+		/// `emissionGraceFrames`, had silence emitted in its place, and then handed over the
+		/// period it was quiet for. That is captured audio genuinely lost: `droppedFrames`, and
+		/// it should be zero.
 		private mutating func discardFrames(before cursor: Int64) {
 			guard startFrame < cursor else {
 				return
 			}
 
 			let available = Int64(samples.count / MixFormat.channelCount)
-			let discarded = Int(min(cursor - startFrame, available))
+			let discarded = min(cursor - startFrame, available)
 			if discarded > 0 {
-				samples.removeFirst(discarded * MixFormat.channelCount)
-				startFrame += Int64(discarded)
-				droppedFrames += Int64(discarded)
+				if hasPlaced {
+					droppedFrames += discarded
+				} else {
+					trimmedFrames += discarded
+				}
+				samples.removeFirst(Int(discarded) * MixFormat.channelCount)
+				startFrame += discarded
 			}
 			if samples.isEmpty {
 				startFrame = cursor

--- a/electron/native/screencapturekit/Tests/OpenScreenCaptureCoreTests/AudioTrackMixerTests.swift
+++ b/electron/native/screencapturekit/Tests/OpenScreenCaptureCoreTests/AudioTrackMixerTests.swift
@@ -85,6 +85,13 @@ final class AudioTrackMixerTests: XCTestCase {
 		XCTAssertEqual(sink.buffers.first?.presentationTimeStamp, sessionStart)
 		XCTAssertEqual(seconds(ofFrames: frames), 0.1, accuracy: 0.011)
 		XCTAssertGreaterThan(peak(frames, from: 0, to: 0.1), audibleThreshold)
+
+		// The 100 ms that predates the origin is accounted as trimmed, never as dropped. Both
+		// are cut by the same code, and counting them together is what made `droppedSeconds`
+		// non-zero on every real take and unusable as a fault signal.
+		let report = mixer.deliveryReport(for: .system)
+		XCTAssertEqual(report.trimmedSeconds, 0.1, accuracy: 0.011)
+		XCTAssertEqual(report.droppedSeconds, 0, accuracy: 0.011)
 	}
 
 	// MARK: - Trailing silence
@@ -380,7 +387,10 @@ final class AudioTrackMixerTests: XCTestCase {
 		clock.advance(seconds: 1)
 		mixer.finish(atSourceTime: clock.now)
 
-		XCTAssertEqual(mixer.deliveryReport(for: .system).droppedSeconds, 0.5, accuracy: 0.011)
+		let report = mixer.deliveryReport(for: .system)
+		XCTAssertEqual(report.droppedSeconds, 0.5, accuracy: 0.011)
+		// Nothing here predates the session, so the other half of the split stays clear.
+		XCTAssertEqual(report.trimmedSeconds, 0, accuracy: 0.011)
 	}
 
 	// MARK: - Pause

--- a/scripts/test-macos-audio-timeline.mjs
+++ b/scripts/test-macos-audio-timeline.mjs
@@ -42,8 +42,20 @@ const PLAY_AT_MS = Number(process.env.OPENSCREEN_SCK_TEST_PLAY_AT_MS ?? 4000);
 const TONE_MS = 3000;
 /** Silence after the tone, so the trailing half of the timeline is exercised too. */
 const TAIL_MS = 3000;
-/** How far the tone may sit from where it was asked for before this is a failure. */
-const TONE_TOLERANCE_S = 0.25;
+/**
+ * How far the tone may sit from where it was asked for before this is a failure.
+ *
+ * This budget is spent almost entirely before the timeline is involved: `afplay` has to
+ * fork, link, open the output device and hand CoreAudio its first samples, and none of that
+ * is charged to the code under test. Measured floor on an M1 Mac mini, output device already
+ * warm and the tone asked for at 1.5s, 4s and 7s: a flat +0.22s at every position. The
+ * original 0.25s left 30ms for the thing actually being measured, which is not a budget.
+ *
+ * 0.40s keeps the regression this exists to catch. The failure it guards against is a
+ * start-up rebase moving real audio by up to 250ms (PR #343); on top of the 0.22s floor that
+ * lands at 0.47s and still fails. A mis-rebase cannot hide under this number.
+ */
+const TONE_TOLERANCE_S = 0.4;
 /** How far the audio track may differ in length from the video track in the same file. */
 const TRACK_TOLERANCE_S = 0.1;
 /** Analysis window for locating the tone. Tight enough to resolve a 250 ms mis-rebase. */
@@ -144,25 +156,34 @@ if (!FFMPEG || !FFPROBE) {
 }
 
 const tonePath = path.join(os.tmpdir(), "openscreen-audio-timeline-tone.wav");
-const madeTone = spawnSync(FFMPEG, [
-	"-hide_banner",
-	"-loglevel",
-	"error",
-	"-f",
-	"lavfi",
-	"-i",
-	`sine=frequency=440:duration=${TONE_MS / 1000}`,
-	"-ac",
-	"2",
-	"-ar",
-	"48000",
-	"-acodec",
-	"pcm_s16le",
-	"-y",
-	tonePath,
-]);
+const madeTone = spawnSync(
+	FFMPEG,
+	[
+		"-hide_banner",
+		"-loglevel",
+		"error",
+		"-f",
+		"lavfi",
+		"-i",
+		`sine=frequency=440:duration=${TONE_MS / 1000}`,
+		"-ac",
+		"2",
+		"-ar",
+		"48000",
+		"-acodec",
+		"pcm_s16le",
+		"-y",
+		tonePath,
+	],
+	{ encoding: "utf8" },
+);
 if (madeTone.status !== 0 || !fs.existsSync(tonePath)) {
-	console.error("Could not synthesise the test tone.");
+	// Report what ffmpeg said. A shared-library build whose dylibs are not on the loader path
+	// fails here with a linker error that has nothing to do with the tone, and swallowing it
+	// sends you looking at the audio pipeline instead of at the binary.
+	const detail = `${madeTone.stderr ?? ""}${madeTone.error?.message ?? ""}`.trim();
+	console.error(`Could not synthesise the test tone with ${FFMPEG}.`);
+	if (detail) console.error(detail.split("\n").slice(-5).join("\n"));
 	process.exit(1);
 }
 
@@ -185,6 +206,53 @@ const request = {
 	cursor: { mode: "editable-overlay" },
 	outputs: { screenPath: outputPath },
 };
+
+/**
+ * Starts the default output device before the take, so its wake-up is not measured as offset.
+ *
+ * The tone's position is compared against the instant playback was ASKED for, so everything
+ * between the two lands in the budget — including CoreAudio starting an idle output device,
+ * which is not free. Measured on an M1 Mac mini: a cold device puts the tone 0.28s late and
+ * fails the 0.25s tolerance on its own, while a warm one is reproducibly 0.18s late at every
+ * position tried. Removing the wake-up is worth more than widening the tolerance would be,
+ * because the tolerance is what gives the measurement its teeth.
+ *
+ * It has to make a real sound: a warm-up of digital silence was tried first and measured no
+ * better than no warm-up at all (0.32s late from cold), because nothing starts the device
+ * until there are samples to play. It is short and it runs BEFORE the helper starts, which is
+ * what keeps it out of the measurement — a warm-up playing once the writer session was open
+ * would be found by `firstAudibleSecond` instead of the tone and reported as a wildly early
+ * hit.
+ */
+function warmOutputDevice() {
+	const warmPath = path.join(os.tmpdir(), "openscreen-audio-timeline-warmup.wav");
+	const made = spawnSync(
+		FFMPEG,
+		[
+			"-hide_banner",
+			"-loglevel",
+			"error",
+			"-f",
+			"lavfi",
+			"-i",
+			"sine=frequency=440:duration=0.5",
+			"-ac",
+			"2",
+			"-ar",
+			"48000",
+			"-acodec",
+			"pcm_s16le",
+			"-y",
+			warmPath,
+		],
+		{ encoding: "utf8" },
+	);
+	if (made.status === 0 && fs.existsSync(warmPath)) {
+		spawnSync("/usr/bin/afplay", [warmPath]);
+		fs.rmSync(warmPath, { force: true });
+	}
+}
+warmOutputDevice();
 
 console.log(
 	`Recording ${(PLAY_AT_MS + TONE_MS + TAIL_MS) / 1000}s on display ${displayId}: ` +
@@ -380,10 +448,15 @@ proc.on("close", (code, signal) => {
 	// The mixer's own account of what the system-audio tap actually handed over. On a take
 	// where nothing plays, this is the measurement that says whether ScreenCaptureKit's
 	// system-audio output is silence-gapped the way the WASAPI loopback tap is, or whether it
-	// streams silence continuously — and `droppedSeconds` is the cost side: audio the tap
-	// delivered too late to place, which should be zero.
+	// streams silence continuously.
 	const summary = helperEvents.findLast((event) => event.event === "audio-timeline");
 	const system = summary?.system;
+	// `droppedSeconds` is audio the mixer could not place, and nothing else: what a source loses
+	// at the head of a take while it is still catching up to a cursor that has already started
+	// moving is reported apart, as `trimmedSeconds`. That one is normal here and varies from
+	// take to take — it was measured at 0.00s to 0.04s across runs on one machine — which is
+	// exactly why it cannot share a counter with a fault. This can now be checked against zero,
+	// the only threshold that means anything.
 	const dropped = Number(system?.droppedSeconds ?? 0);
 	if (dropped > 0) {
 		problems.push(
@@ -402,7 +475,8 @@ proc.on("close", (code, signal) => {
 		const undelivered = Number(system.undeliveredSeconds ?? 0);
 		console.log(
 			`      system audio delivered nothing for ${undelivered.toFixed(2)}s of a ${track.toFixed(2)}s ` +
-				`track, longest hole ${Number(system.longestHoleSeconds ?? 0).toFixed(2)}s\n` +
+				`track, longest hole ${Number(system.longestHoleSeconds ?? 0).toFixed(2)}s, ` +
+				`${Number(system.trimmedSeconds ?? 0).toFixed(2)}s trimmed while the tap caught up\n` +
 				`      => ${
 					undelivered > track / 2
 						? "ScreenCaptureKit GAPS its silence, like WASAPI loopback"


### PR DESCRIPTION
Follow-up to #410, which was written and reviewed entirely on Windows. This is what running it against a real ScreenCaptureKit turned up.

## What was wrong

`droppedSeconds` counted two things that mean opposite things.

A source that has never delivered is not in the quorum that can hold the cursor back, so the track starts moving before the audio tap has said anything at all. Whatever the tap hands over first describes a span the cursor has already crossed, and is discarded — that is the design working, and the origin staying anchored to the video. The same counter also held audio discarded after a source went quiet past `emissionGraceFrames` and then handed over the period it was quiet for, which is captured audio genuinely lost.

Against a live tap the first kind is never zero, so `droppedSeconds == 0` was unsatisfiable and the check meant nothing. It measured 0.00s–0.05s per take, varying run to run, which is why `test:sck-audio-timeline:mac` failed intermittently rather than outright.

`hasPlaced` is the line between them: whether the source ever reached the mix, not where its frames sit.

## The hypothesis that was wrong

Worth recording, because it is the one the code invites. `SourceTimeline` documents a negative frame index as "audio captured before the writer session started", so the obvious split is at frame zero.

That was tried and refuted by measurement: splitting there reported `trimmedSeconds: 0` while the whole loss stayed on the dropped side. This audio does not predate the session — it arrives after the cursor has passed it, which is a different thing and needs a different boundary.

## The question #410 left open

`AudioTrackMixer` asked, in a comment, whether ScreenCaptureKit's system-audio tap gaps its silence the way the WASAPI loopback tap does. A take has now been run: **it streams silence.** 12.05s with nothing playing at all reported 0.07s undelivered — 0.6% of the track, in a single hole at the head while the tap came up. So on macOS the clock only carries the take's edges. The answer is now recorded in the source rather than in a review thread.

## Also in here

`test:sck-audio-timeline:mac` failed for two further reasons that were never the timeline:

- The tone's position carries afplay's start-up and the output device waking. Warming the device first removes the second; the first is a floor of **+0.22s** on this machine, flat at 1.5s, 4s and 7s, which left 30ms inside the old 0.25s tolerance for the thing being measured. 0.40s still fails the 250ms start-up rebase the tolerance exists to catch (0.22 + 0.25 = 0.47). A silent warm-up was tried first and measured no better than none: nothing starts the device until there are samples to play.
- ffmpeg's stderr was swallowed behind "Could not synthesise the test tone.", which sends you to the audio pipeline when the real fault is the loader path.

## Verification

- `npm run test:swift:mac` — 13/13, on Swift 6.3.2 / macOS 26.5. Both directions of the split are pinned: pre-session → `trimmed 0.1` / `dropped 0`, late arrival → `dropped 0.5` / `trimmed 0`.
- `npm run test:sck-audio-timeline:mac` — 8 consecutive live recordings green before rebasing, `droppedSeconds` zero throughout.

## Two caveats

**Everything here was measured on one machine** — an M1 Mac mini, macOS 26.5, no microphone. The 0.22s afplay floor and the 0.00s–0.05s catch-up are solid there; I have no data for Intel, a laptop, or an external output device.

**An unrelated flake showed up while verifying, and it is not fixed here.** The recording's *video* track sometimes comes up short — 10.48s and once 3.40s against an 11.0s audio track, roughly 2 runs in 6, while the audio side stayed healthy (`droppedSeconds: 0`). Since this test's tightest assertion compares audio length against video length, that flake fails it for reasons outside the audio path. It is not from this change: the helper sources are byte-identical between the base this was written on and current `main`, and the diff here adds two counters and one bool without touching control flow. Worth its own look.

<!-- discord-thread-id:1540111438130188309 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved macOS audio timeline reporting by distinguishing audio trimmed before the timeline begins from audio dropped after mixing has started.
  - Delivery summaries now include the duration of trimmed audio for clearer diagnostics.
  - Audio timeline validation now provides more reliable timing results and clearer failure details.
- **Bug Fixes**
  - Corrected reporting for late-arriving and pre-session audio so each condition is categorized accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->