### PR TITLE
ci(nix): let the build job finish, and name the stage that fails

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -48,9 +48,14 @@ concurrency:
   # evicted the previous run before it finished: the first four runs on main were
   # cancelled at 21m38s, 25s, 7m05s and then one that only survived because the
   # merges happened to stop. A cancelled run is not a failure either, so the
-  # branch showed nothing while the workflow reported nothing. Queueing instead
-  # costs at most one pending run -- GitHub keeps a single pending entry per group
-  # and replaces it -- and every merge eventually gets an answer.
+  # branch showed nothing while the workflow reported nothing.
+  #
+  # What this buys is that a started run finishes, not that every merge is
+  # verified: GitHub holds a single pending entry per group and a newer push
+  # replaces it, so merges landing while a run is in flight still go unbuilt.
+  # That is the affordable half. Verifying each merge would need a queue this
+  # workflow does not have, and is not worth it for a half-hour job whose purpose
+  # is catching drift rather than gating a commit.
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -43,7 +43,15 @@ concurrency:
   # Keying on the event as well keeps a merge train collapsing to its latest push
   # without letting it cancel the schedule.
   group: nix-build-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
+  # false, where a PR-branch check would want true. This job takes half an hour
+  # and main takes merges minutes apart, so cancel-in-progress meant each merge
+  # evicted the previous run before it finished: the first four runs on main were
+  # cancelled at 21m38s, 25s, 7m05s and then one that only survived because the
+  # merges happened to stop. A cancelled run is not a failure either, so the
+  # branch showed nothing while the workflow reported nothing. Queueing instead
+  # costs at most one pending run -- GitHub keeps a single pending entry per group
+  # and replaces it -- and every merge eventually gets an answer.
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -294,6 +302,13 @@ jobs:
           # capture failures are a separate problem, already reported above.
           echo "--- record then export ---"
           EXPORTED=""
+          # Tracked apart from EXPORTED so the verdict can name the stage that
+          # actually failed. Every run so far has died in record without export
+          # ever executing, while the annotation said "the export path does not
+          # work" -- an accusation aimed at the one component the run never
+          # reached, and the compositor addon is precisely what this step exists
+          # to vouch for.
+          RECORDED=0
           for i in 1 2 3; do
             echo "=== export attempt $i/3 ==="
             rm -f /tmp/demo.openscreen /tmp/demo.mp4
@@ -302,8 +317,12 @@ jobs:
             if [ "$RC" -ne 0 ] || [ ! -f /tmp/demo.openscreen ]; then
               echo "record failed (rc=$RC); last lines:"
               tail -5 "/tmp/rec.$i.out" || true
+              # The bound inside get-sources names its own failure; surface it
+              # rather than leaving the reason five lines up in a scratch file.
+              grep -a "get-sources\]" "/tmp/rec.$i.out" | tail -3 || true
               continue
             fi
+            RECORDED=1
             echo "recorded. project:"
             head -c 200 /tmp/demo.openscreen; echo
 
@@ -319,8 +338,10 @@ jobs:
           done
 
           EXPORT_OK=0
-          if [ -z "$EXPORTED" ]; then
-            echo "::error::No attempt produced an MP4. The compositor addon is packaged but the export path does not work."
+          if [ -z "$EXPORTED" ] && [ "$RECORDED" -eq 0 ]; then
+            echo "::error::No attempt got past record, so export never ran and the compositor addon is unproven. This is a capture failure on this host, not an export failure."
+          elif [ -z "$EXPORTED" ]; then
+            echo "::error::record produced a project but no attempt produced an MP4. The compositor addon is packaged and the export path does not work."
           else
             SIZE=$(wc -c < "$EXPORTED")
             # An MP4 opens with a 4-byte length then 'ftyp'. A zero-length or
@@ -350,7 +371,7 @@ jobs:
           # per-attempt warnings above keep that flakiness visible without letting
           # it decide the build; tighten this to $ATTEMPTS once the capture failure
           # is understood and fixed.
-          echo "=== verdict: enumeration $OK/$ATTEMPTS ok, export $EXPORT_OK ==="
+          echo "=== verdict: enumeration $OK/$ATTEMPTS ok, record $RECORDED, export $EXPORT_OK ==="
           if [ "$EXPORT_OK" -ne 1 ] || [ "$OK" -eq 0 ]; then
             exit 1
           fi

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -52,7 +52,7 @@ import {
 import type { CursorTelemetryReader } from "../ai-edition/deep-agent/service";
 import { DocumentService } from "../ai-edition/document-service";
 import { LlmConfigStore } from "../ai-edition/llm-config-store";
-import { mainLogBuffer } from "../diagnostics/main-log-buffer";
+import { isDiagnosticModeEnabled, mainLogBuffer } from "../diagnostics/main-log-buffer";
 import { mainT } from "../i18n";
 import { getInstallChannel } from "../install-channel";
 import { RECORDINGS_DIR } from "../main";
@@ -1716,12 +1716,35 @@ export function registerIpcHandlers(
 		// await it, and a renderer-side race would only stop *waiting* while this
 		// keeps running and its reply goes to nobody. Rejecting is what turns an
 		// indefinite spinner into the pickers' existing error branch.
-		const sources = await withDeadline(
-			desktopCapturer.getSources(opts),
-			GET_SOURCES_TIMEOUT_MS,
-			`Desktop source enumeration did not return within ${GET_SOURCES_TIMEOUT_MS}ms. ` +
-				"This usually means the display or GPU stack cannot be reached — check that a display server is available.",
-		);
+		// How long it actually took, under the existing diagnostic flag. The bound
+		// above turned an indefinite hang into a named failure, which is where the
+		// open question starts rather than ends: on a headless runner `openscreen
+		// sources` gets an answer within 20s four times in five while `record` --
+		// the same call with the same options -- exceeds 30s every time. A duration
+		// on both paths is what tells those apart; a threshold alone cannot.
+		const startedAt = Date.now();
+		const diagnostic = isDiagnosticModeEnabled();
+		let sources: Awaited<ReturnType<typeof desktopCapturer.getSources>>;
+		try {
+			sources = await withDeadline(
+				desktopCapturer.getSources(opts),
+				GET_SOURCES_TIMEOUT_MS,
+				`Desktop source enumeration did not return within ${GET_SOURCES_TIMEOUT_MS}ms. ` +
+					"This usually means the display or GPU stack cannot be reached — check that a display server is available.",
+			);
+		} catch (error) {
+			if (diagnostic) {
+				console.info(
+					`[get-sources] gave up after ${Date.now() - startedAt}ms (types=${(opts?.types ?? []).join(",")})`,
+				);
+			}
+			throw error;
+		}
+		if (diagnostic) {
+			console.info(
+				`[get-sources] returned ${sources.length} source(s) in ${Date.now() - startedAt}ms (types=${(opts?.types ?? []).join(",")})`,
+			);
+		}
 		lastEnumeratedSources = new Map(sources.map((source) => [source.id, source]));
 		return sources.map((source) => ({
 			id: source.id,

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -1734,8 +1734,13 @@ export function registerIpcHandlers(
 			);
 		} catch (error) {
 			if (diagnostic) {
+				// The reason, not an assumption about it: this catch also sees a
+				// getSources that rejected on its own, well inside the deadline, and
+				// calling that a timeout would point the next reader at the wrong thing.
+				// The deadline error carries its own wording.
+				const reason = error instanceof Error ? error.message : String(error);
 				console.info(
-					`[get-sources] gave up after ${Date.now() - startedAt}ms (types=${(opts?.types ?? []).join(",")})`,
+					`[get-sources] failed after ${Date.now() - startedAt}ms (types=${(opts?.types ?? []).join(",")}): ${reason}`,
 				);
 			}
 			throw error;


### PR DESCRIPTION
## What this does

Follow-up to #419, from what its first runs on `main` actually reported. Nothing here touches the derivation — the build is green and stays green.

**A started run could not finish.** `cancel-in-progress` killed every run before it reported: 21m38s, 25s, 7m05s, all cancelled, each evicted by the next merge. A half-hour job against a branch that takes merges minutes apart cannot survive that, and a cancelled run is not a failure, so the branch showed nothing while the workflow reported nothing. #419 half-fixed this by keying the group on `event_name` so the schedule and pushes stop colliding; push-versus-push is the same mechanism and I missed it.

To be precise about what `cancel-in-progress: false` buys, since an earlier draft of this overclaimed: a run that has **started** now finishes. It does not mean every merge is verified — GitHub holds one pending entry per group and a newer push replaces it, so merges landing mid-run still go unbuilt. That is the affordable half, and the one that was missing. Verifying each merge needs a queue this workflow does not have, and is not worth it for a drift check.

**The failure annotation named the wrong component.** Every run so far dies inside `record`, with export never executing:

```
=== export attempt 1/3 ===
record failed (rc=1); last lines:
Error invoking remote method 'get-sources':
Desktop source enumeration did not return within 30000ms.
```

and the message read *"the compositor addon is packaged but the export path does not work"* — aimed at the one thing the run had not reached, and the addon is precisely what the step exists to vouch for. It now tracks whether `record` ever produced a project and says which stage failed, surfacing the reason the run already writes to a scratch file.

**A duration, so the open question can be answered.** The bound #419 added turned an indefinite hang into a named failure, which is where the question starts rather than ends: `openscreen sources` gets an answer within 20s four times in five, while `record` — same call, same options — exceeds 30s on all three attempts. The log has nothing to say about that difference beyond which side of the threshold each landed on. `get-sources` now logs how long it took and, on failure, the actual error rather than an assumed timeout. Gated on the existing `OPENSCREEN_DIAGNOSTIC` flag, so a normal run is unchanged.

## Where this leaves the open problem

Unchanged and undiagnosed: capture is unreliable on the GitHub runner, and `record` in particular does not get its source list. This adds the measurement that would distinguish "slow here, fast there" from "never returns here"; it does not attempt a fix, because there is nothing yet to base one on.

For the record, the last run before #419 landed failed the same way with `rc=124` — killed by the outer bound at 120s with no reason given. So the failure is not new; only the fact that the log now names it is.

One thing worth flagging: the 30s bound in `get-sources` is itself unvalidated. It converted a hang into a named failure, but if `record` genuinely needs 45s on a slow runner then that bound is what fails it. The duration added here is what would settle that, on data rather than on my estimate.

## Verified

`npx vitest --run`: 1749 passed, 0 failed. `npx tsc --noEmit` and `biome check`: clean on the changed file. Workflow YAML parses and every embedded `run` block passes `bash -n`.

Not verified: no `nix build` from here — no nix on this machine. The changes are the workflow's control flow and one gated log line, neither of which the derivation depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smoke-test reporting by distinguishing recording failures from export failures and including recording status in final results.
  * Improved diagnostics for desktop source-enumeration failures, including clearer timeout and native error details.

* **Improvements**
  * Workflow runs now allow in-progress runs to finish while replacing only older pending runs for the same event and reference.
  * Added clearer reporting for failures occurring before and after recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->