### PR TITLE
ci(nix): print the get-sources duration on every attempt, not just failures

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -239,7 +239,16 @@ jobs:
             # path), and 60 left barely 25s for a cold Electron start under Xvfb
             # from a 1.7G closure -- so the outer kill could fire while every
             # internal bound was working.
-            CLI_TIMEOUT=$SOURCES_TIMEOUT OPENSCREEN_DIAGNOSTIC=1 run_cli $SANDBOX $CHROME_FLAGS sources -o "/tmp/sources.$i.json" >"/tmp/sources.$i.out" 2>"/tmp/sources.$i.err" || RC=$?
+            # 2>&1, like record and export: the probe above established that this
+            # host's xvfb-run folds stderr into stdout anyway, so the separate .err
+            # capture was a file nothing could ever read.
+            CLI_TIMEOUT=$SOURCES_TIMEOUT OPENSCREEN_DIAGNOSTIC=1 run_cli $SANDBOX $CHROME_FLAGS sources -o "/tmp/sources.$i.json" >"/tmp/sources.$i.out" 2>&1 || RC=$?
+            # Before the branching, so a success reports its duration too. The
+            # measurement was added to compare this path against record's, and the
+            # first run to carry it printed only record's -- the grep lived in a
+            # failure branch, so the successful side, which is the interesting one,
+            # went into a scratch file and stayed there.
+            grep -a "get-sources\]" "/tmp/sources.$i.out" || true
             # Every non-zero outcome is a failure. The kill is tracked on top of
             # that rather than instead of it, because it says something different:
             # the run never got far enough to report a reason at all.
@@ -319,12 +328,13 @@ jobs:
             rm -f /tmp/demo.openscreen /tmp/demo.mp4
             RC=0
             CLI_TIMEOUT=120 OPENSCREEN_DIAGNOSTIC=1 run_cli $SANDBOX $CHROME_FLAGS record --duration 2 --project /tmp/demo.openscreen >"/tmp/rec.$i.out" 2>&1 || RC=$?
+            # Outside the failure branch for the same reason as above: a record that
+            # works is exactly the measurement missing from the comparison, since
+            # this path has never yet produced one.
+            grep -a "get-sources\]" "/tmp/rec.$i.out" || true
             if [ "$RC" -ne 0 ] || [ ! -f /tmp/demo.openscreen ]; then
               echo "record failed (rc=$RC); last lines:"
               tail -5 "/tmp/rec.$i.out" || true
-              # The bound inside get-sources names its own failure; surface it
-              # rather than leaving the reason five lines up in a scratch file.
-              grep -a "get-sources\]" "/tmp/rec.$i.out" | tail -3 || true
               continue
             fi
             RECORDED=1


### PR DESCRIPTION
## What this does

The `get-sources` duration added in #429 exists to compare the `sources` path against `record`'s. The first run carrying it printed only `record`'s — the grep sat inside a failure branch, so the successful side, which is the interesting half, went into a scratch file and stayed there. The durations had to be reconstructed from log timestamps, which is the guessing the instrumentation was meant to replace.

Both greps move ahead of the branching. On the `record` side that matters more than on `sources`: a `record` that works is the one measurement this path has never produced.

The `sources` capture also folds into `2>&1`, like `record` and `export` already do. The probe at the top of the step established that this host's `xvfb-run` merges stderr into stdout, so the separate `.err` file could never hold anything.

## What the reconstruction already shows

Worth recording, because it settles a question left open in #429 — whether the 30s bound in the shared handler is too tight for a slow runner.

It is not. Enumeration on this host is **bimodal, not slow**:

```
attempt 1  succeeded   [milestone +491ms]
attempt 2  succeeded   [milestone +377ms]
attempt 3  failed      Desktop source enumeration did not return within 20000ms
attempt 4  succeeded   [milestone +387ms]
attempt 5  failed      Desktop source enumeration did not return within 20000ms
```

Successes land under half a second including Electron start. Failures do not return at all and are cut by whichever bound applies — 20s in the sources runner, 30s in the shared handler. There is no middle, so there is no threshold to tune, and raising the bound would buy nothing.

The asymmetry that motivated the measurement holds and got stronger: `record` has taken the non-returning path 6 times out of 6 across two runs, against roughly 5 in 10 for `sources`. At a 40% per-attempt rate, six in a row is under 0.5%, so something about the `record` path looks specific rather than unlucky. This PR does not attempt that; it makes the next run able to say so with a number.

## Verified

Workflow YAML parses; all four embedded `run` blocks pass `bash -n`. No remaining reference to the removed `.err` file. No code changes, so no test or typecheck impact.

Not verified: the durations this is meant to print. That takes a run on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1540328704755114027 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic reporting for source and recording smoke tests.
  * Combined standard output and error output into a single test log for easier troubleshooting.
  * Ensured diagnostic milestones are reported for every test attempt, including successful runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->