### PR TITLE
fix(editor): suppress editor shortcuts under every modal, not just some

### DIFF
--- a/src/components/ai-edition/NewEditorShell.dialogShortcuts.test.tsx
+++ b/src/components/ai-edition/NewEditorShell.dialogShortcuts.test.tsx
@@ -5,8 +5,11 @@
 // run underneath the backdrop — Delete destroying the selected region, Ctrl+O stacking a second
 // aria-modal dialog, `?` stacking the shortcuts dialog on top of the one already there.
 //
-// The guard reads `isDialogOpen()` (EditorDialogsContext, answered from a ref) and
-// `isConfigOpen`. Both are asserted through the shell's real keydown handler here.
+// The guard asks `isModalOpen()` (lib/ai-edition/modalGuard) — one question about the screen,
+// not one flag per dialog. The flag version named the two dialogs whose open state lived in a
+// context and missed every modal the shell owns as plain `useState`, so Z/T/C kept adding
+// regions under the Export modal (issue #434). The modal opened below is one of those: its
+// state is a `useState` in the shell, exactly like Export's.
 
 import "@testing-library/jest-dom";
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
@@ -46,20 +49,12 @@ vi.mock("@/contexts/I18nContext", () => ({
 	useScopedT: () => (key: string) => key,
 }));
 
-import { EditorDialogsProvider, useEditorDialogActions } from "@/contexts/EditorDialogsContext";
+import { EditorDialogsProvider } from "@/contexts/EditorDialogsContext";
 import { NewEditorShell } from "./NewEditorShell";
-
-let dialogActions: ReturnType<typeof useEditorDialogActions> | null = null;
-
-function CaptureDialogActions() {
-	dialogActions = useEditorDialogActions();
-	return null;
-}
 
 function renderShell() {
 	return render(
 		<EditorDialogsProvider>
-			<CaptureDialogActions />
 			<NewEditorShell />
 		</EditorDialogsProvider>,
 	);
@@ -72,7 +67,6 @@ function pressOnBody(init: KeyboardEventInit) {
 
 beforeEach(() => {
 	openConfig.mockClear();
-	dialogActions = null;
 	// No preload in jsdom, and no scrolling either; the chat transcript pins itself to the
 	// bottom on every render.
 	(window as unknown as { electronAPI?: unknown }).electronAPI = {
@@ -122,6 +116,18 @@ afterEach(() => {
 	(window as unknown as { electronAPI?: unknown }).electronAPI = undefined;
 });
 
+/**
+ * Ctrl+O is handled before the `hasProject` gate, so it opens the project picker whatever the
+ * editor's state — the cheapest way to put a real, shell-owned modal on screen. Its handler is
+ * async (it awaits the unsaved-changes prompt before opening the picker), hence the async act:
+ * a synchronous assertion would pass whether the guard is there or not.
+ */
+async function openShellModal() {
+	await act(async () => {
+		pressOnBody({ key: "o", ctrlKey: true });
+	});
+}
+
 describe("NewEditorShell shortcuts, with a dialog over the editor", () => {
 	it("routes ? to the shortcuts dialog while nothing is open", () => {
 		renderShell();
@@ -131,49 +137,46 @@ describe("NewEditorShell shortcuts, with a dialog over the editor", () => {
 		expect(openConfig).toHaveBeenCalledTimes(1);
 	});
 
-	it("suppresses ? once a dialog owns the screen, and resumes when it closes", () => {
-		renderShell();
-
-		act(() => {
-			dialogActions?.openDialog("providers");
-		});
-		pressOnBody({ key: "?" });
-		expect(openConfig).not.toHaveBeenCalled();
-
-		act(() => {
-			dialogActions?.closeDialog();
-		});
-		pressOnBody({ key: "?" });
-		expect(openConfig).toHaveBeenCalledTimes(1);
-	});
-
-	// Ctrl+O is handled before the `hasProject` gate, so it fired whatever the editor's state —
-	// this is the one that put a SECOND aria-modal dialog on screen, both of them emitting the
-	// hardcoded `id="modal-title"`. Its handler is async (it awaits the unsaved-changes prompt
-	// before opening the picker), hence the async act: a synchronous assertion here would pass
-	// whether the guard is there or not.
 	it("opens the project picker on Ctrl+O while nothing is open", async () => {
 		renderShell();
 
-		await act(async () => {
-			pressOnBody({ key: "o", ctrlKey: true });
-		});
+		await openShellModal();
 
 		// The provider dialog is mounted in App.tsx, not here, so the shell renders no dialog of
 		// its own unless Ctrl+O got through.
 		expect(screen.getByRole("dialog")).toBeInTheDocument();
 	});
 
-	it("suppresses Ctrl+O once a dialog owns the screen", async () => {
+	// The #434 shape: a modal the shell owns as local state, which no context knows about. `?`
+	// is the observable because it is the one shortcut that survives the `hasProject` gate —
+	// the keys the issue reports (Z, T, C) sit further down the same handler, behind the same
+	// single `return`.
+	it("suppresses ? while a modal the shell itself owns is open, and resumes when it closes", async () => {
 		renderShell();
 
-		act(() => {
-			dialogActions?.openDialog("providers");
-		});
+		await openShellModal();
+		pressOnBody({ key: "?" });
+		expect(openConfig).not.toHaveBeenCalled();
+
+		// ModalShell listens for Escape on `document`, so this closes the picker for real
+		// rather than reaching into the shell's state.
+		fireEvent.keyDown(document, { key: "Escape" });
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+		pressOnBody({ key: "?" });
+		expect(openConfig).toHaveBeenCalledTimes(1);
+	});
+
+	// The other half of the same bug: a shortcut that opens a dialog stacked a SECOND one on
+	// screen under the first, both of them emitting the hardcoded `id="modal-title"`.
+	it("does not stack a second dialog when Ctrl+N fires under an open modal", async () => {
+		renderShell();
+
+		await openShellModal();
 		await act(async () => {
-			pressOnBody({ key: "o", ctrlKey: true });
+			pressOnBody({ key: "n", ctrlKey: true });
 		});
 
-		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		expect(screen.getAllByRole("dialog")).toHaveLength(1);
 	});
 });

--- a/src/components/ai-edition/NewEditorShell.tsx
+++ b/src/components/ai-edition/NewEditorShell.tsx
@@ -13,6 +13,7 @@ import {
 	applyProbedDuration,
 	replaceTimeline as replaceTimelineOp,
 } from "@/lib/ai-edition/document/timeline";
+import { isModalOpen } from "@/lib/ai-edition/modalGuard";
 import { type AxcutClip, documentSchema } from "@/lib/ai-edition/schema";
 import { useProjectStore } from "@/lib/ai-edition/store/projectStore";
 import {
@@ -130,12 +131,12 @@ export function NewEditorShell() {
 		action: "close" | "new" | "open" | "record";
 		resolve: (choice: UnsavedChoice) => void;
 	} | null>(null);
-	const { shortcuts, isMac, isConfigOpen, openConfig: openShortcutsConfig } = useShortcuts();
+	const { shortcuts, isMac, openConfig: openShortcutsConfig } = useShortcuts();
 	// The actions half of the dialog context, not the section: this component only ever *opens*
 	// one, and subscribing it to the open state would re-render the whole editor — timeline,
-	// preview, transport — twice per dialog interaction. `isDialogOpen` answers the keyboard
-	// handler below from a ref, which is why it can live in a value that never changes.
-	const { openDialog, isDialogOpen } = useEditorDialogActions();
+	// preview, transport — twice per dialog interaction. Whether a dialog is open is a question
+	// for `isModalOpen`, which answers for every modal rather than for this context's one.
+	const { openDialog } = useEditorDialogActions();
 	// Transcription is local and every transcript-driven feature (Smart cuts,
 	// captions, the transcript pane) needs one, so the editor produces them by
 	// itself instead of waiting for the user to find the button. This hook is
@@ -861,9 +862,10 @@ export function NewEditorShell() {
 			// A modal owns the screen. Its own controls are buttons, not text fields, so the two
 			// guards above let every editor shortcut through underneath it: Delete destroyed the
 			// selected region behind the backdrop, Ctrl+O stacked a second `aria-modal` dialog on
-			// top, and `?` stacked the shortcuts dialog. Both flags are reachable now that the
-			// open state is lifted out of the components that used to own it (#420).
-			if (isDialogOpen() || isConfigOpen) return;
+			// top, and `?` stacked the shortcuts dialog. One question about the screen, not one
+			// flag per dialog — the flag version knew only about the two dialogs whose open state
+			// happened to live in a context, so Z/T/C kept adding regions under Export (#434).
+			if (isModalOpen()) return;
 			const ctrl = e.ctrlKey || e.metaKey;
 			if (ctrl && e.key === "s") {
 				e.preventDefault();
@@ -1049,8 +1051,6 @@ export function NewEditorShell() {
 		saveDocument,
 		copiedClipId,
 		openShortcutsConfig,
-		isConfigOpen,
-		isDialogOpen,
 		shortcuts,
 		isMac,
 		togglePlay,

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -35,6 +35,11 @@ const DialogContent = React.forwardRef<
 		<DialogOverlay />
 		<DialogPrimitive.Content
 			ref={ref}
+			// Radix 1.1.15 renders `role="dialog"` but no `aria-modal`, and a modal `Dialog` is
+			// exactly what this content is. Stated explicitly it also makes these dialogs visible
+			// to `isModalOpen` (lib/ai-edition/modalGuard), the one predicate the editor's global
+			// shortcuts ask before acting. Before `{...props}` so a caller can still override it.
+			aria-modal="true"
 			className={cn(
 				"fixed left-[50%] top-[50%] z-[10000] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
 				className,

--- a/src/contexts/EditorDialogsContext.tsx
+++ b/src/contexts/EditorDialogsContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, type ReactNode, useContext, useMemo, useRef, useState } from "react";
+import { createContext, type ReactNode, useContext, useMemo, useState } from "react";
 
 // Which of the editor chrome's own dialogs is open, lifted out of the component that used to
 // own it.
@@ -16,16 +16,17 @@ import { createContext, type ReactNode, useContext, useMemo, useRef, useState } 
 // Split in two on purpose. The section changes on every open and close, the actions never do.
 // `NewEditorShell` owns the timeline, the preview and the transport, and only ever needs to
 // *open* a dialog — subscribing it to the section would re-render the whole editor twice per
-// dialog interaction, so it takes the actions alone. `isDialogOpen` serves the readers that
-// are event handlers rather than renders: it answers from a ref, which is what lets it sit in
-// a value whose identity never changes.
+// dialog interaction, so it takes the actions alone.
+//
+// Nothing asks this context whether a dialog is open. It briefly answered that for the editor's
+// global shortcuts, which was only ever half an answer — this context knows about its own
+// dialogs and about no others (#434). `isModalOpen` (lib/ai-edition/modalGuard) is where that
+// question is asked now.
 export type EditorDialogSection = "providers";
 
 interface EditorDialogsActions {
 	openDialog: (section: EditorDialogSection) => void;
 	closeDialog: () => void;
-	/** A live answer without a subscription — for event handlers, never for rendering. */
-	isDialogOpen: () => boolean;
 }
 
 // `undefined` is the "no provider above me" marker, so that `null` stays free to mean the real
@@ -49,24 +50,11 @@ export function useEditorDialogActions(): EditorDialogsActions {
 
 export function EditorDialogsProvider({ children }: { children: ReactNode }) {
 	const [section, setSection] = useState<EditorDialogSection | null>(null);
-	// Mirrored so `isDialogOpen` can read the current section without the actions value having
-	// to depend on it. Written by the two openers, not during render and not from an effect:
-	// during render a discarded one would leave the ref claiming a dialog that never committed,
-	// and from an effect a keystroke landing between the click and the commit would still get
-	// the previous answer. `setSection` is called from nowhere else, so the two cannot drift.
-	const sectionRef = useRef<EditorDialogSection | null>(null);
 
 	const actions = useMemo<EditorDialogsActions>(
 		() => ({
-			openDialog: (next) => {
-				sectionRef.current = next;
-				setSection(next);
-			},
-			closeDialog: () => {
-				sectionRef.current = null;
-				setSection(null);
-			},
-			isDialogOpen: () => sectionRef.current !== null,
+			openDialog: (next) => setSection(next),
+			closeDialog: () => setSection(null),
 		}),
 		[],
 	);

--- a/src/lib/ai-edition/modalGuard.test.tsx
+++ b/src/lib/ai-edition/modalGuard.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+// `isModalOpen` is only as good as the attribute it looks for, and that attribute lives in two
+// components rather than in this module. So the contract is asserted against the real ones:
+// `ModalShell` (every modal in the ai-edition tree — Export, Open project, New project, Edit
+// clip, the unsaved-changes prompt, the AI providers dialog) and `ui/dialog`'s Radix content
+// (the shortcuts dialog and the drop-error dialog). Radix 1.1.15 emits `role="dialog"` and no
+// `aria-modal` of its own, which is why `dialog.tsx` states it.
+
+import "@testing-library/jest-dom";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/contexts/I18nContext", () => ({
+	useScopedT: () => (key: string) => key,
+}));
+
+import { ModalShell } from "@/components/ai-edition/Modals";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { isModalOpen } from "./modalGuard";
+
+afterEach(cleanup);
+
+const noop = () => {
+	/* nothing to close in these tests */
+};
+
+describe("isModalOpen", () => {
+	it("is false with nothing on screen", () => {
+		render(<div>the editor</div>);
+
+		expect(isModalOpen()).toBe(false);
+	});
+
+	it("is true while a ModalShell is open, false once it closes", () => {
+		const { rerender } = render(
+			<ModalShell open onClose={noop} title="Export">
+				<button type="button">Start export</button>
+			</ModalShell>,
+		);
+		expect(isModalOpen()).toBe(true);
+
+		rerender(
+			<ModalShell open={false} onClose={noop} title="Export">
+				<button type="button">Start export</button>
+			</ModalShell>,
+		);
+		expect(isModalOpen()).toBe(false);
+	});
+
+	it("is true while a ui/dialog content is open", () => {
+		render(
+			<Dialog open>
+				<DialogContent aria-label="Keyboard shortcuts">
+					<button type="button">Reset</button>
+				</DialogContent>
+			</Dialog>,
+		);
+
+		expect(isModalOpen()).toBe(true);
+	});
+});

--- a/src/lib/ai-edition/modalGuard.ts
+++ b/src/lib/ai-edition/modalGuard.ts
@@ -1,0 +1,24 @@
+// One central answer to "is a modal on screen?", for the window-level keydown handlers that
+// own the editor's shortcuts (`NewEditorShell`) and its undo/redo (`store/undo`).
+//
+// It asks the DOM instead of enumerating open-state flags. The flag version covered exactly
+// the two dialogs whose open state had been lifted into a context for unrelated reasons (#420)
+// — the AI providers dialog and the shortcuts dialog — and silently missed every modal that
+// kept its `useState` where it was: Export, Open project, New project, Edit clip, the
+// unsaved-changes prompt (issue #434). Each new modal was a new special case nobody would
+// remember to add.
+//
+// Every modal in this tree already announces itself the same way: `ModalShell` and the
+// hand-rolled portal in `LeftPanel` render `aria-modal="true"`, and `ui/dialog` passes the same
+// attribute to Radix's content. So one selector answers for all of them, including the ones
+// that do not exist yet.
+
+/**
+ * True while a modal owns the screen.
+ *
+ * For window-level event handlers, never for rendering: it reads the live DOM, so a component
+ * that called it during render would not re-render when the answer changed.
+ */
+export function isModalOpen(): boolean {
+	return document.querySelector('[aria-modal="true"]') !== null;
+}

--- a/src/lib/ai-edition/store/undo.modalGuard.test.tsx
+++ b/src/lib/ai-edition/store/undo.modalGuard.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+// Undo/redo are bound on `window` here, not in `NewEditorShell` — the shell explicitly defers
+// Ctrl+Z / Ctrl+Y to this listener. So the shell's modal guard never runs for them, and until
+// this listener asked the same question, Ctrl+Z rewrote the document under every open modal,
+// including the ones the shell already suppressed everything else for (issue #434, compounding
+// with #433).
+
+import "@testing-library/jest-dom";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type AxcutDocument, axcutSchemaVersion } from "../schema";
+import { useProjectStore } from "./projectStore";
+import { clearHistory, pushHistory, useUndoRedoShortcuts } from "./undo";
+
+function doc(title: string): AxcutDocument {
+	return {
+		schemaVersion: axcutSchemaVersion,
+		project: {
+			id: "proj_test",
+			title,
+			createdAt: "2026-06-25T10:00:00.000Z",
+			updatedAt: "2026-06-25T10:00:00.000Z",
+		},
+		assets: [],
+		transcript: null,
+		transcripts: [],
+		timeline: {
+			clips: [],
+			gaps: [],
+			trimRanges: [],
+			muteRanges: [],
+			speedRanges: [],
+			captionRanges: [],
+		},
+		annotations: [],
+		zoomRanges: [],
+		legacyEditor: null,
+	};
+}
+
+const onAfter = vi.fn();
+
+/** `aria-modal="true"` on a `role="dialog"` is what every modal in the editor renders — see
+ *  `ModalShell` and `ui/dialog`, both pinned in `modalGuard.test.tsx`. */
+function Harness({ modal }: { modal: boolean }) {
+	useUndoRedoShortcuts(onAfter);
+	return modal ? <div role="dialog" aria-modal="true" /> : null;
+}
+
+beforeEach(() => {
+	onAfter.mockClear();
+	clearHistory();
+	useProjectStore.getState().clear();
+	// One edit in the past, so a working Ctrl+Z has something to roll back to.
+	useProjectStore.setState({ projectId: "proj_test", document: doc("after") });
+	pushHistory({ projectId: "proj_test", doc: doc("before") });
+});
+
+afterEach(() => {
+	cleanup();
+	clearHistory();
+	useProjectStore.getState().clear();
+});
+
+describe("useUndoRedoShortcuts under a modal", () => {
+	it("undoes on Ctrl+Z with nothing on screen", () => {
+		render(<Harness modal={false} />);
+
+		fireEvent.keyDown(document.body, { key: "z", ctrlKey: true });
+
+		expect(onAfter).toHaveBeenCalledTimes(1);
+		expect(useProjectStore.getState().document?.project.title).toBe("before");
+	});
+
+	it("leaves the document alone while a modal owns the screen", () => {
+		const { rerender } = render(<Harness modal />);
+
+		fireEvent.keyDown(document.body, { key: "z", ctrlKey: true });
+
+		expect(onAfter).not.toHaveBeenCalled();
+		expect(useProjectStore.getState().document?.project.title).toBe("after");
+
+		// Nothing was consumed either: the edit is still undoable once the modal is gone.
+		rerender(<Harness modal={false} />);
+		fireEvent.keyDown(document.body, { key: "z", ctrlKey: true });
+		expect(useProjectStore.getState().document?.project.title).toBe("before");
+	});
+});

--- a/src/lib/ai-edition/store/undo.ts
+++ b/src/lib/ai-edition/store/undo.ts
@@ -5,6 +5,7 @@
 // free so it works in any renderer.
 
 import { useEffect, useRef } from "react";
+import { isModalOpen } from "../modalGuard";
 import { useProjectStore } from "./projectStore";
 
 type Snapshot = { projectId: string; doc: unknown };
@@ -66,6 +67,10 @@ export function useUndoRedoShortcuts(onAfter: () => void) {
 		const onKey = (e: KeyboardEvent) => {
 			if (e.target instanceof HTMLTextAreaElement || e.target instanceof HTMLInputElement) return;
 			if (e.target instanceof HTMLElement && e.target.isContentEditable) return;
+			// `NewEditorShell` hands Ctrl+Z / Ctrl+Y to this listener instead of handling them,
+			// so its modal guard never runs for them: without this one, undo kept rewriting the
+			// document under every open modal, including the ones the shell does suppress.
+			if (isModalOpen()) return;
 			const ctrl = e.ctrlKey || e.metaKey;
 			if (ctrl && e.shiftKey && e.key.toLowerCase() === "z") {
 				e.preventDefault();


### PR DESCRIPTION
## What

While the **Export** modal is open, pressing `Z`, `T` or `C` still creates zoom / trim / camera regions on the timeline behind it. Same for every other modal the editor shell owns, and `Ctrl+Z` under *any* modal — including the two that were otherwise covered.

This replaces the guard's list of open-state flags with one central question — *is a modal on screen?* — answered from the DOM.

Fixes #434

## Root cause

`65aa74ef` added the guard as:

```ts
if (isDialogOpen() || isConfigOpen) return;          // NewEditorShell.tsx:866
```

Two flags, not two modals:

- `isDialogOpen()` comes from `EditorDialogsContext` and answers `sectionRef.current !== null`, where `EditorDialogSection` has exactly one member: `"providers"`.
- `isConfigOpen` comes from `ShortcutsContext` and is the Keyboard Shortcuts dialog alone.

Those are precisely the two dialogs whose open state had been lifted into a context for an unrelated reason (the app menu, #420). Every other modal keeps its `useState` in the component that mounts it — `const [exportOpen, setExportOpen] = useState(false)` sits in `NewEditorShell` itself, in the same component as the handler, and the guard cannot see it. Same for Open project, New project, Edit clip and the unsaved-changes prompt.

The two guards preceding it only skip `HTMLInputElement` / `HTMLTextAreaElement` / `isContentEditable` targets, and `ModalShell` focuses a `tabIndex={-1}` div — a div, not a text field — so `Z` / `T` / `C` reach `tl.addZoom` / `tl.addTrim` / `tl.addCameraFullscreen` untouched. The commit message said as much itself: *"Both flags are reachable now that the open state is lifted out of the components that used to own it (#420)"* — the fix was scoped to what #420 made reachable, not to the set of modals.

**Second instance of the same bug:** `src/lib/ai-edition/store/undo.ts` registers its own `window` keydown listener with the identical input/textarea/contentEditable guards and **no modal guard at all**, and `NewEditorShell` deliberately defers `Ctrl+Z` / `Ctrl+Y` to it. So undo/redo mutated the timeline under every modal, including the two the shell did suppress — which is exactly what the issue flags as compounding with #433.

## What changed

**New `src/lib/ai-edition/modalGuard.ts`** — one predicate both callers can import (`undo.ts` is a store file, so this lives outside the component tree):

```ts
export function isModalOpen(): boolean {
	return document.querySelector('[aria-modal="true"]') !== null;
}
```

Every modal in this tree already announces itself that way: `ModalShell` (Export, Open project, New project, Edit clip, unsaved changes, AI providers) and `LeftPanel`'s hand-rolled portal both render `aria-modal="true"`.

**`src/components/ui/dialog.tsx`** — added `aria-modal="true"` to `DialogPrimitive.Content`. Radix 1.1.15 renders `role="dialog"` with no `aria-modal` (verified in `node_modules/@radix-ui/react-dialog/dist/index.mjs`), and this is what folds `ShortcutsConfigDialog` and `EditorEmptyState`'s drop-error dialog under the same selector. It is placed *before* `{...props}` so a caller can still override it, and both consumers are modal dialogs (no `modal={false}` anywhere in `src/`).

**Why `[aria-modal="true"]` and not a `[role="dialog"][data-state="open"]` fallback:** Radix **Popover** content also renders `role="dialog"`, and popovers are used by `ColorField` and `V4Timeline`. A `role`-based selector would silently suppress editor shortcuts under every color picker.

**`src/components/ai-edition/NewEditorShell.tsx`** — the guard becomes `if (isModalOpen()) return;`. `isConfigOpen` and `isDialogOpen` drop out of the destructures and the effect deps.

**`src/lib/ai-edition/store/undo.ts`** — the same one-line guard after the target checks.

**`src/contexts/EditorDialogsContext.tsx`** — `NewEditorShell` was the only consumer of `isDialogOpen`, so it and the `sectionRef` that existed to mirror the section for it are removed. The context goes back to being a section plus two openers, which is the shape its own comment describes wanting.

### Why not the alternatives

- Adding `"export"` to `EditorDialogSection` is a second special case and leaves the other modals broken.
- A ModalShell-driven open-modal counter in context is more plumbing, still misses the two Radix dialogs and LeftPanel's portal, and cannot be read from `undo.ts` without threading a hook through the store layer.
- A target-based check (`e.target.closest('[role="dialog"]')`) fails exactly when the bug bites: the app menu closes without restoring focus, so `e.target` is usually `document.body` — the premise of `65aa74ef`'s own commit message.

## Tests

`NewEditorShell.dialogShortcuts.test.tsx` used to drive the context (`dialogActions.openDialog("providers")`), which puts nothing on screen — it asserted the flag, not the behavior. It now opens a modal the shell itself owns via `Ctrl+O` (local `useState`, the same shape as Export) and asserts:

- `?` does not reach `openConfig` while it is open, and does once Escape closes it
- `Ctrl+N` does not stack a second dialog underneath

`?` is the observable because it is the one shortcut that survives the `hasProject` gate; the keys the issue reports (`Z`, `T`, `C`) sit further down the same handler, behind the same single `return`.

Two new files:

- `src/lib/ai-edition/store/undo.modalGuard.test.tsx` — `Ctrl+Z` leaves the document alone while an `aria-modal` dialog is on screen, and the edit is still undoable once it is gone.
- `src/lib/ai-edition/modalGuard.test.tsx` — pins the attribute the predicate depends on against the *real* `ModalShell` and `ui/dialog` components, since it lives in them rather than in the guard.

### Verified failing without the fix

Neutralizing `isModalOpen()` to `return false` (the pre-fix state for these tests: neither flag's dialog is on screen in any of them):

```
     × leaves the document alone while a modal owns the screen 7ms
     × suppresses ? while a modal the shell itself owns is open, and resumes when it closes 34ms
     × does not stack a second dialog when Ctrl+N fires under an open modal 56ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
AssertionError: expected [ …(2) ] to have a length of 1 but got 2
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 Test Files  2 failed (2)
      Tests  3 failed | 3 passed (6)
```

Stashing only the `dialog.tsx` change:

```
     × is true while a ui/dialog content is open 113ms
AssertionError: expected false to be true // Object.is equality
 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

## How verified

All run on the final rebased tree (branched from `origin/main`, rebased onto `b1fc616f`).

```
$ npx tsc --noEmit
app-typecheck exit=0

$ npx tsc -p tsconfig.test.json --noEmit
test-typecheck exit=0

$ npm run lint
Checked 671 files in 670ms. No fixes applied.
Found 13 warnings.          # exit 0; all 13 pre-existing, none in the touched files

$ npx vitest --run src/components/ai-edition src/lib/ai-edition src/contexts src/components/ui src/components/video-editor
 Test Files  72 passed (72)
      Tests  822 passed (822)
   Duration  19.49s
```

The broad targeted run (rather than only the touched files) is deliberate: `ui/dialog` is a shared primitive, so every consumer of it and of `EditorDialogsContext` was exercised. Not manually smoke-tested against the packaged app — the issue's repro is a real Export-modal keypress, worth one pass on Windows before release.


## Interaction with #433 — read before merging either

`claude/fix-433-undo-redo` touches two of the same files. The two branches merge with one trivial conflict in `src/lib/ai-edition/store/undo.ts` (a straight union of the import list and the keydown guard), and the merged tree is fully green: both typechecks, lint, and 816 tests across `src/lib/ai-edition src/components/ai-edition src/contexts src/components/ui`.

**It is green and still broken.** A combined-merge check found a semantic conflict that neither branch's tests catch:

#433 stops using Electron's `role: "undo"` and gives the Edit menu its own `CmdOrCtrl+Z` accelerator, forwarded over IPC as `menu-undo` to `runUndo` in `undo.ts`. That handler checks only `isTextEditingTarget(document.activeElement)`. **There is no `isModalOpen()` on that path**, and a modal's controls are buttons, not text fields — so the check passes and `undo()` rewrites the document under the open modal. That is verbatim the bug this PR closes.

Reachable on every platform, for two different reasons:

- **macOS** — unconditional. AppKit matches the menu key equivalent in `-[NSApplication sendEvent:]` before the event reaches the web contents, so the guarded keydown listener never runs. This PR's guard becomes dead code on macOS once #433 lands.
- **Windows/Linux** — this PR's guard is what *creates* the condition. It returns early without `preventDefault()`, so the key becomes an unhandled keyboard event, which is exactly how Electron dispatches menu accelerators on those platforms. No modal: the shortcut preventDefaults and the accelerator is suppressed. Modal open: it is not, and the accelerator fires into the unguarded `runUndo`.

Verified empirically on the merged tree with a throwaway probe (since deleted): the keydown path is correctly guarded and comes back `defaultPrevented === false`, while `runUndo()` with an `aria-modal="true"` node in the DOM rewrote the document and fired the persist callback.

**Whichever of the two lands second must carry this**, in `src/lib/ai-edition/store/undo.ts` — text-field check first, so a rename dialog's input still gets the browser's text undo:

```ts
if (isTextEditingTarget(window.document.activeElement)) {
	window.document.execCommand?.("undo");
	return;
}
if (isModalOpen()) return;
if (undo()) onAfterRef.current();
```

…and the same in `runRedo`, plus a case in #433's `"the Edit menu's undo/redo route"` describe that appends an `aria-modal="true"` node and asserts the document is untouched. That block currently clears `document.body` in its `beforeEach`, which incidentally guarantees `isModalOpen()` is false — which is why it passes today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)