### PR TITLE
fix(editor): make undo/redo actually apply

### DIFF
--- a/electron/edit-menu.test.ts
+++ b/electron/edit-menu.test.ts
@@ -1,0 +1,73 @@
+// Regression cover for the macOS half of #433.
+//
+// The Edit menu used to carry `role: "undo"` / `role: "redo"` with
+// `registerAccelerator: false`. That field is documented `@platform linux,win32`,
+// so on darwin it does nothing at all: AppKit still matches the menu's Cmd+Z key
+// equivalent inside `-[NSApplication sendEvent:]`, before the key event reaches
+// the web contents, and the editor's own keydown handler never runs.
+//
+// These tests pin the shape that actually reaches the renderer on every platform:
+// an explicit accelerator and a click that dispatches to the editor.
+
+import { describe, expect, it, vi } from "vitest";
+import { buildEditMenuSubmenu, type EditorUndoRedoChannel } from "./edit-menu";
+
+function build() {
+	const dispatch = vi.fn<(channel: EditorUndoRedoChannel) => void>();
+	const items = buildEditMenuSubmenu({
+		label: (_key, fallback) => fallback,
+		dispatch,
+	});
+	return { items, dispatch };
+}
+
+describe("buildEditMenuSubmenu", () => {
+	it("owns Cmd+Z itself instead of leaning on registerAccelerator", () => {
+		const { items } = build();
+		const undoItem = items.find((i) => i.label === "Undo");
+
+		expect(undoItem?.accelerator).toBe("CmdOrCtrl+Z");
+		// The two things that made the previous version a no-op on macOS.
+		expect(undoItem?.role).toBeUndefined();
+		expect(undoItem?.registerAccelerator).toBeUndefined();
+	});
+
+	it("owns Shift+Cmd+Z for redo on the same terms", () => {
+		const { items } = build();
+		const redoItem = items.find((i) => i.label === "Redo");
+
+		expect(redoItem?.accelerator).toBe("Shift+CmdOrCtrl+Z");
+		expect(redoItem?.role).toBeUndefined();
+		expect(redoItem?.registerAccelerator).toBeUndefined();
+	});
+
+	it("routes both to the editor renderer, which owns the document's undo stack", () => {
+		// `webContents.undo()` -- what the roles ran -- is the WEB EDITING undo. It does
+		// nothing outside a focused text field, so on macOS Cmd+Z was swallowed by a menu
+		// item that could not have serviced it anyway.
+		const { items, dispatch } = build();
+
+		items
+			.find((i) => i.label === "Undo")
+			?.click?.(
+				// The click signature carries a menu item, a window and the event; none of
+				// them are read here.
+				undefined as never,
+				undefined as never,
+				undefined as never,
+			);
+		expect(dispatch).toHaveBeenCalledWith("menu-undo");
+
+		items
+			.find((i) => i.label === "Redo")
+			?.click?.(undefined as never, undefined as never, undefined as never);
+		expect(dispatch).toHaveBeenCalledWith("menu-redo");
+	});
+
+	it("leaves the clipboard items as roles", () => {
+		// They act on the focused text selection, which is exactly what the roles do --
+		// and nothing in the editor shadows them.
+		const { items } = build();
+		expect(items.map((i) => i.role).filter(Boolean)).toEqual(["cut", "copy", "paste", "selectAll"]);
+	});
+});

--- a/electron/edit-menu.test.ts
+++ b/electron/edit-menu.test.ts
@@ -7,10 +7,19 @@
 // the web contents, and the editor's own keydown handler never runs.
 //
 // These tests pin the shape that actually reaches the renderer on every platform:
-// an explicit accelerator and a click that dispatches to the editor.
+// an explicit accelerator and a click that dispatches to the editor -- and, in the
+// second describe, where that dispatch actually lands. Dropping the roles took
+// `webContents.undo()` away from every window, so the non-editor fallback is not a
+// detail: it is the half of the design that keeps the launch and notes windows
+// working.
 
 import { describe, expect, it, vi } from "vitest";
-import { buildEditMenuSubmenu, type EditorUndoRedoChannel } from "./edit-menu";
+import {
+	buildEditMenuSubmenu,
+	type EditorUndoRedoChannel,
+	routeEditorUndoRedo,
+	type UndoRedoWindow,
+} from "./edit-menu";
 
 function build() {
 	const dispatch = vi.fn<(channel: EditorUndoRedoChannel) => void>();
@@ -69,5 +78,67 @@ describe("buildEditMenuSubmenu", () => {
 		// and nothing in the editor shadows them.
 		const { items } = build();
 		expect(items.map((i) => i.role).filter(Boolean)).toEqual(["cut", "copy", "paste", "selectAll"]);
+	});
+});
+
+function editorWindow() {
+	const webContents = {
+		send: vi.fn<(channel: EditorUndoRedoChannel) => void>(),
+		undo: vi.fn(),
+		redo: vi.fn(),
+	};
+	const isDestroyed = vi.fn(() => false);
+	return {
+		window: { isDestroyed, webContents } satisfies UndoRedoWindow,
+		webContents,
+		isDestroyed,
+	};
+}
+
+describe("routeEditorUndoRedo", () => {
+	it("hands the editor window the request over IPC", () => {
+		// The editor renderer owns the document's undo stack, and applies the text-field
+		// rule its own keydown path applies. `webContents.undo()` could not do either.
+		const target = editorWindow();
+
+		routeEditorUndoRedo("menu-undo", target.window, () => true);
+		routeEditorUndoRedo("menu-redo", target.window, () => true);
+
+		expect(target.webContents.send.mock.calls).toEqual([["menu-undo"], ["menu-redo"]]);
+		expect(target.webContents.undo).not.toHaveBeenCalled();
+		expect(target.webContents.redo).not.toHaveBeenCalled();
+	});
+
+	it("falls back to the web-editing undo when the focused window is not the editor", () => {
+		// The case the whole design rests on. Dropping `role: "undo"` took the menu's
+		// built-in `webContents.undo()` away from EVERY window, so the launch window and
+		// the notes window -- where the role was the right answer -- get it back here.
+		const target = editorWindow();
+
+		routeEditorUndoRedo("menu-undo", target.window, () => false);
+		expect(target.webContents.undo).toHaveBeenCalledOnce();
+		expect(target.webContents.redo).not.toHaveBeenCalled();
+
+		routeEditorUndoRedo("menu-redo", target.window, () => false);
+		expect(target.webContents.redo).toHaveBeenCalledOnce();
+
+		expect(target.webContents.send).not.toHaveBeenCalled();
+	});
+
+	it("does nothing when there is no window, or it has been destroyed", () => {
+		// Unlike `sendEditorMenuAction` this never creates one: Cmd+Z is not a request to
+		// open the editor. And the destroyed check runs before anything reads the window,
+		// which is why `isEditor` is a callback -- `webContents.getURL()` on a destroyed
+		// window throws.
+		const isEditor = vi.fn(() => true);
+		expect(() => routeEditorUndoRedo("menu-undo", null, isEditor)).not.toThrow();
+
+		const target = editorWindow();
+		target.isDestroyed.mockReturnValue(true);
+		routeEditorUndoRedo("menu-undo", target.window, isEditor);
+
+		expect(target.webContents.send).not.toHaveBeenCalled();
+		expect(target.webContents.undo).not.toHaveBeenCalled();
+		expect(isEditor).not.toHaveBeenCalled();
 	});
 });

--- a/electron/edit-menu.ts
+++ b/electron/edit-menu.ts
@@ -35,6 +35,51 @@ export interface EditMenuOptions {
 	dispatch: (channel: EditorUndoRedoChannel) => void;
 }
 
+/** The slice of `WebContents` the routing below touches. */
+export interface UndoRedoWebContents {
+	send: (channel: EditorUndoRedoChannel) => void;
+	undo: () => void;
+	redo: () => void;
+}
+
+/** The slice of `BrowserWindow` the routing below touches. */
+export interface UndoRedoWindow {
+	isDestroyed: () => boolean;
+	webContents: UndoRedoWebContents;
+}
+
+/**
+ * Deliver an undo/redo request to the window that should service it.
+ *
+ * Lives here rather than in `main.ts` for the reason `about.ts` does: `main.ts`
+ * calls `app.requestSingleInstanceLock()` at import time and cannot be loaded by a
+ * test, so anything left in it is untested by construction.
+ *
+ * Three cases, and the middle one is the whole reason the menu items dropped their
+ * `role`. There is no window, or it is gone: nothing to do — unlike
+ * `sendEditorMenuAction` this never CREATES an editor window, because Cmd+Z is not
+ * a request to open the editor. The window is not the editor — the launch window,
+ * the notes window — so the web-editing undo the `undo` role used to provide is the
+ * right one after all, and it is reached directly. Otherwise it is the editor, and
+ * the editor's renderer owns the document's undo stack.
+ *
+ * `isEditor` is a callback, not a flag, so nothing reads the window's URL before
+ * the destroyed check has run.
+ */
+export function routeEditorUndoRedo(
+	channel: EditorUndoRedoChannel,
+	window: UndoRedoWindow | null | undefined,
+	isEditor: () => boolean,
+): void {
+	if (!window || window.isDestroyed()) return;
+	if (!isEditor()) {
+		if (channel === "menu-undo") window.webContents.undo();
+		else window.webContents.redo();
+		return;
+	}
+	window.webContents.send(channel);
+}
+
 export function buildEditMenuSubmenu({
 	label,
 	dispatch,

--- a/electron/edit-menu.ts
+++ b/electron/edit-menu.ts
@@ -1,0 +1,62 @@
+// The application menu's Edit submenu, split out of `main.ts` so it can be tested
+// (same shape as `about.ts`).
+//
+// Undo/Redo are deliberately NOT `role: "undo"` / `role: "redo"`.
+//
+// Those roles run `webContents.undo()`, the WEB EDITING undo, which does nothing
+// at all outside a focused text field. On macOS their Cmd+Z key equivalent is
+// matched by AppKit inside `-[NSApplication sendEvent:]`, BEFORE the key event
+// reaches the web contents, so the editor's own document-level handler
+// (`useUndoRedoShortcuts`) never sees the keydown and Ctrl+Z silently did
+// nothing (#433).
+//
+// `registerAccelerator: false` does not fix that. Electron annotates the field
+// `@platform linux,win32` (see `MenuItemConstructorOptions` in electron.d.ts),
+// so on darwin it is ignored outright and the menu keeps the key equivalent.
+// And on Windows and Linux the roles were never the problem: menu accelerators
+// there are dispatched from the unhandled-keyboard-event path, i.e. AFTER the
+// renderer, which the renderer's own `preventDefault()` already suppresses.
+//
+// So the items own the accelerator on every platform and forward to the editor
+// renderer, which applies exactly the rule its keydown path applies: a focused
+// text field gets the browser's text undo, anything else gets the document undo.
+// `dispatch` is what falls back to `webContents.undo()` when the focused window
+// is not the editor at all.
+
+import type { MenuItemConstructorOptions } from "electron";
+
+/** IPC channels the Edit menu forwards to the editor renderer. */
+export type EditorUndoRedoChannel = "menu-undo" | "menu-redo";
+
+export interface EditMenuOptions {
+	/** Localised label for `key`, falling back to `fallback` when untranslated. */
+	label: (key: string, fallback: string) => string;
+	/** Route an undo/redo request to whichever window should service it. */
+	dispatch: (channel: EditorUndoRedoChannel) => void;
+}
+
+export function buildEditMenuSubmenu({
+	label,
+	dispatch,
+}: EditMenuOptions): MenuItemConstructorOptions[] {
+	return [
+		{
+			label: label("actions.undo", "Undo"),
+			accelerator: "CmdOrCtrl+Z",
+			click: () => dispatch("menu-undo"),
+		},
+		{
+			label: label("actions.redo", "Redo"),
+			accelerator: "Shift+CmdOrCtrl+Z",
+			click: () => dispatch("menu-redo"),
+		},
+		{ type: "separator" },
+		// The clipboard roles keep theirs: they act on the focused text selection,
+		// which is precisely what `webContents.cut/copy/paste` do, and the editor has
+		// no document-level meaning for them to shadow.
+		{ role: "cut", label: label("actions.cut", "Cut") },
+		{ role: "copy", label: label("actions.copy", "Copy") },
+		{ role: "paste", label: label("actions.paste", "Paste") },
+		{ role: "selectAll", label: label("actions.selectAll", "Select All") },
+	];
+}

--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -383,6 +383,10 @@ interface Window {
 		onMenuLoadProject: (callback: () => void) => () => void;
 		onMenuSaveProject: (callback: () => void) => () => void;
 		onMenuSaveProjectAs: (callback: () => void) => () => void;
+		/** Edit > Undo / Redo. On macOS the menu is the only route Cmd+Z has to the
+		 *  renderer at all — see `electron/edit-menu.ts`. */
+		onMenuUndo: (callback: () => void) => () => void;
+		onMenuRedo: (callback: () => void) => () => void;
 		quitApp: () => void;
 		setTitleBarOverlay: (color: string, symbolColor: string) => void;
 		getPlatform: () => string;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -33,6 +33,7 @@ import {
 import { parseCliArgs } from "./cli/args";
 import { runCli } from "./cli/cliMain";
 import { isDiagnosticModeEnabled, mainLogBuffer } from "./diagnostics/main-log-buffer";
+import { buildEditMenuSubmenu, type EditorUndoRedoChannel } from "./edit-menu";
 import {
 	loadAndRegisterGlobalShortcut,
 	registerOpenAppShortcut,
@@ -189,6 +190,25 @@ function sendEditorMenuAction(
 	targetWindow.webContents.send(channel);
 }
 
+/**
+ * Route the Edit menu's Undo/Redo to whoever should service it.
+ *
+ * Unlike `sendEditorMenuAction` this never CREATES an editor window: Cmd+Z is not
+ * a request to open the editor. And when the focused window is not the editor --
+ * the launch window, the notes window -- the web-editing undo the `undo` role used
+ * to provide is the right one after all, so fall through to it.
+ */
+function sendEditorUndoRedo(channel: EditorUndoRedoChannel) {
+	const targetWindow = BrowserWindow.getFocusedWindow() ?? mainWindow;
+	if (!targetWindow || targetWindow.isDestroyed()) return;
+	if (!isEditorWindow(targetWindow)) {
+		if (channel === "menu-undo") targetWindow.webContents.undo();
+		else targetWindow.webContents.redo();
+		return;
+	}
+	targetWindow.webContents.send(channel);
+}
+
 function setupApplicationMenu() {
 	const isMac = process.platform === "darwin";
 	const template: Electron.MenuItemConstructorOptions[] = [];
@@ -274,32 +294,11 @@ function setupApplicationMenu() {
 		},
 		{
 			label: mainT("common", "actions.edit") || "Edit",
-			submenu: [
-				// `registerAccelerator: false` on both: the roles run `webContents.undo()`,
-				// the WEB EDITING undo, which does nothing outside a focused text field —
-				// and registering their accelerators lets the native menu eat Ctrl+Z /
-				// Ctrl+Shift+Z before the renderer's document-level handler
-				// (`useUndoRedoShortcuts`) ever sees the keydown. The items stay, greyed
-				// shortcut text and all, so text fields keep their menu entries.
-				{
-					role: "undo",
-					label: mainT("common", "actions.undo") || "Undo",
-					registerAccelerator: false,
-				},
-				{
-					role: "redo",
-					label: mainT("common", "actions.redo") || "Redo",
-					registerAccelerator: false,
-				},
-				{ type: "separator" },
-				{ role: "cut", label: mainT("common", "actions.cut") || "Cut" },
-				{ role: "copy", label: mainT("common", "actions.copy") || "Copy" },
-				{ role: "paste", label: mainT("common", "actions.paste") || "Paste" },
-				{
-					role: "selectAll",
-					label: mainT("common", "actions.selectAll") || "Select All",
-				},
-			],
+			// Built in `edit-menu.ts` — read its header for why Undo/Redo are not roles.
+			submenu: buildEditMenuSubmenu({
+				label: (key, fallback) => mainT("common", key) || fallback,
+				dispatch: sendEditorUndoRedo,
+			}),
 		},
 		{
 			label: mainT("common", "actions.view") || "View",

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -275,8 +275,22 @@ function setupApplicationMenu() {
 		{
 			label: mainT("common", "actions.edit") || "Edit",
 			submenu: [
-				{ role: "undo", label: mainT("common", "actions.undo") || "Undo" },
-				{ role: "redo", label: mainT("common", "actions.redo") || "Redo" },
+				// `registerAccelerator: false` on both: the roles run `webContents.undo()`,
+				// the WEB EDITING undo, which does nothing outside a focused text field —
+				// and registering their accelerators lets the native menu eat Ctrl+Z /
+				// Ctrl+Shift+Z before the renderer's document-level handler
+				// (`useUndoRedoShortcuts`) ever sees the keydown. The items stay, greyed
+				// shortcut text and all, so text fields keep their menu entries.
+				{
+					role: "undo",
+					label: mainT("common", "actions.undo") || "Undo",
+					registerAccelerator: false,
+				},
+				{
+					role: "redo",
+					label: mainT("common", "actions.redo") || "Redo",
+					registerAccelerator: false,
+				},
 				{ type: "separator" },
 				{ role: "cut", label: mainT("common", "actions.cut") || "Cut" },
 				{ role: "copy", label: mainT("common", "actions.copy") || "Copy" },

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -33,7 +33,7 @@ import {
 import { parseCliArgs } from "./cli/args";
 import { runCli } from "./cli/cliMain";
 import { isDiagnosticModeEnabled, mainLogBuffer } from "./diagnostics/main-log-buffer";
-import { buildEditMenuSubmenu, type EditorUndoRedoChannel } from "./edit-menu";
+import { buildEditMenuSubmenu, type EditorUndoRedoChannel, routeEditorUndoRedo } from "./edit-menu";
 import {
 	loadAndRegisterGlobalShortcut,
 	registerOpenAppShortcut,
@@ -191,22 +191,12 @@ function sendEditorMenuAction(
 }
 
 /**
- * Route the Edit menu's Undo/Redo to whoever should service it.
- *
- * Unlike `sendEditorMenuAction` this never CREATES an editor window: Cmd+Z is not
- * a request to open the editor. And when the focused window is not the editor --
- * the launch window, the notes window -- the web-editing undo the `undo` role used
- * to provide is the right one after all, so fall through to it.
+ * Resolve which window the Edit menu's Undo/Redo is aimed at. The routing itself
+ * is `routeEditorUndoRedo`, in `edit-menu.ts`, where a test can reach it.
  */
 function sendEditorUndoRedo(channel: EditorUndoRedoChannel) {
 	const targetWindow = BrowserWindow.getFocusedWindow() ?? mainWindow;
-	if (!targetWindow || targetWindow.isDestroyed()) return;
-	if (!isEditorWindow(targetWindow)) {
-		if (channel === "menu-undo") targetWindow.webContents.undo();
-		else targetWindow.webContents.redo();
-		return;
-	}
-	targetWindow.webContents.send(channel);
+	routeEditorUndoRedo(channel, targetWindow, () => !!targetWindow && isEditorWindow(targetWindow));
 }
 
 function setupApplicationMenu() {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -354,6 +354,20 @@ contextBridge.exposeInMainWorld("electronAPI", {
 		ipcRenderer.on("menu-save-project-as", listener);
 		return () => ipcRenderer.removeListener("menu-save-project-as", listener);
 	},
+	// The Edit menu's Undo/Redo. On macOS this is the ONLY way Cmd+Z reaches the
+	// renderer: AppKit matches the menu's key equivalent before the key event is
+	// delivered to the web contents, so the document-level keydown handler never
+	// runs. See `electron/edit-menu.ts`.
+	onMenuUndo: (callback: () => void) => {
+		const listener = () => callback();
+		ipcRenderer.on("menu-undo", listener);
+		return () => ipcRenderer.removeListener("menu-undo", listener);
+	},
+	onMenuRedo: (callback: () => void) => {
+		const listener = () => callback();
+		ipcRenderer.on("menu-redo", listener);
+		return () => ipcRenderer.removeListener("menu-redo", listener);
+	},
 	quitApp: () => {
 		ipcRenderer.send("app-quit");
 	},

--- a/src/components/ai-edition/CaptionsPane.tsx
+++ b/src/components/ai-edition/CaptionsPane.tsx
@@ -181,10 +181,13 @@ export function CaptionsPane() {
 	const clearLegacyCaptionAnnotations = async () => {
 		const doc = useProjectStore.getState().document;
 		if (!doc) return;
-		await saveDocument({
-			...doc,
-			annotations: doc.annotations.filter((a) => a.annotationSource !== "auto-caption"),
-		});
+		await saveDocument(
+			{
+				...doc,
+				annotations: doc.annotations.filter((a) => a.annotationSource !== "auto-caption"),
+			},
+			{ history: true },
+		);
 	};
 
 	return (

--- a/src/components/ai-edition/NewEditorShell.tsx
+++ b/src/components/ai-edition/NewEditorShell.tsx
@@ -575,25 +575,31 @@ export function NewEditorShell() {
 		(target: TrimTarget, startSec: number, endSec: number, reason: string) => {
 			// `clipId` is what keeps the cut on the block the user typed in: with two clips
 			// over the same media, an asset-only trim showed up on both (see `trimAppliesToClip`).
-			void applyTimelineOp({
-				type: "add_trim_range",
-				assetId: target.assetId,
-				clipId: target.clipId,
-				startSec,
-				endSec,
-				reason,
-			});
+			void applyTimelineOp(
+				{
+					type: "add_trim_range",
+					assetId: target.assetId,
+					clipId: target.clipId,
+					startSec,
+					endSec,
+					reason,
+				},
+				{ history: true },
+			);
 		},
 		[applyTimelineOp],
 	);
 
 	const handleRemoveTrimRange = useCallback(
 		(trimId: string) => {
-			void applyTimelineOp({
-				type: "remove_trim_range",
-				trimId,
-				reason: "Restored from transcript pane.",
-			});
+			void applyTimelineOp(
+				{
+					type: "remove_trim_range",
+					trimId,
+					reason: "Restored from transcript pane.",
+				},
+				{ history: true },
+			);
 		},
 		[applyTimelineOp],
 	);

--- a/src/components/ai-edition/NewEditorShell.tsx
+++ b/src/components/ai-edition/NewEditorShell.tsx
@@ -165,7 +165,7 @@ export function NewEditorShell() {
 	// edit the user just undid came back. `history: false` is load-bearing — a
 	// recording save here would push the restored document straight back onto the
 	// stack and clear the redo the undo had just created.
-	useUndoRedoShortcuts(() => {
+	const { runUndo, runRedo } = useUndoRedoShortcuts(() => {
 		const doc = useProjectStore.getState().document;
 		if (doc) void useProjectStore.getState().saveDocument(doc, { history: false });
 	});
@@ -317,7 +317,7 @@ export function NewEditorShell() {
 			const doc = useProjectStore.getState().document;
 			// The store already toasted the reason; answering false is what keeps the
 			// window open on top of it.
-			if (doc) return await saveDocument(doc);
+			if (doc) return await saveDocument(doc, { history: true });
 			return true;
 		});
 
@@ -651,15 +651,20 @@ export function NewEditorShell() {
 	const handleSave = useCallback(async () => {
 		const doc = useProjectStore.getState().document;
 		if (!doc) return;
-		if (await saveDocument(doc)) toast.success("Project saved");
+		if (await saveDocument(doc, { history: true })) toast.success("Project saved");
 	}, [saveDocument]);
 
 	// Native File menu (electron/main.ts) → v4 actions. The menu is shown via
 	// Menu.setApplicationMenu and dispatches these IPC events; the old editor
 	// listened to them, but the v4 shell replaced it, leaving the File items
 	// dead. Wire them to the same handlers the top-bar buttons use so the
-	// File/Edit/View menu bar works again (Edit/View items use Electron roles).
+	// File/Edit/View menu bar works again (the View items still use Electron roles).
 	// The v4 editor has no separate "Save As" location, so it maps to Save.
+	//
+	// Edit > Undo/Redo are here too, and not roles: on macOS the menu's Cmd+Z key
+	// equivalent is matched by AppKit before the key event reaches the renderer, so
+	// this subscription is the ONLY thing that makes Ctrl+Z work there. See
+	// `electron/edit-menu.ts`.
 	useEffect(() => {
 		const api = window.electronAPI;
 		if (!api) return;
@@ -668,18 +673,20 @@ export function NewEditorShell() {
 			api.onMenuLoadProject?.(() => setOpenProjectOpen(true)),
 			api.onMenuSaveProject?.(() => void handleSave()),
 			api.onMenuSaveProjectAs?.(() => void handleSave()),
+			api.onMenuUndo?.(runUndo),
+			api.onMenuRedo?.(runRedo),
 		];
 		return () => {
 			for (const unsub of unsubscribers) unsub?.();
 		};
-	}, [handleSave]);
+	}, [handleSave, runUndo, runRedo]);
 
 	const handleRenameProject = useCallback(
 		async (title: string) => {
 			const doc = useProjectStore.getState().document;
 			if (!doc) return;
 			if (title === doc.project.title) return;
-			await saveDocument({ ...doc, project: { ...doc.project, title } });
+			await saveDocument({ ...doc, project: { ...doc.project, title } }, { history: true });
 		},
 		[saveDocument],
 	);
@@ -703,7 +710,7 @@ export function NewEditorShell() {
 					// A failed save cancels the action that prompted this dialog. The store has
 					// already said why -- which is what the bare `catch {}` here used to swallow,
 					// leaving the window refusing to close with nothing on screen explaining it.
-					if (doc && !(await saveDocument(doc))) {
+					if (doc && !(await saveDocument(doc, { history: true }))) {
 						resolve("cancel");
 						return;
 					}
@@ -797,24 +804,33 @@ export function NewEditorShell() {
 		);
 
 		if (snapshot.kind === "zoom") {
-			await saveDocument({
-				...doc,
-				zoomRanges: [...doc.zoomRanges, ...anchored] as typeof doc.zoomRanges,
-			});
+			await saveDocument(
+				{
+					...doc,
+					zoomRanges: [...doc.zoomRanges, ...anchored] as typeof doc.zoomRanges,
+				},
+				{ history: true },
+			);
 		} else if (snapshot.kind === "annotation") {
-			await saveDocument({
-				...doc,
-				annotations: [...doc.annotations, ...anchored] as typeof doc.annotations,
-			});
+			await saveDocument(
+				{
+					...doc,
+					annotations: [...doc.annotations, ...anchored] as typeof doc.annotations,
+				},
+				{ history: true },
+			);
 		} else {
 			// speed and cameraFullscreen are both plain spans on legacyEditor.
 			const key = snapshot.kind === "speed" ? "speedRegions" : "cameraFullscreenRegions";
 			const legacy = (doc.legacyEditor as Record<string, unknown>) ?? {};
 			const prev = (legacy[key] as unknown[]) ?? [];
-			await saveDocument({
-				...doc,
-				legacyEditor: { ...legacy, [key]: [...prev, ...anchored] },
-			});
+			await saveDocument(
+				{
+					...doc,
+					legacyEditor: { ...legacy, [key]: [...prev, ...anchored] },
+				},
+				{ history: true },
+			);
 		}
 		toast.success("Region pasted");
 		// `tl` belongs here now that the trim branch calls tl.addTrim: useTimeline
@@ -889,7 +905,7 @@ export function NewEditorShell() {
 					if (choice === "save") {
 						const doc = useProjectStore.getState().document;
 						// Stay put if the save did not land -- the store has already said why.
-						if (doc && !(await saveDocument(doc))) return;
+						if (doc && !(await saveDocument(doc, { history: true }))) return;
 					}
 					setNewProjectOpen(true);
 				})();
@@ -903,7 +919,7 @@ export function NewEditorShell() {
 					if (choice === "save") {
 						const doc = useProjectStore.getState().document;
 						// Stay put if the save did not land -- the store has already said why.
-						if (doc && !(await saveDocument(doc))) return;
+						if (doc && !(await saveDocument(doc, { history: true }))) return;
 					}
 					setOpenProjectOpen(true);
 				})();

--- a/src/components/ai-edition/NewEditorShell.tsx
+++ b/src/components/ai-edition/NewEditorShell.tsx
@@ -160,8 +160,14 @@ export function NewEditorShell() {
 		[transcriptions],
 	);
 	const tl = useTimeline();
+	// An undo only puts the restored document back in the store and marks it dirty,
+	// so without this the reverted state never reached disk: close the window and the
+	// edit the user just undid came back. `history: false` is load-bearing — a
+	// recording save here would push the restored document straight back onto the
+	// stack and clear the redo the undo had just created.
 	useUndoRedoShortcuts(() => {
-		// ponytail: placeholder, wire when undo stack merges with history
+		const doc = useProjectStore.getState().document;
+		if (doc) void useProjectStore.getState().saveDocument(doc, { history: false });
 	});
 	const [copiedClipId, setCopiedClipId] = useState<string | null>(null);
 	const [projectSummaries, setProjectSummaries] = useState<AiEditionProjectSummary[]>([]);
@@ -368,7 +374,10 @@ export function NewEditorShell() {
 					[{ startSec: 0, endSec: known }],
 					"Auto-created full-duration clip",
 				);
-				void state.saveDocument(next);
+				// `history: false` for both writes in this callback: they are the probed
+				// duration being folded into the document on load, not something the user
+				// did — an undo landing on one of them would empty their timeline.
+				void state.saveDocument(next, { history: false });
 				return;
 			}
 			// Hand the probed duration to the pure document layer: it patches only the
@@ -379,7 +388,7 @@ export function NewEditorShell() {
 			// nothing is waiting, so there is nothing to guard here.
 			const next = applyProbedDuration(doc, assetId, known);
 			if (next !== doc) {
-				void state.saveDocument(next);
+				void state.saveDocument(next, { history: false });
 			}
 		},
 		[setSourceDuration],

--- a/src/components/ai-edition/recordingImport.test.ts
+++ b/src/components/ai-edition/recordingImport.test.ts
@@ -1,15 +1,33 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { replaceTimeline as replaceTimelineOp } from "@/lib/ai-edition/document/timeline";
+import { type AxcutDocument, createEmptyDocument } from "@/lib/ai-edition/schema";
 import { useProjectStore } from "@/lib/ai-edition/store/projectStore";
+import { undo } from "@/lib/ai-edition/store/undo";
+import { past } from "@/lib/ai-edition/store/undoStack";
 import { importPendingRecording } from "./recordingImport";
 
-// The store's own bridge calls are never reached — every action the import uses
-// is stubbed below — but importing the store pulls the client in, so stub it.
-vi.mock("@/native/client", () => ({ nativeBridgeClient: { aiEdition: {} } }));
+// The first describe stubs the store actions, so the bridge is never reached
+// there. The second one runs the REAL store against these, which is the only way
+// to see what the import leaves on the undo stack.
+const bridge = vi.hoisted(() => ({
+	create: vi.fn(),
+	addAsset: vi.fn(),
+	save: vi.fn(),
+}));
+vi.mock("@/native/client", () => ({ nativeBridgeClient: { aiEdition: bridge } }));
 
 const createProject = vi.fn(async () => undefined);
 const addAsset = vi.fn(async () => null);
 const replaceTimeline = vi.fn(async () => undefined);
+
+// Read before anything stubs them: the first describe replaces these actions on the
+// live store, and `clear()` resets the DATA, not the actions.
+const realActions = {
+	createProject: useProjectStore.getState().createProject,
+	addAsset: useProjectStore.getState().addAsset,
+	replaceTimeline: useProjectStore.getState().replaceTimeline,
+};
 
 /** Stands in for the main-process recording slot: one value, set and read. */
 function stubElectronApi(screenVideoPath: string | null) {
@@ -86,6 +104,86 @@ describe("importPendingRecording", () => {
 		expect(replaceTimeline).toHaveBeenCalledWith(
 			[{ startSec: 0, endSec: 60 }],
 			"Auto-imported recording",
+			{ history: false },
 		);
+	});
+});
+
+// The whole hand-off, against the real store: stop the recording, land in the
+// editor, press Ctrl+Z.
+//
+// The user has made no edit at this point -- the editor built this project for
+// them, unattended, on mount. The seed below used to record itself as an undo
+// step because `projectStore.replaceTimeline` hardcoded `{ history: true }` inside
+// itself, where the option was invisible to its caller. So a brand-new project
+// opened with `past.length === 1`, the first Ctrl+Z restored the state before the
+// seed -- an empty timeline -- and `NewEditorShell`'s post-undo persist wrote that
+// empty timeline to disk.
+describe("what the recording import leaves on the undo stack", () => {
+	const PROJECT_ID = "project_imported";
+	const SCREEN_PATH = "/recordings/recording-1.webm";
+
+	/** The document the main process actually returns from `addAsset`: an asset with
+	 *  no `durationSec` (it stats the file, it does not probe it). */
+	function withAsset(): AxcutDocument {
+		const doc = createEmptyDocument({ projectId: PROJECT_ID, title: "Recording" });
+		return {
+			...doc,
+			assets: [
+				{
+					id: "asset_1",
+					kind: "video",
+					label: "recording-1.webm",
+					originalPath: SCREEN_PATH,
+					cameraTrack: null,
+				},
+			],
+			project: { ...doc.project, primaryAssetId: "asset_1" },
+		};
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		useProjectStore.getState().clear();
+		useProjectStore.setState(realActions);
+		past.length = 0;
+		bridge.create.mockImplementation(async () => ({
+			success: true,
+			document: createEmptyDocument({ projectId: PROJECT_ID, title: "Recording" }),
+		}));
+		bridge.addAsset.mockImplementation(async () => ({ success: true, document: withAsset() }));
+		bridge.save.mockImplementation(async (document: unknown) => ({ success: true, document }));
+		stubElectronApi(SCREEN_PATH);
+	});
+
+	it("leaves it empty: the user has not edited anything yet", async () => {
+		await importPendingRecording();
+
+		expect(past).toHaveLength(0);
+		expect(undo()).toBe(false);
+	});
+
+	it("still has its clip after the first Ctrl+Z", async () => {
+		await importPendingRecording();
+
+		// The `<video>` reports its duration and `NewEditorShell.handleLoadedMetadata`
+		// folds it in -- which is when the clip the user sees actually appears, since
+		// `replaceTimeline` sizes clips from `asset.durationSec` and the import has none.
+		// Automatic too, hence `history: false`.
+		const loaded = useProjectStore.getState().document as AxcutDocument;
+		const probed: AxcutDocument = {
+			...loaded,
+			assets: loaded.assets.map((a) => ({ ...a, durationSec: 42 })),
+		};
+		await useProjectStore
+			.getState()
+			.saveDocument(replaceTimelineOp(probed, [{ startSec: 0, endSec: 42 }], "Auto-created"), {
+				history: false,
+			});
+		expect(useProjectStore.getState().document?.timeline.clips).toHaveLength(1);
+
+		undo();
+
+		expect(useProjectStore.getState().document?.timeline.clips).toHaveLength(1);
 	});
 });

--- a/src/components/ai-edition/recordingImport.test.ts
+++ b/src/components/ai-edition/recordingImport.test.ts
@@ -4,7 +4,7 @@ import { replaceTimeline as replaceTimelineOp } from "@/lib/ai-edition/document/
 import { type AxcutDocument, createEmptyDocument } from "@/lib/ai-edition/schema";
 import { useProjectStore } from "@/lib/ai-edition/store/projectStore";
 import { undo } from "@/lib/ai-edition/store/undo";
-import { past } from "@/lib/ai-edition/store/undoStack";
+import { clearHistory, past } from "@/lib/ai-edition/store/undoStack";
 import { importPendingRecording } from "./recordingImport";
 
 // The first describe stubs the store actions, so the bridge is never reached
@@ -146,7 +146,7 @@ describe("what the recording import leaves on the undo stack", () => {
 		vi.clearAllMocks();
 		useProjectStore.getState().clear();
 		useProjectStore.setState(realActions);
-		past.length = 0;
+		clearHistory();
 		bridge.create.mockImplementation(async () => ({
 			success: true,
 			document: createEmptyDocument({ projectId: PROJECT_ID, title: "Recording" }),

--- a/src/components/ai-edition/recordingImport.ts
+++ b/src/components/ai-edition/recordingImport.ts
@@ -47,9 +47,16 @@ export async function importPendingRecording(): Promise<boolean> {
 	// overwrites this when handleLoadedMetadata fires with a finite value.
 	const doc = useProjectStore.getState().document;
 	if (doc && doc.timeline.clips.length === 0 && doc.assets.length > 0) {
+		// `history: false`. Nothing here is an edit: the user finished a recording and the
+		// editor built them a project around it, unattended, on mount. Recording it left a
+		// brand-new project sitting at `past.length === 1` before the user had touched
+		// anything, so their FIRST Ctrl+Z restored the state before the seed -- an empty
+		// timeline -- and the persist that follows an undo wrote that empty timeline to disk.
 		await useProjectStore
 			.getState()
-			.replaceTimeline([{ startSec: 0, endSec: 60 }], "Auto-imported recording");
+			.replaceTimeline([{ startSec: 0, endSec: 60 }], "Auto-imported recording", {
+				history: false,
+			});
 	}
 	return true;
 }

--- a/src/lib/ai-edition/store/agentDocumentApply.test.ts
+++ b/src/lib/ai-edition/store/agentDocumentApply.test.ts
@@ -109,6 +109,43 @@ describe("applyAgentDocumentIfCurrent", () => {
 		expect(useProjectStore.getState().document?.project.title).toBe("User edit");
 	});
 
+	it("does not roll back over an undo that overtook its save", async () => {
+		// `saveDocument` resolves false for two different things now: the write failed,
+		// and the write was superseded by an undo while it was in flight. The rollback
+		// above is right for the first and catastrophic for the second -- it would put
+		// the agent's pre-edit document over the one the user just asked to return to,
+		// on the agent's behalf, seconds after they pressed Ctrl+Z.
+		const before = createEmptyDocument({ projectId: "project_1", title: "Before" });
+		useProjectStore.setState({ projectId: "project_1", document: before, revision: 4 });
+
+		// A user edit to have something to undo TO, then hold the agent's save open.
+		saveMock.mockImplementation(async (document: unknown) => ({ success: true, document }));
+		await useProjectStore
+			.getState()
+			.saveDocument(
+				{ ...before, project: { ...before.project, title: "User edit" } },
+				{ history: true },
+			);
+
+		let release: (() => void) | undefined;
+		saveMock.mockImplementationOnce(async (document: unknown) => {
+			await new Promise<void>((resolve) => {
+				release = resolve;
+			});
+			return { success: true, document };
+		});
+		const agentResult = { ...before, project: { ...before.project, title: "Agent edit" } };
+		const applying = applyAgentDocumentIfCurrent(agentResult);
+
+		expect(undo()).toBe(true);
+		expect(useProjectStore.getState().document?.project.title).toBe("Before");
+
+		release?.();
+		await expect(applying).resolves.toBe("save-failed");
+
+		expect(useProjectStore.getState().document?.project.title).toBe("Before");
+	});
+
 	it("records exactly one undo step for an agent edit that lands", async () => {
 		// Two writes, one step: the optimistic `setDocument` opts out and the save
 		// names the pre-agent document as its base. Losing the step altogether would

--- a/src/lib/ai-edition/store/agentDocumentApply.test.ts
+++ b/src/lib/ai-edition/store/agentDocumentApply.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createEmptyDocument } from "../schema";
 import { applyAgentDocumentIfCurrent, runAgentTurn } from "./agentDocumentApply";
 import { useProjectStore } from "./projectStore";
+import { clearHistory, redo, undo } from "./undo";
+import { future, past } from "./undoStack";
 
 const saveMock = vi.hoisted(() => vi.fn());
 
@@ -15,6 +17,7 @@ vi.mock("@/native/client", () => ({
 describe("applyAgentDocumentIfCurrent", () => {
 	beforeEach(() => {
 		useProjectStore.getState().clear();
+		clearHistory();
 		saveMock.mockReset();
 	});
 
@@ -40,10 +43,13 @@ describe("applyAgentDocumentIfCurrent", () => {
 			project: { ...before.project, title: "Agent edit" },
 		};
 		useProjectStore.setState({ projectId: "project_1", document: before, revision: 4 });
-		useProjectStore.getState().setDocument({
-			...before,
-			project: { ...before.project, title: "Manual edit" },
-		});
+		useProjectStore.getState().setDocument(
+			{
+				...before,
+				project: { ...before.project, title: "Manual edit" },
+			},
+			{ history: true },
+		);
 
 		await expect(applyAgentDocumentIfCurrent(agentResult, 4)).resolves.toBe("conflict");
 
@@ -68,6 +74,55 @@ describe("applyAgentDocumentIfCurrent", () => {
 
 		expect(useProjectStore.getState().document?.project.title).toBe("Before");
 		expect(useProjectStore.getState().dirty).toBe(false);
+	});
+
+	it("leaves no undo step behind a rejected agent edit", async () => {
+		// The rollback is a `setState` by design, so it cannot pop an entry the apply
+		// already pushed. Recording on the optimistic `setDocument` therefore left a
+		// phantom Ctrl+Z step for an edit that never reached disk -- and `pushHistory`
+		// had cleared `future` on the way in, so the user's redo went with it.
+		const before = createEmptyDocument({ projectId: "project_1", title: "Before" });
+		useProjectStore.setState({ projectId: "project_1", document: before, revision: 4 });
+
+		// A real edit and an undo first, so there is a redo entry to lose.
+		saveMock.mockResolvedValueOnce({
+			success: true,
+			document: { ...before, project: { ...before.project, title: "User edit" } },
+		});
+		await useProjectStore
+			.getState()
+			.saveDocument(
+				{ ...before, project: { ...before.project, title: "User edit" } },
+				{ history: true },
+			);
+		expect(undo()).toBe(true);
+		expect(past).toHaveLength(0);
+		expect(future).toHaveLength(1);
+
+		saveMock.mockResolvedValue({ success: false, error: "EACCES" });
+		const agentResult = { ...before, project: { ...before.project, title: "Agent edit" } };
+		await expect(applyAgentDocumentIfCurrent(agentResult)).resolves.toBe("save-failed");
+
+		expect(past).toHaveLength(0);
+		expect(future).toHaveLength(1);
+		expect(redo()).toBe(true);
+		expect(useProjectStore.getState().document?.project.title).toBe("User edit");
+	});
+
+	it("records exactly one undo step for an agent edit that lands", async () => {
+		// Two writes, one step: the optimistic `setDocument` opts out and the save
+		// names the pre-agent document as its base. Losing the step altogether would
+		// be the same class of bug in the other direction.
+		const before = createEmptyDocument({ projectId: "project_1", title: "Before" });
+		const agentResult = { ...before, project: { ...before.project, title: "Agent edit" } };
+		useProjectStore.setState({ projectId: "project_1", document: before, revision: 4 });
+		saveMock.mockImplementation(async (document) => ({ success: true, document }));
+
+		await expect(applyAgentDocumentIfCurrent(agentResult, 4)).resolves.toBe("applied");
+
+		expect(past).toHaveLength(1);
+		expect(undo()).toBe(true);
+		expect(useProjectStore.getState().document?.project.title).toBe("Before");
 	});
 
 	it("still rejects when the agent hands back something that is not a document", async () => {
@@ -99,6 +154,7 @@ describe("applyAgentDocumentIfCurrent", () => {
 describe("runAgentTurn", () => {
 	beforeEach(() => {
 		useProjectStore.getState().clear();
+		clearHistory();
 		saveMock.mockReset();
 	});
 
@@ -112,10 +168,13 @@ describe("runAgentTurn", () => {
 
 		const { result, applyDocument } = await runAgentTurn(async (documentSnapshot) => {
 			// A background transcription landing mid-turn, which is the common case.
-			useProjectStore.getState().setDocument({
-				...before,
-				project: { ...before.project, title: "Manual edit" },
-			});
+			useProjectStore.getState().setDocument(
+				{
+					...before,
+					project: { ...before.project, title: "Manual edit" },
+				},
+				{ history: true },
+			);
 			return {
 				document: { ...documentSnapshot, project: { ...before.project, title: "Agent edit" } },
 			};
@@ -133,10 +192,13 @@ describe("runAgentTurn", () => {
 		saveMock.mockImplementation(async (document) => ({ success: true, document }));
 
 		const { applyDocument } = await runAgentTurn(async () => {
-			useProjectStore.getState().setDocument({
-				...before,
-				project: { ...before.project, title: "Manual edit" },
-			});
+			useProjectStore.getState().setDocument(
+				{
+					...before,
+					project: { ...before.project, title: "Manual edit" },
+				},
+				{ history: true },
+			);
 			return { document: { ...before, project: { ...before.project, title: "Agent edit" } } };
 		});
 

--- a/src/lib/ai-edition/store/agentDocumentApply.ts
+++ b/src/lib/ai-edition/store/agentDocumentApply.ts
@@ -54,7 +54,14 @@ export async function applyAgentDocumentIfCurrent(
 	// `saveDocument` that threw -- the two landed within minutes of each other, and a
 	// dead `catch` type-checks, so the rollback stopped firing and this returned
 	// "applied" for a write that never happened.
-	if (previous) useProjectStore.setState({ document: previous, dirty: previousDirty });
+	//
+	// Guarded on the store still holding the agent's document, the same way the drag
+	// commits in `useTimeline` guard theirs. `false` also means "an undo overtook this
+	// write" now, and there the store holds the document the user asked to return to --
+	// restoring `previous` over it would revert their Ctrl+Z on the agent's behalf.
+	if (previous && useProjectStore.getState().document === parsed) {
+		useProjectStore.setState({ document: previous, dirty: previousDirty });
+	}
 	return "save-failed";
 }
 

--- a/src/lib/ai-edition/store/agentDocumentApply.ts
+++ b/src/lib/ai-edition/store/agentDocumentApply.ts
@@ -25,19 +25,27 @@ export async function applyAgentDocumentIfCurrent(
 	const previous = store.document;
 	const previousDirty = store.dirty;
 	// Both calls, not just the save. `setDocument` puts the agent's document on screen
-	// NOW, without waiting on the disk round-trip `saveDocument` awaits. Both record the
-	// outgoing document on the undo stack, and recording it twice is not a risk: the
-	// second sees the document the first already installed and skips.
-	store.setDocument(parsed);
-	if (await store.saveDocument(parsed)) return "applied";
+	// NOW, without waiting on the disk round-trip `saveDocument` awaits.
+	//
+	// Only the SAVE records history, and `historyBase` is what makes that possible: by
+	// the time it runs, the store already holds the agent's document, so its own idea
+	// of "previous" is useless. Recording on the `setDocument` instead put the entry on
+	// the stack before the write was known to have landed — and the rollback below, a
+	// `setState` by design, could not take it back off. A rejected agent edit left a
+	// phantom Ctrl+Z step and a cleared `future` for something that never happened.
+	store.setDocument(parsed, { history: false });
+	if (await store.saveDocument(parsed, { history: true, historyBase: previous })) {
+		return "applied";
+	}
 
 	// The edits are on screen by now. Leaving them there while the caller says they
 	// were not applied tells the user two opposite things at once, and worse: `dirty`
 	// is set, so the next unrelated save would quietly persist the document we just
 	// said was rejected.
 	//
-	// Restored through `setState` rather than `setDocument`, so the rejected document
-	// does not land on the undo stack. `revision` keeps the bump: it did move, and
+	// Restored through `setState` rather than `setDocument`, so the restore itself is
+	// not recorded — and there is nothing on the stack to take back off either, because
+	// the write above records only on success. `revision` keeps the bump: it did move, and
 	// leaving it forward makes any in-flight guard read "conflict", which is the safe
 	// direction to be wrong in.
 	//

--- a/src/lib/ai-edition/store/agentDocumentApply.ts
+++ b/src/lib/ai-edition/store/agentDocumentApply.ts
@@ -24,10 +24,10 @@ export async function applyAgentDocumentIfCurrent(
 	const parsed = ensureDocument(document);
 	const previous = store.document;
 	const previousDirty = store.dirty;
-	// Both calls, not just the save. `setDocument` is the only thing that pushes the
-	// outgoing document onto the undo stack, so deleting it as "redundant next to
-	// saveDocument, which sets `document` too" silently breaks Ctrl+Z after an agent edit.
-	// `saveDocument` is what reaches the disk.
+	// Both calls, not just the save. `setDocument` puts the agent's document on screen
+	// NOW, without waiting on the disk round-trip `saveDocument` awaits. Both record the
+	// outgoing document on the undo stack, and recording it twice is not a risk: the
+	// second sees the document the first already installed and skips.
 	store.setDocument(parsed);
 	if (await store.saveDocument(parsed)) return "applied";
 

--- a/src/lib/ai-edition/store/documentWriteAudit.test.ts
+++ b/src/lib/ai-edition/store/documentWriteAudit.test.ts
@@ -213,6 +213,9 @@ const DECLARED: WritePath[] = [
 	w("src/lib/ai-edition/store/useSequentialTimelineOps.ts", "apply", "save", "forwarded"),
 
 	// Every timeline edit the user makes with the mouse or the keyboard.
+	// The Edit Clip dialog's Apply: source range and crop composed into ONE save (#355),
+	// where they used to be two writes that overwrote each other.
+	w("src/lib/ai-edition/store/useTimeline.ts", "applyClipEdit", "save", "gesture"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "addAnnotation", "save", "gesture"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "addCameraFullscreen", "save", "gesture"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "addSpeed", "save", "gesture"),
@@ -242,8 +245,6 @@ const DECLARED: WritePath[] = [
 	w("src/lib/ai-edition/store/useTimeline.ts", "updateAnnotationLive", "set", "automatic"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "updateAnnotationSpan", "save", "gesture"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "updateCameraFullscreenSpan", "save", "gesture"),
-	w("src/lib/ai-edition/store/useTimeline.ts", "updateClipCrop", "save", "gesture"),
-	w("src/lib/ai-edition/store/useTimeline.ts", "updateClipSourceRange", "save", "gesture"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "updateSpeedSpan", "save", "gesture"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "updateSpeedValue", "save", "gesture"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "updateTrim", "save", "gesture"),

--- a/src/lib/ai-edition/store/documentWriteAudit.test.ts
+++ b/src/lib/ai-edition/store/documentWriteAudit.test.ts
@@ -23,11 +23,30 @@
 //
 // So: this file is the table. A new write, a moved one, or a changed `history`
 // value fails here with a diff, and the only way to make it pass is to write down
-// what triggers it. `recordHistory` is unreachable except through the two writers
-// enumerated below, and the only other way an entry reaches a stack is undo/redo
-// stepping over one -- the tests after the table pin both, and the stacks are
-// `readonly` so there is no third way that skips a name this file can count. The
-// table is the whole surface, not a sample of it.
+// what triggers it.
+//
+// What a green run here means, exactly. The scan is SYNTACTIC: it walks the
+// non-test `.ts`/`.tsx` under `src/`, matches calls on the callee's written name,
+// and reads each one's trigger off the object literal at the call site. So the
+// table covers every `saveDocument` / `setDocument` written as such in shipped
+// renderer code, and the tests below it pin the names an entry can reach a stack
+// through -- `recordHistory`, called only by those two writers, then `pushHistory`,
+// plus undo/redo's own two pushes for the entries they step over.
+//
+// What it does not see, so nobody reads more into that than is in it:
+//   - INDIRECTION, both ways round. The callee name is whatever the source says,
+//     so a write reached through an alias or a callback is not a row at all. And
+//     `readonly` on the stacks is erased at runtime, so `(past as Snapshot[]).push(...)`
+//     compiles, runs, and appears nowhere here -- the `@ts-expect-error`s below
+//     pin the un-cast form only.
+//   - DATAFLOW. `forwarded` asks where the identifier handed on was BOUND, not
+//     what value arrives in it. A parameter reassigned to a hardcode is still a
+//     parameter, and so is a callback parameter the same expression supplies from
+//     a literal. Both read as forwarded; the last describe in this file pins them
+//     saying so.
+// None of that is in the tree today, and finding it is a reading job, not this
+// file's. What this file guarantees is the part a reading job keeps missing: that
+// nobody added a write in plain sight without saying who asked for it.
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { relative, resolve } from "node:path";
@@ -280,11 +299,18 @@ function declaresInList(list: ts.VariableDeclarationList, name: string): boolean
 
 /** Whether this scope binds `name` as a LOCAL — the thing a forward is not. */
 function scopeDeclaresLocal(scope: ts.Node, name: string): boolean {
-	const inStatements = (statements: readonly ts.Statement[]) =>
-		statements.some(
-			(statement) =>
-				ts.isVariableStatement(statement) && declaresInList(statement.declarationList, name),
-		);
+	const declares = (statement: ts.Statement): boolean => {
+		if (ts.isVariableStatement(statement)) return declaresInList(statement.declarationList, name);
+		// `function opts() {}` and `class opts {}` bind the name exactly as a `const`
+		// does, and shadow an outer parameter of that name exactly as one does. Reading
+		// only variable statements meant the walk could not SEE those bindings, so it
+		// carried on outwards and reported the shadowed parameter — answering "where was
+		// this name bound" with a scope the name does not come from.
+		if (ts.isFunctionDeclaration(statement) || ts.isClassDeclaration(statement))
+			return statement.name?.text === name;
+		return false;
+	};
+	const inStatements = (statements: readonly ts.Statement[]) => statements.some(declares);
 	if (ts.isSourceFile(scope) || ts.isBlock(scope) || ts.isModuleBlock(scope))
 		return inStatements(scope.statements);
 	if (ts.isCaseBlock(scope)) return scope.clauses.some((clause) => inStatements(clause.statements));
@@ -417,7 +443,7 @@ describe("every write that can reach the undo stack", () => {
 		expect(scanned.writes.map(sortKey).sort()).toEqual(DECLARED.map(sortKey).sort());
 	});
 
-	// The table is only the whole surface while these two hold. `recordHistory` is
+	// The table stands in for the stack only while these two hold. `recordHistory` is
 	// module-private to `projectStore`, and `pushHistory` is reachable from anywhere
 	// that imports `undoStack` — so the stack grows one more entry point the moment
 	// somebody calls it directly, and the table would stop being the audit.
@@ -437,8 +463,9 @@ describe("every write that can reach the undo stack", () => {
 	it("grows the stacks only through `pushHistory` and undo/redo's own two pushes", () => {
 		// `undo` and `redo` hand each other the document they are stepping over, which
 		// is not a new edit and must not clear the other stack -- so they cannot go
-		// through `pushHistory`. Those two calls are the whole remainder, and the rows
-		// below are what makes that a checked statement rather than a claim.
+		// through `pushHistory`. Those two calls are the whole remainder of the ones
+		// written under their own name, and the rows below are what makes that a
+		// checked statement rather than a claim.
 		expect(scanned.callsTo.get("pushPast")).toEqual([
 			{ file: "src/lib/ai-edition/store/undo.ts", fn: "redo" },
 		]);
@@ -447,7 +474,7 @@ describe("every write that can reach the undo stack", () => {
 		]);
 	});
 
-	it("cannot be grown by an importer reaching around those names", () => {
+	it("does not let an importer push to the stacks in passing", () => {
 		// The hole this closes. `past` and `future` were exported as `Snapshot[]`, and
 		// `const` binds the reference, not the contents -- so `past.push(...)` from any
 		// importer recorded history, and the scan above could not see it: it keys on the
@@ -455,7 +482,10 @@ describe("every write that can reach the undo stack", () => {
 		//
 		// The assertions are the `@ts-expect-error`s. Each one is an error itself the
 		// moment the directive stops suppressing anything, so this test fails the
-		// typecheck pass if the stacks ever go mutable again.
+		// typecheck pass if the stacks ever go mutable again. "In passing" is the whole
+		// claim: `readonly` is a compile-time thing, so somebody who WANTS to write to
+		// these arrays still can, by casting the type back off -- and the scan will not
+		// see that either.
 		// @ts-expect-error `past` is `readonly Snapshot[]`; record through `pushHistory`.
 		past.push({ projectId: "project_x", doc: {} });
 		// @ts-expect-error `future` is `readonly Snapshot[]`; step forward through `pushFuture`.
@@ -552,5 +582,60 @@ describe("how a write's trigger is read off its call site", () => {
 				}
 			`),
 		).toBe("no options argument");
+	});
+
+	it.each([
+		["function", "function opts() {}"],
+		["class", "class opts {}"],
+	])("reads a local %s declaration as a local, not as a forward", (_kind, declaration) => {
+		// The scope walk used to read variable statements and nothing else, so these two
+		// bindings were invisible to it: it walked straight past them to the `opts`
+		// parameter outside and called the call forwarded. Neither shape is a valid
+		// options object, so this is not a hole anything could have fallen through -- it
+		// is the walk answering "where was this name bound" correctly.
+		expect(
+			classify(`
+				function wrapper(opts) {
+					return () => {
+						${declaration}
+						saveDocument(doc, opts);
+					};
+				}
+			`),
+		).toBe("local variable \`opts\`");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// And the rule's edge, pinned as it actually is. `forwarded` is a question about
+// BINDINGS, not about values, and these two are where those answers part company.
+// They are here so the header's "does not catch" is a measured statement rather
+// than a remembered one, and so a future tightening has a fixture to flip rather
+// than a paragraph to argue with.
+// ---------------------------------------------------------------------------
+
+describe("what reading the call site cannot tell you", () => {
+	it("calls a callback parameter forwarded even when the caller is the local hardcode", () => {
+		// `forEach` supplies `opts` from a literal three lines up. Nobody outside decided
+		// anything, but the binding really is a parameter, and a binding is all the walk
+		// looks at.
+		expect(
+			classify(`
+				[{ history: true }].forEach((opts) => saveDocument(doc, opts));
+			`),
+		).toBe("forwarded");
+	});
+
+	it("calls a parameter forwarded after it has been reassigned to a hardcode", () => {
+		// The value reaching the writer is the literal on the line above. Following that
+		// is dataflow analysis, which this file does not do.
+		expect(
+			classify(`
+				function wrapper(doc, opts) {
+					opts = { history: true };
+					saveDocument(doc, opts);
+				}
+			`),
+		).toBe("forwarded");
 	});
 });

--- a/src/lib/ai-edition/store/documentWriteAudit.test.ts
+++ b/src/lib/ai-edition/store/documentWriteAudit.test.ts
@@ -33,6 +33,17 @@
 // through -- `recordHistory`, called only by those two writers, then `pushHistory`,
 // plus undo/redo's own two pushes for the entries they step over.
 //
+// And the third writer, which neither of those names covers:
+// `useProjectStore.setState({ document })` puts a document in the store around both
+// of them. Four shipped sites do it -- undo's own restore, and the three rollbacks
+// that put a document back when a save failed -- and every one of them means to,
+// because none of them is an edit. But a `history` option that cannot be omitted is
+// no guard at all against a writer that never takes one, so those sites are rows
+// too, carrying `unrecorded`: out of scope for the stack, in scope for the
+// guarantee, and a new one has to come here and say who asked. The match is keyed on
+// the RECEIVER as well as the name, because `useTranscriptionStore.setState` is a
+// different store and writes no document.
+//
 // What it does not see, so nobody reads more into that than is in it:
 //   - INDIRECTION, both ways round. The callee name is whatever the source says,
 //     so a write reached through an alias or a callback is not a row at all. And
@@ -44,9 +55,10 @@
 //     parameter, and so is a callback parameter the same expression supplies from
 //     a literal. Both read as forwarded; the last describe in this file pins them
 //     saying so.
-// None of that is in the tree today, and finding it is a reading job, not this
+// Neither shape is in the tree today, and finding either is a reading job, not this
 // file's. What this file guarantees is the part a reading job keeps missing: that
-// nobody added a write in plain sight without saying who asked for it.
+// nobody added a write in plain sight -- through either recording writer or straight
+// into the store -- without saying who asked for it.
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { relative, resolve } from "node:path";
@@ -70,15 +82,28 @@ type Trigger =
 	 *  identifier passed on must resolve to a PARAMETER, in the first enclosing
 	 *  scope that binds that name — a local `const` of the same name is not a
 	 *  forward, however many outer functions have a parameter called that. */
-	| "forwarded";
+	| "forwarded"
+	/** Not a recording writer at all. `useProjectStore.setState` writes the document
+	 *  into the store directly, so nothing can reach the stacks from here and there is
+	 *  no `history` option to decide — which is exactly why these are rows. Every one
+	 *  of today's four is a restore, and a restore must not record: the entry it would
+	 *  reverse is the one it is undoing. */
+	| "unrecorded";
 
 interface WritePath {
 	file: string;
 	/** Nearest named function around the call. */
 	fn: string;
-	writer: "saveDocument" | "setDocument";
+	writer: "saveDocument" | "setDocument" | "useProjectStore.setState";
 	trigger: Trigger;
 }
+
+/** Short keys for the table below, spelled out here so a row stays one line. */
+const WRITER_NAMES = {
+	save: "saveDocument",
+	set: "setDocument",
+	state: "useProjectStore.setState",
+} as const;
 
 // ---------------------------------------------------------------------------
 // The table. Sorted by file, then function, then writer — same order the scan
@@ -130,6 +155,15 @@ const DECLARED: WritePath[] = [
 		"set",
 		"automatic",
 	),
+	// Putting the pre-agent document back when the save the user's edit depended on
+	// failed. Straight into the store, so it cannot record — and must not: the entry
+	// it would reverse was never pushed, because the save records only on success.
+	w(
+		"src/lib/ai-edition/store/agentDocumentApply.ts",
+		"applyAgentDocumentIfCurrent",
+		"state",
+		"unrecorded",
+	),
 
 	// Linking the camera track found next to a newly added asset. Part of the
 	// import, not an edit of its own.
@@ -147,6 +181,12 @@ const DECLARED: WritePath[] = [
 		"automatic",
 	),
 	w("src/lib/ai-edition/store/transcriptionStore.ts", "runJob", "save", "automatic"),
+
+	// Ctrl+Z / Ctrl+Shift+Z putting a snapshot back on screen. The one write in the
+	// tree that MUST go around both recording writers: routing it through one meant an
+	// undo re-recorded the document it had just replaced and cleared `future` on the
+	// way past, so redo was gone before the user could reach for it.
+	w("src/lib/ai-edition/store/undo.ts", "restore", "state", "unrecorded"),
 
 	// Caption settings. Every pair is one optimistic `setDocument` (automatic) plus
 	// the save that is the actual edit and names the pre-edit document.
@@ -182,7 +222,12 @@ const DECLARED: WritePath[] = [
 	// The two drag commits. One undo step per gesture, recorded on release and only
 	// if the write lands — `historyBase` carries the pre-drag document.
 	w("src/lib/ai-edition/store/useTimeline.ts", "commitAnnotationChange", "save", "gesture"),
+	// And the rollback each of them runs when that write does not land: the pre-drag
+	// document back into the store, around the writers, so it records nothing. There is
+	// nothing to take off either — the commit records only on success.
+	w("src/lib/ai-edition/store/useTimeline.ts", "commitAnnotationChange", "state", "unrecorded"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "commitZoomFocus", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "commitZoomFocus", "state", "unrecorded"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "duplicateClip", "save", "gesture"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "insertClipAt", "save", "gesture"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "moveClip", "save", "gesture"),
@@ -212,15 +257,43 @@ const DECLARED: WritePath[] = [
 	w("src/lib/ai-edition/store/useTimeline.ts", "useTimeline", "save", "automatic"),
 ];
 
-function w(file: string, fn: string, writer: "save" | "set", trigger: Trigger): WritePath {
-	return { file, fn, writer: writer === "save" ? "saveDocument" : "setDocument", trigger };
+function w(
+	file: string,
+	fn: string,
+	writer: keyof typeof WRITER_NAMES,
+	trigger: Trigger,
+): WritePath {
+	return { file, fn, writer: WRITER_NAMES[writer], trigger };
 }
 
 // ---------------------------------------------------------------------------
 // The scan
 // ---------------------------------------------------------------------------
 
+/** The two writers that take a `history` option, so the compiler can force their
+ *  call sites to decide. `useProjectStore.setState` is the third writer and matches
+ *  separately — see `isProjectStoreSetState`. */
 const WRITERS = new Set(["saveDocument", "setDocument"]);
+
+/**
+ * `useProjectStore.setState(...)` written as such: a document into the store around
+ * both recording writers, and the shape neither `WRITERS` nor the `history` option
+ * can see.
+ *
+ * Keyed on the RECEIVER as well as the method name. `calleeName` returns the
+ * property name alone, and `useTranscriptionStore.setState` — four calls in this
+ * same directory — writes no document; matching on `setState` would file all four
+ * as document writes.
+ */
+function isProjectStoreSetState(call: ts.CallExpression): boolean {
+	const target = call.expression;
+	return (
+		ts.isPropertyAccessExpression(target) &&
+		ts.isIdentifier(target.expression) &&
+		target.expression.text === "useProjectStore" &&
+		target.name.text === "setState"
+	);
+}
 
 function sourceFiles(dir: string): string[] {
 	return readdirSync(dir).flatMap((entry) => {
@@ -419,6 +492,15 @@ function scan(): Scan {
 						fn: name,
 						writer: callee as WritePath["writer"],
 						trigger: triggerOf(node) as Trigger,
+					});
+				} else if (isProjectStoreSetState(node)) {
+					// No options argument to read a trigger off — that is the whole reason this
+					// shape needs a row rather than a compile error.
+					writes.push({
+						file,
+						fn: enclosingFunctionName(node),
+						writer: "useProjectStore.setState",
+						trigger: "unrecorded",
 					});
 				}
 			}
@@ -637,5 +719,49 @@ describe("what reading the call site cannot tell you", () => {
 				}
 			`),
 		).toBe("forwarded");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// The third writer's match. It is the one row-producing rule in this file that is
+// NOT keyed on the callee name alone, and the reason is a name collision that is
+// already in the tree.
+// ---------------------------------------------------------------------------
+
+describe("which `setState` the scan files as a document write", () => {
+	/** Whether the first `setState(...)` in a snippet would produce a row. */
+	function matches(fixture: string): boolean {
+		const source = ts.createSourceFile(
+			"fixture.ts",
+			fixture,
+			ts.ScriptTarget.Latest,
+			true,
+			ts.ScriptKind.TS,
+		);
+		const calls: ts.CallExpression[] = [];
+		const visit = (node: ts.Node) => {
+			if (ts.isCallExpression(node) && calleeName(node) === "setState") calls.push(node);
+			ts.forEachChild(node, visit);
+		};
+		visit(source);
+		const [call] = calls;
+		if (!call) throw new Error("fixture has no `setState` call");
+		return isProjectStoreSetState(call);
+	}
+
+	it("counts a write straight into the project store", () => {
+		expect(matches("useProjectStore.setState({ document: next });")).toBe(true);
+	});
+
+	it("does not count another store of the same shape", () => {
+		// `useTranscriptionStore.setState` is four calls in this same directory and writes
+		// no document. Keyed on the method name alone, all four would have been rows —
+		// and a table padded with writes it cannot judge is a table nobody reads.
+		expect(matches("useTranscriptionStore.setState((state) => state);")).toBe(false);
+	});
+
+	it("does not count a bare `setState` that no receiver names", () => {
+		// React's own, in a `.tsx` the walk covers.
+		expect(matches("setState({ open: true });")).toBe(false);
 	});
 });

--- a/src/lib/ai-edition/store/documentWriteAudit.test.ts
+++ b/src/lib/ai-edition/store/documentWriteAudit.test.ts
@@ -285,14 +285,61 @@ const WRITERS = new Set(["saveDocument", "setDocument"]);
  * same directory — writes no document; matching on `setState` would file all four
  * as document writes.
  */
+function objectLiteralHasDocument(obj: ts.ObjectLiteralExpression): boolean {
+	return obj.properties.some((prop) => {
+		if (ts.isSpreadAssignment(prop)) return false;
+		const name = prop.name;
+		if (!name) return false;
+		if (ts.isIdentifier(name)) return name.text === "document";
+		if (ts.isStringLiteral(name)) return name.text === "document";
+		return false;
+	});
+}
+
+function returnedObjectHasDocument(expr: ts.Expression): boolean {
+	let node: ts.Expression = expr;
+	while (ts.isParenthesizedExpression(node)) node = node.expression;
+	// `useTimeline`'s two rollbacks return `cond ? { document } : {}`, so a branch counts:
+	// the call CAN write a document, which is what the row is about.
+	if (ts.isConditionalExpression(node)) {
+		return returnedObjectHasDocument(node.whenTrue) || returnedObjectHasDocument(node.whenFalse);
+	}
+	if (ts.isBinaryExpression(node)) {
+		return returnedObjectHasDocument(node.left) || returnedObjectHasDocument(node.right);
+	}
+	return ts.isObjectLiteralExpression(node) && objectLiteralHasDocument(node);
+}
+
+function writesDocumentProperty(arg: ts.Expression | undefined): boolean {
+	if (!arg) return false;
+	// `setState({ document, ... })`
+	if (ts.isObjectLiteralExpression(arg)) return objectLiteralHasDocument(arg);
+	// `setState((state) => ({ document, ... }))`. Three of the four production call sites
+	// take this shape, so an object-literal-only check would drop them from the table.
+	if (ts.isArrowFunction(arg) || ts.isFunctionExpression(arg)) {
+		const body = arg.body;
+		if (!ts.isBlock(body)) return returnedObjectHasDocument(body);
+		return body.statements.some(
+			(st) =>
+				ts.isReturnStatement(st) && !!st.expression && returnedObjectHasDocument(st.expression),
+		);
+	}
+	return false;
+}
+
 function isProjectStoreSetState(call: ts.CallExpression): boolean {
 	const target = call.expression;
-	return (
-		ts.isPropertyAccessExpression(target) &&
-		ts.isIdentifier(target.expression) &&
-		target.expression.text === "useProjectStore" &&
-		target.name.text === "setState"
-	);
+	if (
+		!ts.isPropertyAccessExpression(target) ||
+		!ts.isIdentifier(target.expression) ||
+		target.expression.text !== "useProjectStore" ||
+		target.name.text !== "setState"
+	) {
+		return false;
+	}
+	// The receiver alone is not enough: `useProjectStore.setState({ dirty: true })` writes no
+	// document and must not become a row. Ask what the call actually writes.
+	return writesDocumentProperty(call.arguments[0]);
 }
 
 function sourceFiles(dir: string): string[] {
@@ -414,12 +461,25 @@ function scopeDeclaresLocal(scope: ts.Node, name: string): boolean {
  * `saveDocument(applied.document, opts)` inside a zero-parameter `async () => {}`,
  * and `opts` is the parameter of the `useCallback` arrow two scopes further out.
  */
+/** Scopes that bind parameters. Wider than `isFunctionLike`, which exists to NAME a
+ *  function: a constructor and a `set` accessor take parameters but have no name a
+ *  reader would use for a write site, so they belong here and not there. */
+function declaresParameter(node: ts.Node, name: string): boolean {
+	if (
+		isFunctionLike(node) ||
+		ts.isConstructorDeclaration(node) ||
+		ts.isSetAccessorDeclaration(node)
+	) {
+		return node.parameters.some((p) => bindsName(p.name, name));
+	}
+	return false;
+}
+
 function bindingOf(call: ts.Node, name: string): "parameter" | "local" {
 	let node: ts.Node | undefined = call.parent;
 	while (node) {
 		if (scopeDeclaresLocal(node, name)) return "local";
-		if (isFunctionLike(node) && node.parameters.some((p) => bindsName(p.name, name)))
-			return "parameter";
+		if (declaresParameter(node, name)) return "parameter";
 		node = node.parent;
 	}
 	// Bound nowhere on the way out: a module binding, an import, or a global. None of
@@ -763,5 +823,62 @@ describe("which `setState` the scan files as a document write", () => {
 	it("does not count a bare `setState` that no receiver names", () => {
 		// React's own, in a `.tsx` the walk covers.
 		expect(matches("setState({ open: true });")).toBe(false);
+	});
+
+	it("does not count a write into the project store that carries no document", () => {
+		// The receiver is right and the call is real, but nothing here reaches the
+		// document — filing it would put a row in the table that no reader can judge.
+		expect(matches("useProjectStore.setState({ dirty: true });")).toBe(false);
+	});
+
+	it("counts the updater form, which is how three of the four real ones are written", () => {
+		expect(
+			matches(
+				"useProjectStore.setState((state) => ({ document: doc, revision: state.revision + 1 }));",
+			),
+		).toBe(true);
+	});
+
+	it("counts an updater that only writes the document on one branch", () => {
+		// `commitZoomFocus` and `commitAnnotationChange` both return
+		// `state.document === doc ? { document: rollback, ... } : {}`. The call CAN write a
+		// document, which is what the row is about — an object-literal-only check drops both.
+		expect(
+			matches(
+				"useProjectStore.setState((state) => (state.document === doc ? { document: rollback } : {}));",
+			),
+		).toBe(true);
+	});
+
+	it("counts an updater with a block body", () => {
+		expect(matches("useProjectStore.setState((state) => { return { document: doc }; });")).toBe(
+			true,
+		);
+	});
+});
+
+describe("which scopes bind a parameter", () => {
+	it("reads a constructor parameter as forwarded, not as a local", () => {
+		expect(
+			classify(`
+				class Writer {
+					constructor(opts) {
+						saveDocument(doc, opts);
+					}
+				}
+			`),
+		).toBe("forwarded");
+	});
+
+	it("reads a setter parameter as forwarded, not as a local", () => {
+		expect(
+			classify(`
+				class Writer {
+					set options(opts) {
+						saveDocument(doc, opts);
+					}
+				}
+			`),
+		).toBe("forwarded");
 	});
 });

--- a/src/lib/ai-edition/store/documentWriteAudit.test.ts
+++ b/src/lib/ai-edition/store/documentWriteAudit.test.ts
@@ -1,0 +1,361 @@
+// Every path that can reach the undo stack, pinned.
+//
+// #433 has now produced three rounds of the SAME defect: a write the user never
+// made recording itself as the thing their next Ctrl+Z reverses. Each round the
+// fix was aimed at the instance.
+//
+//   1. `setDocument` was the only writer that recorded, so nothing the user did
+//      was on the stack at all.
+//   2. `probeAndCorrectClip` -- a background duration probe -- recorded, because
+//      `history` defaulted to `true` and the probe said nothing. Making the option
+//      REQUIRED was supposed to end it: omitting it is now a compile error.
+//   3. It did not. `projectStore.replaceTimeline(intervals, reason)` hardcoded
+//      `{ history: true }` INSIDE itself, so the option never appeared in the
+//      signature its callers see and no compile error could reach them. Its one
+//      caller is the unattended recording import that runs on editor mount, so a
+//      user landed in a brand-new project with `past.length === 1` and their first
+//      Ctrl+Z emptied the timeline.
+//
+// The compiler can force a DIRECT call site to decide. It cannot see that the
+// function doing the deciding had no business deciding. That is a judgement about
+// who triggered the write, and the only place to record a judgement is next to the
+// code, in a table somebody has to edit.
+//
+// So: this file is the table. A new write, a moved one, or a changed `history`
+// value fails here with a diff, and the only way to make it pass is to write down
+// what triggers it. `recordHistory` is unreachable except through the two writers
+// enumerated below, which the last two tests pin as well -- so the table is the
+// whole surface, not a sample of it.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+const SRC = resolve(ROOT, "src");
+
+/** What made this write happen. The judgement the compiler cannot make. */
+type Trigger =
+	/** The user did something. Records an undo step. */
+	| "gesture"
+	/** Nobody asked: a probe, a background job, an auto-import, a persist that
+	 *  follows an undo, or the optimistic half of an optimistic-then-save pair.
+	 *  Records nothing. */
+	| "automatic"
+	/** A wrapper. Hands its caller's option straight through, so the decision stays
+	 *  with whoever knows the answer. `forwarded` is checked structurally: the
+	 *  identifier passed on must be a PARAMETER of the enclosing function. */
+	| "forwarded";
+
+interface WritePath {
+	file: string;
+	/** Nearest named function around the call. */
+	fn: string;
+	writer: "saveDocument" | "setDocument";
+	trigger: Trigger;
+}
+
+// ---------------------------------------------------------------------------
+// The table. Sorted by file, then function, then writer — same order the scan
+// produces, so a failure reads as a plain diff.
+// ---------------------------------------------------------------------------
+
+const DECLARED: WritePath[] = [
+	// Dropping the legacy auto-caption annotations is a button in the captions pane.
+	w(
+		"src/components/ai-edition/CaptionsPane.tsx",
+		"clearLegacyCaptionAnnotations",
+		"save",
+		"gesture",
+	),
+
+	// The persist that follows an undo. Recording it would undo the undo.
+	w("src/components/ai-edition/NewEditorShell.tsx", "NewEditorShell", "save", "automatic"),
+	// "Save" on the unsaved-changes prompt.
+	w("src/components/ai-edition/NewEditorShell.tsx", "handleConfirmUnsaved", "save", "gesture"),
+	// The probed duration folded into the document when the <video> loads. Twice:
+	// the first clip seed, and the backfill for clips still on a placeholder length.
+	w("src/components/ai-edition/NewEditorShell.tsx", "handleLoadedMetadata", "save", "automatic"),
+	w("src/components/ai-edition/NewEditorShell.tsx", "handleLoadedMetadata", "save", "automatic"),
+	// Renaming the project from the title field.
+	w("src/components/ai-edition/NewEditorShell.tsx", "handleRenameProject", "save", "gesture"),
+	// Ctrl+S / File > Save.
+	w("src/components/ai-edition/NewEditorShell.tsx", "handleSave", "save", "gesture"),
+	// "Save" chosen on the way out of Ctrl+N and Ctrl+O.
+	w("src/components/ai-edition/NewEditorShell.tsx", "onKey", "save", "gesture"),
+	w("src/components/ai-edition/NewEditorShell.tsx", "onKey", "save", "gesture"),
+	// Ctrl+V of a copied region: zoom, annotation, or a legacy span.
+	w("src/components/ai-edition/NewEditorShell.tsx", "pasteRegion", "save", "gesture"),
+	w("src/components/ai-edition/NewEditorShell.tsx", "pasteRegion", "save", "gesture"),
+	w("src/components/ai-edition/NewEditorShell.tsx", "pasteRegion", "save", "gesture"),
+	// The window is closing and the user answered "save".
+	w("src/components/ai-edition/NewEditorShell.tsx", "unsubSaveBeforeClose", "save", "gesture"),
+
+	// The agent's document. The optimistic write is not the edit — the save is, and
+	// it names the pre-agent document as what Ctrl+Z returns to.
+	w(
+		"src/lib/ai-edition/store/agentDocumentApply.ts",
+		"applyAgentDocumentIfCurrent",
+		"save",
+		"gesture",
+	),
+	w(
+		"src/lib/ai-edition/store/agentDocumentApply.ts",
+		"applyAgentDocumentIfCurrent",
+		"set",
+		"automatic",
+	),
+
+	// Linking the camera track found next to a newly added asset. Part of the
+	// import, not an edit of its own.
+	w("src/lib/ai-edition/store/projectStore.ts", "addAsset", "save", "automatic"),
+	// THE round-3 fix. This is the shape that defeated round 2: a store action that
+	// writes on someone else's behalf. It forwards now, so its callers decide.
+	w("src/lib/ai-edition/store/projectStore.ts", "replaceTimeline", "save", "forwarded"),
+
+	// A transcription verdict remembered on the asset, and a transcript arriving
+	// from a background whisper job. Neither is an edit.
+	w(
+		"src/lib/ai-edition/store/transcriptionStore.ts",
+		"persistPermanentFailure",
+		"save",
+		"automatic",
+	),
+	w("src/lib/ai-edition/store/transcriptionStore.ts", "runJob", "save", "automatic"),
+
+	// Caption settings. Every pair is one optimistic `setDocument` (automatic) plus
+	// the save that is the actual edit and names the pre-edit document.
+	w("src/lib/ai-edition/store/useCaptions.ts", "commit", "save", "gesture"),
+	w("src/lib/ai-edition/store/useCaptions.ts", "deleteTranslation", "save", "gesture"),
+	w("src/lib/ai-edition/store/useCaptions.ts", "deleteTranslation", "set", "automatic"),
+	w("src/lib/ai-edition/store/useCaptions.ts", "saveTranslation", "save", "gesture"),
+	w("src/lib/ai-edition/store/useCaptions.ts", "saveTranslation", "set", "automatic"),
+	w("src/lib/ai-edition/store/useCaptions.ts", "set", "save", "gesture"),
+	w("src/lib/ai-edition/store/useCaptions.ts", "set", "set", "automatic"),
+	// A slider mid-drag: sixty of these a second, one undo step for the lot, opened
+	// by the commit above.
+	w("src/lib/ai-edition/store/useCaptions.ts", "setLive", "set", "automatic"),
+
+	// Editor settings — same live/commit split, same reasoning.
+	w("src/lib/ai-edition/store/useEditorSettings.ts", "commit", "save", "gesture"),
+	w("src/lib/ai-edition/store/useEditorSettings.ts", "set", "save", "gesture"),
+	w("src/lib/ai-edition/store/useEditorSettings.ts", "set", "set", "automatic"),
+	w("src/lib/ai-edition/store/useEditorSettings.ts", "setLive", "set", "automatic"),
+
+	// The serialised timeline-op queue. Another wrapper: it used to hardcode
+	// `{ history: true }`, which was right for both of today's callers and would have
+	// been wrong for the first background one.
+	w("src/lib/ai-edition/store/useSequentialTimelineOps.ts", "apply", "save", "forwarded"),
+
+	// Every timeline edit the user makes with the mouse or the keyboard.
+	w("src/lib/ai-edition/store/useTimeline.ts", "addAnnotation", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "addCameraFullscreen", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "addSpeed", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "addTrim", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "addZoom", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "addZoomsBulk", "save", "gesture"),
+	// The two drag commits. One undo step per gesture, recorded on release and only
+	// if the write lands — `historyBase` carries the pre-drag document.
+	w("src/lib/ai-edition/store/useTimeline.ts", "commitAnnotationChange", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "commitZoomFocus", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "duplicateClip", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "insertClipAt", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "moveClip", "save", "gesture"),
+	// The round-2 defect: a background duration probe every freshly imported asset
+	// fires, because `addAsset` never populates `durationSec`.
+	w("src/lib/ai-edition/store/useTimeline.ts", "probeAndCorrectClip", "save", "automatic"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "removeClip", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "removeRegion", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "removeRegions", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "setTrimEntries", "save", "gesture"),
+	// The live halves of the two drags.
+	w("src/lib/ai-edition/store/useTimeline.ts", "updateAnnotationLive", "set", "automatic"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "updateAnnotationSpan", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "updateCameraFullscreenSpan", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "updateClipCrop", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "updateClipSourceRange", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "updateSpeedSpan", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "updateSpeedValue", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "updateTrim", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "updateZoomDepth", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "updateZoomFocusLive", "set", "automatic"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "updateZoomFocusMode", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "updateZoomRotation", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "updateZoomSpan", "save", "gesture"),
+	// Source-dimension backfill for assets a migration left unprobed. On load, for
+	// every project, whether or not the user touches anything.
+	w("src/lib/ai-edition/store/useTimeline.ts", "useTimeline", "save", "automatic"),
+];
+
+function w(file: string, fn: string, writer: "save" | "set", trigger: Trigger): WritePath {
+	return { file, fn, writer: writer === "save" ? "saveDocument" : "setDocument", trigger };
+}
+
+// ---------------------------------------------------------------------------
+// The scan
+// ---------------------------------------------------------------------------
+
+const WRITERS = new Set(["saveDocument", "setDocument"]);
+
+function sourceFiles(dir: string): string[] {
+	return readdirSync(dir).flatMap((entry) => {
+		const full = resolve(dir, entry);
+		if (statSync(full).isDirectory()) return sourceFiles(full);
+		if (!/\.tsx?$/.test(entry) || /\.(test|spec)\.tsx?$/.test(entry)) return [];
+		return [full];
+	});
+}
+
+function calleeName(call: ts.CallExpression): string | null {
+	if (ts.isIdentifier(call.expression)) return call.expression.text;
+	if (ts.isPropertyAccessExpression(call.expression)) return call.expression.name.text;
+	return null;
+}
+
+type FunctionLike =
+	| ts.FunctionDeclaration
+	| ts.FunctionExpression
+	| ts.ArrowFunction
+	| ts.MethodDeclaration;
+
+function isFunctionLike(node: ts.Node): node is FunctionLike {
+	return (
+		ts.isFunctionDeclaration(node) ||
+		ts.isFunctionExpression(node) ||
+		ts.isArrowFunction(node) ||
+		ts.isMethodDeclaration(node)
+	);
+}
+
+/** The name a reader would use for this function: its own, or the binding it is
+ *  assigned to through however many `useCallback(...)` wrappers. */
+function nameOf(fn: FunctionLike): string | null {
+	if (
+		!ts.isArrowFunction(fn) &&
+		!ts.isFunctionExpression(fn) &&
+		fn.name &&
+		ts.isIdentifier(fn.name)
+	)
+		return fn.name.text;
+	let node: ts.Node | undefined = fn.parent;
+	while (node && (ts.isCallExpression(node) || ts.isParenthesizedExpression(node))) {
+		node = node.parent;
+	}
+	if (node && ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) return node.name.text;
+	if (node && ts.isPropertyAssignment(node) && ts.isIdentifier(node.name)) return node.name.text;
+	if (node && ts.isMethodDeclaration(node) && ts.isIdentifier(node.name)) return node.name.text;
+	return null;
+}
+
+/** The innermost enclosing function that has a name, and the chain down to the call —
+ *  `forwarded` needs the chain to check the identifier really is a parameter. */
+function enclosingFunctions(call: ts.Node): { name: string; functions: FunctionLike[] } {
+	const functions: FunctionLike[] = [];
+	let node: ts.Node | undefined = call.parent;
+	let name: string | null = null;
+	while (node) {
+		if (isFunctionLike(node)) {
+			functions.push(node);
+			name ??= nameOf(node);
+		}
+		node = node.parent;
+	}
+	return { name: name ?? "<module>", functions };
+}
+
+function triggerOf(call: ts.CallExpression, functions: FunctionLike[]): Trigger | string {
+	const opts = call.arguments.at(-1);
+	if (!opts) return "no options argument";
+	if (ts.isIdentifier(opts)) {
+		// A wrapper only counts as forwarding if what it passes on came from OUTSIDE.
+		// A local `const opts = { history: true }` is a hardcode wearing a disguise.
+		const isParameter = functions.some((fn) =>
+			fn.parameters.some((p) => ts.isIdentifier(p.name) && p.name.text === opts.text),
+		);
+		return isParameter ? "forwarded" : `local variable \`${opts.text}\``;
+	}
+	if (!ts.isObjectLiteralExpression(opts)) return "options are not an object literal";
+	const history = opts.properties.find(
+		(p) => p.name && ts.isIdentifier(p.name) && p.name.text === "history",
+	);
+	if (!history || !ts.isPropertyAssignment(history)) return "no `history` property";
+	if (history.initializer.kind === ts.SyntaxKind.TrueKeyword) return "gesture";
+	if (history.initializer.kind === ts.SyntaxKind.FalseKeyword) return "automatic";
+	return "`history` is computed, so nobody decided";
+}
+
+interface Scan {
+	writes: WritePath[];
+	/** A Map, not an object: `calleeName` returns whatever the source says, and
+	 *  `"toString" in {}` is true. */
+	callsTo: Map<string, { file: string; fn: string }[]>;
+}
+
+function scan(): Scan {
+	const writes: WritePath[] = [];
+	const callsTo = new Map<string, { file: string; fn: string }[]>([
+		["pushHistory", []],
+		["recordHistory", []],
+	]);
+	for (const path of sourceFiles(SRC)) {
+		const file = relative(ROOT, path).split("\\").join("/");
+		const source = ts.createSourceFile(
+			path,
+			readFileSync(path, "utf8"),
+			ts.ScriptTarget.Latest,
+			true,
+			path.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+		);
+		const visit = (node: ts.Node) => {
+			if (ts.isCallExpression(node)) {
+				const callee = calleeName(node);
+				const { name, functions } = callee ? enclosingFunctions(node) : { name: "", functions: [] };
+				if (callee) callsTo.get(callee)?.push({ file, fn: name });
+				if (callee && WRITERS.has(callee)) {
+					writes.push({
+						file,
+						fn: name,
+						writer: callee as WritePath["writer"],
+						trigger: triggerOf(node, functions) as Trigger,
+					});
+				}
+			}
+			ts.forEachChild(node, visit);
+		};
+		visit(source);
+	}
+	return { writes, callsTo };
+}
+
+function sortKey(path: WritePath): string {
+	return `${path.file}#${path.fn}#${path.writer}#${path.trigger}`;
+}
+
+const scanned = scan();
+
+describe("every write that can reach the undo stack", () => {
+	it("is declared in the table above, with the trigger it actually writes", () => {
+		// A failure here is not a broken test. It means a write path was added, moved
+		// or reclassified, and nobody has said whether the user asked for it. Read the
+		// diff, decide, and put the row in `DECLARED`.
+		expect(scanned.writes.map(sortKey).sort()).toEqual(DECLARED.map(sortKey).sort());
+	});
+
+	// The table is only the whole surface while these two hold. `recordHistory` is
+	// module-private to `projectStore`, and `pushHistory` is reachable from anywhere
+	// that imports `undoStack` — so the stack grows one more entry point the moment
+	// somebody calls it directly, and the table would stop being the audit.
+	it("goes through `recordHistory`, which only `saveDocument` and `setDocument` call", () => {
+		expect(scanned.callsTo.get("recordHistory")).toEqual([
+			{ file: "src/lib/ai-edition/store/projectStore.ts", fn: "saveDocument" },
+			{ file: "src/lib/ai-edition/store/projectStore.ts", fn: "setDocument" },
+		]);
+	});
+
+	it("reaches `pushHistory` from `recordHistory` and nowhere else", () => {
+		expect(scanned.callsTo.get("pushHistory")).toEqual([
+			{ file: "src/lib/ai-edition/store/projectStore.ts", fn: "recordHistory" },
+		]);
+	});
+});

--- a/src/lib/ai-edition/store/documentWriteAudit.test.ts
+++ b/src/lib/ai-edition/store/documentWriteAudit.test.ts
@@ -24,13 +24,16 @@
 // So: this file is the table. A new write, a moved one, or a changed `history`
 // value fails here with a diff, and the only way to make it pass is to write down
 // what triggers it. `recordHistory` is unreachable except through the two writers
-// enumerated below, which the last two tests pin as well -- so the table is the
-// whole surface, not a sample of it.
+// enumerated below, and the only other way an entry reaches a stack is undo/redo
+// stepping over one -- the tests after the table pin both, and the stacks are
+// `readonly` so there is no third way that skips a name this file can count. The
+// table is the whole surface, not a sample of it.
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { relative, resolve } from "node:path";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
+import { clearHistory, future, past } from "./undoStack";
 
 const ROOT = process.cwd();
 const SRC = resolve(ROOT, "src");
@@ -45,7 +48,9 @@ type Trigger =
 	| "automatic"
 	/** A wrapper. Hands its caller's option straight through, so the decision stays
 	 *  with whoever knows the answer. `forwarded` is checked structurally: the
-	 *  identifier passed on must be a PARAMETER of the enclosing function. */
+	 *  identifier passed on must resolve to a PARAMETER, in the first enclosing
+	 *  scope that binds that name — a local `const` of the same name is not a
+	 *  forward, however many outer functions have a parameter called that. */
 	| "forwarded";
 
 interface WritePath {
@@ -248,32 +253,96 @@ function nameOf(fn: FunctionLike): string | null {
 	return null;
 }
 
-/** The innermost enclosing function that has a name, and the chain down to the call —
- *  `forwarded` needs the chain to check the identifier really is a parameter. */
-function enclosingFunctions(call: ts.Node): { name: string; functions: FunctionLike[] } {
-	const functions: FunctionLike[] = [];
+/** The innermost enclosing function that has a name. */
+function enclosingFunctionName(call: ts.Node): string {
 	let node: ts.Node | undefined = call.parent;
-	let name: string | null = null;
 	while (node) {
 		if (isFunctionLike(node)) {
-			functions.push(node);
-			name ??= nameOf(node);
+			const name = nameOf(node);
+			if (name) return name;
 		}
 		node = node.parent;
 	}
-	return { name: name ?? "<module>", functions };
+	return "<module>";
 }
 
-function triggerOf(call: ts.CallExpression, functions: FunctionLike[]): Trigger | string {
+/** Every name a binding introduces, destructuring included. */
+function bindsName(binding: ts.BindingName, name: string): boolean {
+	if (ts.isIdentifier(binding)) return binding.text === name;
+	return binding.elements.some(
+		(element) => ts.isBindingElement(element) && bindsName(element.name, name),
+	);
+}
+
+function declaresInList(list: ts.VariableDeclarationList, name: string): boolean {
+	return list.declarations.some((declaration) => bindsName(declaration.name, name));
+}
+
+/** Whether this scope binds `name` as a LOCAL — the thing a forward is not. */
+function scopeDeclaresLocal(scope: ts.Node, name: string): boolean {
+	const inStatements = (statements: readonly ts.Statement[]) =>
+		statements.some(
+			(statement) =>
+				ts.isVariableStatement(statement) && declaresInList(statement.declarationList, name),
+		);
+	if (ts.isSourceFile(scope) || ts.isBlock(scope) || ts.isModuleBlock(scope))
+		return inStatements(scope.statements);
+	if (ts.isCaseBlock(scope)) return scope.clauses.some((clause) => inStatements(clause.statements));
+	if (ts.isForStatement(scope) || ts.isForInStatement(scope) || ts.isForOfStatement(scope))
+		return (
+			!!scope.initializer &&
+			ts.isVariableDeclarationList(scope.initializer) &&
+			declaresInList(scope.initializer, name)
+		);
+	if (ts.isCatchClause(scope))
+		return !!scope.variableDeclaration && bindsName(scope.variableDeclaration.name, name);
+	return false;
+}
+
+/**
+ * Where the identifier handed to a writer as its options argument was bound.
+ *
+ * The walk goes OUTWARD from the call and stops at the FIRST scope that binds the
+ * name. Stopping is the point. The previous version collected every function-like
+ * ancestor up to the module and asked whether ANY of them had a parameter of that
+ * name, so a local `const opts = { history: true }` read as `forwarded` the moment
+ * an unrelated outer function happened to have an `opts` parameter — which
+ * `useSequentialTimelineOps` does, on the hook itself. That is precisely the
+ * hardcode-in-a-disguise the check exists to expose.
+ *
+ * "The innermost function's parameters" is not the rule either, though, and the
+ * walk has to leave that function: `useSequentialTimelineOps.apply` calls
+ * `saveDocument(applied.document, opts)` inside a zero-parameter `async () => {}`,
+ * and `opts` is the parameter of the `useCallback` arrow two scopes further out.
+ */
+function bindingOf(call: ts.Node, name: string): "parameter" | "local" {
+	let node: ts.Node | undefined = call.parent;
+	while (node) {
+		if (scopeDeclaresLocal(node, name)) return "local";
+		if (isFunctionLike(node) && node.parameters.some((p) => bindsName(p.name, name)))
+			return "parameter";
+		node = node.parent;
+	}
+	// Bound nowhere on the way out: a module binding, an import, or a global. None of
+	// them is the caller's decision either.
+	return "local";
+}
+
+function triggerOf(call: ts.CallExpression): Trigger | string {
+	// Arity before `at(-1)`. On a one-argument call the last argument is the DOCUMENT,
+	// and if that document is an identifier naming an enclosing parameter the call
+	// reads as `forwarded` instead of as the mistake it is. Both writers require the
+	// options argument today, so this cannot bite — but "the compiler would have
+	// caught it" is exactly the reasoning this file exists not to rely on.
+	if (call.arguments.length < 2) return "no options argument";
 	const opts = call.arguments.at(-1);
 	if (!opts) return "no options argument";
 	if (ts.isIdentifier(opts)) {
 		// A wrapper only counts as forwarding if what it passes on came from OUTSIDE.
 		// A local `const opts = { history: true }` is a hardcode wearing a disguise.
-		const isParameter = functions.some((fn) =>
-			fn.parameters.some((p) => ts.isIdentifier(p.name) && p.name.text === opts.text),
-		);
-		return isParameter ? "forwarded" : `local variable \`${opts.text}\``;
+		return bindingOf(call, opts.text) === "parameter"
+			? "forwarded"
+			: `local variable \`${opts.text}\``;
 	}
 	if (!ts.isObjectLiteralExpression(opts)) return "options are not an object literal";
 	const history = opts.properties.find(
@@ -297,6 +366,12 @@ function scan(): Scan {
 	const callsTo = new Map<string, { file: string; fn: string }[]>([
 		["pushHistory", []],
 		["recordHistory", []],
+		// The other two ways an entry can land on a stack. They exist because the
+		// arrays are `readonly` now, which is what turned "somebody called `.push` on
+		// an exported array" — invisible here, the callee name is `push` — into a
+		// named call this scan can count.
+		["pushPast", []],
+		["pushFuture", []],
 	]);
 	for (const path of sourceFiles(SRC)) {
 		const file = relative(ROOT, path).split("\\").join("/");
@@ -310,14 +385,14 @@ function scan(): Scan {
 		const visit = (node: ts.Node) => {
 			if (ts.isCallExpression(node)) {
 				const callee = calleeName(node);
-				const { name, functions } = callee ? enclosingFunctions(node) : { name: "", functions: [] };
+				const name = callee ? enclosingFunctionName(node) : "";
 				if (callee) callsTo.get(callee)?.push({ file, fn: name });
 				if (callee && WRITERS.has(callee)) {
 					writes.push({
 						file,
 						fn: name,
 						writer: callee as WritePath["writer"],
-						trigger: triggerOf(node, functions) as Trigger,
+						trigger: triggerOf(node) as Trigger,
 					});
 				}
 			}
@@ -357,5 +432,125 @@ describe("every write that can reach the undo stack", () => {
 		expect(scanned.callsTo.get("pushHistory")).toEqual([
 			{ file: "src/lib/ai-edition/store/projectStore.ts", fn: "recordHistory" },
 		]);
+	});
+
+	it("grows the stacks only through `pushHistory` and undo/redo's own two pushes", () => {
+		// `undo` and `redo` hand each other the document they are stepping over, which
+		// is not a new edit and must not clear the other stack -- so they cannot go
+		// through `pushHistory`. Those two calls are the whole remainder, and the rows
+		// below are what makes that a checked statement rather than a claim.
+		expect(scanned.callsTo.get("pushPast")).toEqual([
+			{ file: "src/lib/ai-edition/store/undo.ts", fn: "redo" },
+		]);
+		expect(scanned.callsTo.get("pushFuture")).toEqual([
+			{ file: "src/lib/ai-edition/store/undo.ts", fn: "undo" },
+		]);
+	});
+
+	it("cannot be grown by an importer reaching around those names", () => {
+		// The hole this closes. `past` and `future` were exported as `Snapshot[]`, and
+		// `const` binds the reference, not the contents -- so `past.push(...)` from any
+		// importer recorded history, and the scan above could not see it: it keys on the
+		// callee NAME, and the name there is `push`.
+		//
+		// The assertions are the `@ts-expect-error`s. Each one is an error itself the
+		// moment the directive stops suppressing anything, so this test fails the
+		// typecheck pass if the stacks ever go mutable again.
+		// @ts-expect-error `past` is `readonly Snapshot[]`; record through `pushHistory`.
+		past.push({ projectId: "project_x", doc: {} });
+		// @ts-expect-error `future` is `readonly Snapshot[]`; step forward through `pushFuture`.
+		future.push({ projectId: "project_x", doc: {} });
+		// @ts-expect-error `length` is read-only too; empty the stacks with `clearHistory`.
+		past.length = 0;
+
+		// The lines above still RUN -- `readonly` is erased, it is the same array -- so
+		// leave the module the way this file found it.
+		clearHistory();
+		expect(past).toHaveLength(0);
+		expect(future).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// The audit's own rule, pinned. The table above is worth exactly as much as
+// `triggerOf`, and a `forwarded` that an unrelated outer parameter name can spoof
+// is the hole the audit exists to close.
+// ---------------------------------------------------------------------------
+
+/** Classify the first `saveDocument(...)` call in a snippet. Parsed, not
+ *  type-checked, so the fixtures can leave their free variables undeclared. */
+function classify(fixture: string): Trigger | string {
+	const source = ts.createSourceFile(
+		"fixture.ts",
+		fixture,
+		ts.ScriptTarget.Latest,
+		true,
+		ts.ScriptKind.TS,
+	);
+	const calls: ts.CallExpression[] = [];
+	const visit = (node: ts.Node) => {
+		if (ts.isCallExpression(node) && calleeName(node) === "saveDocument") calls.push(node);
+		ts.forEachChild(node, visit);
+	};
+	visit(source);
+	const [call] = calls;
+	if (!call) throw new Error("fixture has no `saveDocument` call");
+	return triggerOf(call);
+}
+
+describe("how a write's trigger is read off its call site", () => {
+	it("does not call a local `opts` forwarded because an OUTER function has one", () => {
+		// The shape that was live: `useSequentialTimelineOps` takes a parameter called
+		// `options`, so anything written inside that hook as a local `options` would have
+		// read as `forwarded` -- a hardcode wearing exactly the disguise the check is
+		// supposed to strip off.
+		expect(
+			classify(`
+				function useOps(opts) {
+					return () => {
+						const opts = { history: true };
+						saveDocument(doc, opts);
+					};
+				}
+			`),
+		).toBe("local variable `opts`");
+	});
+
+	it("still forwards across an inner function that takes no parameters", () => {
+		// `useSequentialTimelineOps.apply`, reduced: the call sits in a zero-parameter
+		// `async () => {}` and `opts` is bound two scopes out. Stopping the walk at the
+		// innermost function would break this row.
+		expect(
+			classify(`
+				const apply = (op, opts) =>
+					enqueue(async () => {
+						const doc = current();
+						return saveDocument(doc, opts);
+					});
+			`),
+		).toBe("forwarded");
+	});
+
+	it("reads a destructured local as a local, not as a forward", () => {
+		expect(
+			classify(`
+				function wrapper(opts) {
+					const { opts } = defaults;
+					saveDocument(doc, opts);
+				}
+			`),
+		).toBe("local variable `opts`");
+	});
+
+	it("says so when there is no options argument at all", () => {
+		// Without the arity check the last argument here is the DOCUMENT, and `doc` names
+		// an enclosing parameter -- so the call reported itself as forwarding.
+		expect(
+			classify(`
+				function wrapper(doc) {
+					saveDocument(doc);
+				}
+			`),
+		).toBe("no options argument");
 	});
 });

--- a/src/lib/ai-edition/store/projectStore.test.ts
+++ b/src/lib/ai-edition/store/projectStore.test.ts
@@ -422,4 +422,64 @@ describe("useProjectStore", () => {
 		// document is the one being dropped.
 		expect(past).toHaveLength(0);
 	});
+	describe("addAsset drops work the user has already moved on from", () => {
+		// `addAsset` awaits the native add, a camera lookup, a dimension probe and a save,
+		// and then writes the store unconditionally. Anything the user does in those gaps
+		// -- deleting the open project, switching to another one -- used to lose to the
+		// write that landed last.
+		function pendingAdd() {
+			let release!: (value: { document: typeof sampleDoc }) => void;
+			bridgeMocks.addAsset.mockReturnValue(
+				new Promise((resolve) => {
+					release = resolve;
+				}),
+			);
+			return { release };
+		}
+
+		beforeEach(() => {
+			// biome-ignore lint/suspicious/noExplicitAny: test-only stub of the legacy contextBridge surface
+			(window as any).electronAPI = {
+				findRecordingCamera: vi.fn().mockResolvedValue({ success: false }),
+			};
+		});
+
+		it("does not reinstall a deleted project's document", async () => {
+			bridgeMocks.create.mockResolvedValue({ success: true, document: sampleDoc });
+			await useProjectStore.getState().createProject("Test");
+
+			const { release } = pendingAdd();
+			const pending = useProjectStore.getState().addAsset("C:/clip.mp4");
+
+			// The user deletes the project while the add is still in flight.
+			useProjectStore.getState().clear();
+			release({ document: sampleDoc });
+
+			await expect(pending).resolves.toBeNull();
+			expect(useProjectStore.getState().document).toBeNull();
+			expect(useProjectStore.getState().projectId).toBeNull();
+		});
+
+		it("does not drop one project's asset into the project the user switched to", async () => {
+			bridgeMocks.create.mockResolvedValue({ success: true, document: sampleDoc });
+			await useProjectStore.getState().createProject("Test");
+
+			const { release } = pendingAdd();
+			const pending = useProjectStore.getState().addAsset("C:/clip.mp4");
+
+			const other = {
+				...sampleDoc,
+				project: { ...sampleDoc.project, id: "proj_other", title: "Other" },
+			};
+			bridgeMocks.get.mockResolvedValue({ success: true, document: other });
+			await useProjectStore.getState().loadProject("proj_other");
+
+			release({ document: sampleDoc });
+
+			await expect(pending).resolves.toBeNull();
+			// Still the project the user chose, not the one the add was building on.
+			expect(useProjectStore.getState().projectId).toBe("proj_other");
+			expect(useProjectStore.getState().document?.project.id).toBe("proj_other");
+		});
+	});
 });

--- a/src/lib/ai-edition/store/projectStore.test.ts
+++ b/src/lib/ai-edition/store/projectStore.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useProjectStore } from "./projectStore";
+import { clearHistory, past, pushHistory } from "./undoStack";
 
 const bridgeMocks = vi.hoisted(() => ({
 	get: vi.fn(),
@@ -377,5 +378,48 @@ describe("useProjectStore", () => {
 			status: "idle",
 			error: null,
 		});
+	});
+
+	it("clear drops the undo history with the project", () => {
+		// Explicit rather than leaning on the `beforeEach`, which reaches this same code.
+		clearHistory();
+		useProjectStore.setState({ projectId: "proj_test", document: sampleDoc });
+		pushHistory({ projectId: "proj_test", doc: sampleDoc });
+		expect(past).toHaveLength(1);
+
+		useProjectStore.getState().clear();
+
+		// Hygiene rather than a restore hazard -- `undo` refuses a snapshot whose
+		// projectId does not match, and there is no projectId left to match. What the
+		// stack was actually holding is up to fifty cloned documents, kept alive until
+		// the next project load.
+		expect(past).toHaveLength(0);
+	});
+
+	it("clear supersedes a save that was already in flight", async () => {
+		// `clear()`'s one production caller deletes the open project. A background save
+		// issued a moment earlier -- a transcript, a duration probe -- used to resolve
+		// after it and reinstall the deleted project's document over the empty state,
+		// with `dirty: false` and a fresh `lastSavedAt` claiming it was on disk.
+		const renamed = { ...sampleDoc, project: { ...sampleDoc.project, title: "Renamed" } };
+		clearHistory();
+		useProjectStore.setState({ projectId: "proj_test", document: sampleDoc, dirty: true });
+		let release: (() => void) | undefined;
+		bridgeMocks.save.mockReturnValue(
+			new Promise((resolve) => {
+				release = () => resolve({ success: true, document: renamed });
+			}),
+		);
+
+		const inFlight = useProjectStore.getState().saveDocument(renamed, { history: true });
+		useProjectStore.getState().clear();
+		release?.();
+
+		await expect(inFlight).resolves.toBe(false);
+		expect(useProjectStore.getState().document).toBeNull();
+		expect(useProjectStore.getState().dirty).toBe(false);
+		// And nothing recorded either: the write that would have pushed the pre-rename
+		// document is the one being dropped.
+		expect(past).toHaveLength(0);
 	});
 });

--- a/src/lib/ai-edition/store/projectStore.test.ts
+++ b/src/lib/ai-edition/store/projectStore.test.ts
@@ -312,7 +312,9 @@ describe("useProjectStore", () => {
 			bridgeMocks.save.mockResolvedValue({ success: false, error: "EACCES" });
 
 			const edited = { ...sampleDoc, project: { ...sampleDoc.project, title: "Edited" } };
-			await expect(useProjectStore.getState().saveDocument(edited)).resolves.toBe(false);
+			await expect(
+				useProjectStore.getState().saveDocument(edited, { history: true }),
+			).resolves.toBe(false);
 
 			expect(toastMocks.error).toHaveBeenCalledWith("Failed to save project", {
 				description: "EACCES",
@@ -329,7 +331,9 @@ describe("useProjectStore", () => {
 			useProjectStore.setState({ projectId: "proj_test", document: sampleDoc, dirty: true });
 			bridgeMocks.save.mockRejectedValue(new Error("bridge is gone"));
 
-			await expect(useProjectStore.getState().saveDocument(sampleDoc)).resolves.toBe(false);
+			await expect(
+				useProjectStore.getState().saveDocument(sampleDoc, { history: true }),
+			).resolves.toBe(false);
 			expect(toastMocks.error).toHaveBeenCalledWith("Failed to save project", {
 				description: "bridge is gone",
 			});
@@ -340,7 +344,9 @@ describe("useProjectStore", () => {
 			useProjectStore.setState({ projectId: "proj_test", document: sampleDoc, dirty: true });
 			bridgeMocks.save.mockResolvedValue({ success: true, document: saved });
 
-			await expect(useProjectStore.getState().saveDocument(saved)).resolves.toBe(true);
+			await expect(useProjectStore.getState().saveDocument(saved, { history: true })).resolves.toBe(
+				true,
+			);
 
 			expect(toastMocks.error).not.toHaveBeenCalled();
 			const state = useProjectStore.getState();

--- a/src/lib/ai-edition/store/projectStore.ts
+++ b/src/lib/ai-edition/store/projectStore.ts
@@ -20,15 +20,38 @@ export type ProjectStatus = "idle" | "loading" | "ready" | "error";
 
 export interface DocumentWriteOptions {
 	/**
-	 * Record the outgoing document on the undo stack. Defaults to `true`: a write
-	 * is a user edit unless the caller says otherwise.
+	 * Record the outgoing document on the undo stack.
 	 *
-	 * Pass `false` for writes the user never asked for -- probe backfills,
-	 * transcripts arriving from a background job, the restore an undo itself
-	 * persists. Those must not become Ctrl+Z steps, and a persist that re-recorded
-	 * the document it just restored would undo the undo.
+	 * REQUIRED, and deliberately not defaulted either way. A default is a decision
+	 * nobody makes: defaulting to `true` let `probeAndCorrectClip` push a background
+	 * probe's document onto the stack simply by not mentioning it, so the first
+	 * Ctrl+Z after a drop snapped the clip back to its 60s placeholder instead of
+	 * removing it -- and defaulting to `false` would recreate #433 itself the next
+	 * time somebody added an edit. Making it a compile error to omit is the only
+	 * version a new call site cannot get wrong by saying nothing.
+	 *
+	 * `true` for anything the user did. `false` for writes they never asked for:
+	 * probe backfills, transcripts arriving from a background job, the camera
+	 * auto-link, the optimistic half of an optimistic-write-then-save pair, and the
+	 * persist an undo itself triggers (which would otherwise undo the undo).
 	 */
-	history?: boolean;
+	history: boolean;
+	/**
+	 * The document Ctrl+Z should return to, when it is NOT the one the store holds
+	 * at the moment of the write.
+	 *
+	 * A live drag writes every pointermove straight into the store with
+	 * `history: false`, so by the time the pointerup commit runs, the "previous"
+	 * document the store holds is the dragged one -- recording that would make the
+	 * gesture un-undoable. The commit passes the PRE-DRAG document here instead, and
+	 * because `saveDocument` records only after the write succeeded, a failed commit
+	 * records nothing at all and its rollback has nothing to pop.
+	 *
+	 * `null` means "there is no state to go back to" and records nothing. Omitting
+	 * the field falls back to the store's current document, which is what an
+	 * ordinary edit wants.
+	 */
+	historyBase?: AxcutDocument | null;
 }
 
 export interface ProjectState {
@@ -64,8 +87,8 @@ export interface ProjectState {
 	 * an unhandled rejection in the renderer with no toast, no log and no clue --
 	 * change a caption font on a read-only project and the edit was simply gone.
 	 */
-	saveDocument: (document: AxcutDocument, opts?: DocumentWriteOptions) => Promise<boolean>;
-	setDocument: (document: AxcutDocument, opts?: DocumentWriteOptions) => void;
+	saveDocument: (document: AxcutDocument, opts: DocumentWriteOptions) => Promise<boolean>;
+	setDocument: (document: AxcutDocument, opts: DocumentWriteOptions) => void;
 	replaceTimeline: (intervals: Interval[], reason: string) => Promise<void>;
 	restoreFullTimeline: () => Promise<void>;
 	setSourceDuration: (sec: number) => void;
@@ -80,10 +103,19 @@ function parseDocument(value: unknown): AxcutDocument {
 }
 
 /**
- * Record `prev` as the state Ctrl+Z returns to, unless the caller opted out or
- * this write is not a change (`commit`-style re-saves hand back the very object
- * the store already holds, and a live drag's `setLive` then `commit` pair would
- * otherwise take two undos to reverse one gesture).
+ * The document a write should record as the state Ctrl+Z returns to. Read
+ * SYNCHRONOUSLY, before any await: after one, `get().document` is whatever the
+ * write installed.
+ */
+function historyBaseFor(opts: DocumentWriteOptions, current: AxcutDocument | null) {
+	return opts.historyBase !== undefined ? opts.historyBase : current;
+}
+
+/**
+ * Push `prev` onto the undo stack, unless the caller opted out or this write is
+ * not a change (`commit`-style re-saves hand back the very object the store
+ * already holds, and an optimistic `setDocument` then `saveDocument` pair would
+ * otherwise take two undos to reverse one edit).
  *
  * Synchronous on purpose -- see the header of `undoStack.ts` for what the
  * deferred `import("./undo")` this replaced did to redo.
@@ -91,9 +123,9 @@ function parseDocument(value: unknown): AxcutDocument {
 function recordHistory(
 	prev: AxcutDocument | null,
 	next: AxcutDocument,
-	opts?: DocumentWriteOptions,
+	opts: DocumentWriteOptions,
 ) {
-	if (opts?.history === false) return;
+	if (!opts.history) return;
 	if (!prev || prev === next) return;
 	pushHistory({ projectId: prev.project.id, doc: structuredClone(prev) });
 }
@@ -276,13 +308,13 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 	},
 
 	async saveDocument(document, opts) {
-		// Snapshot BEFORE the await, while `get().document` is still the pre-edit one.
+		// Read BEFORE the await, while `get().document` is still the pre-edit one.
 		// This is where undo history actually comes from: the editor writes through
 		// `saveDocument` for every user edit -- add a region, delete one, rename the
 		// project, every timeline op -- and `setDocument` is reserved for the handful
 		// of live/optimistic paths. Recording only in `setDocument` left `past` empty
 		// for everything the user does, so Ctrl+Z was a no-op (#433).
-		recordHistory(get().document, document, opts);
+		const base = historyBaseFor(opts, get().document);
 		try {
 			const result = await nativeBridgeClient.aiEdition.save(document);
 			if (!result.success || !result.document) {
@@ -295,6 +327,14 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 				dirty: false,
 				lastSavedAt: new Date(),
 			});
+			// Recorded HERE, below the write, and not above it. `saveDocument` resolves
+			// false on a handled failure (a read-only project) and callers read that as
+			// "the edit did not happen". Recording first left `past` holding a snapshot
+			// identical to the live document and `future` wiped, so the next Ctrl+Z
+			// visibly did nothing and redo was gone -- #433's own symptom, re-created by
+			// the fix for it. Nothing between the `set` above and this line awaits, so no
+			// undo can observe the half-applied state.
+			recordHistory(base, document, opts);
 			return true;
 		} catch (error) {
 			// Logged as well as toasted: a toast is gone in five seconds, and "my edit
@@ -312,7 +352,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 	},
 
 	setDocument(document, opts) {
-		recordHistory(get().document, document, opts);
+		// No await to sit above: this write cannot fail, so recording it up front is
+		// the same thing as recording it afterwards.
+		recordHistory(historyBaseFor(opts, get().document), document, opts);
 		set({
 			document,
 			revision: get().revision + 1,
@@ -324,14 +366,14 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 		const doc = get().document;
 		if (!doc) throw new Error("No project loaded");
 		const next = replaceTimelineOp(doc, intervals, reason);
-		await get().saveDocument(next);
+		await get().saveDocument(next, { history: true });
 	},
 
 	async restoreFullTimeline() {
 		const doc = get().document;
 		if (!doc) throw new Error("No project loaded");
 		const next = restoreFullTimelineOp(doc);
-		await get().saveDocument(next);
+		await get().saveDocument(next, { history: true });
 	},
 
 	setSourceDuration(sec) {

--- a/src/lib/ai-edition/store/projectStore.ts
+++ b/src/lib/ai-edition/store/projectStore.ts
@@ -3,14 +3,10 @@ import { create } from "zustand";
 import { toFileUrl } from "@/components/video-editor/projectPersistence";
 import { toastText } from "@/i18n/toastText";
 import { nativeBridgeClient } from "@/native/client";
-import {
-	type Interval,
-	replaceTimeline as replaceTimelineOp,
-	restoreFullTimeline as restoreFullTimelineOp,
-} from "../document/timeline";
+import { type Interval, replaceTimeline as replaceTimelineOp } from "../document/timeline";
 import { type AxcutAsset, type AxcutDocument, documentSchema } from "../schema";
 import { probeVideoDimensions } from "../timeline/duration";
-import { clearHistory, pushHistory } from "./undoStack";
+import { clearHistory, currentWriteEpoch, pushHistory } from "./undoStack";
 
 // ponytail: thin Zustand wrapper over the native-bridge client. Keeps the
 // current project + revision counter in renderer memory; mutations round-trip
@@ -78,9 +74,15 @@ export interface ProjectState {
 	addAsset: (path: string, label?: string) => Promise<AxcutAsset | null>;
 	removeAsset: (assetId: string) => Promise<void>;
 	/**
-	 * Write the document to disk. Resolves `true` when it landed, `false` when it did
-	 * not -- and a `false` has ALREADY been reported to the user and logged, so a
-	 * caller that ignores it is choosing not to react, not choosing to stay silent.
+	 * Write the document to disk. Resolves `true` when it took effect, `false` when it
+	 * did not.
+	 *
+	 * `false` means one of two things, and neither needs the caller to say anything:
+	 * the write FAILED, which has already been reported to the user and logged; or an
+	 * undo / redo / project switch happened while it was in flight, which the user did
+	 * on purpose and can see on screen. Either way the store does not hold what was
+	 * asked for, so a caller that reacts to `false` by undoing its own optimistic write
+	 * must check the store still holds that write first -- see `agentDocumentApply`.
 	 *
 	 * It never rejects, by design. Every save in the app funnels through here and
 	 * almost all of them are `void`-ed from a click handler, so a rejection here was
@@ -89,8 +91,22 @@ export interface ProjectState {
 	 */
 	saveDocument: (document: AxcutDocument, opts: DocumentWriteOptions) => Promise<boolean>;
 	setDocument: (document: AxcutDocument, opts: DocumentWriteOptions) => void;
-	replaceTimeline: (intervals: Interval[], reason: string) => Promise<void>;
-	restoreFullTimeline: () => Promise<void>;
+	/**
+	 * Rebuild the timeline from `intervals` and save it.
+	 *
+	 * `opts` is NOT optional and NOT defaulted, for the same reason `history` itself is
+	 * not: this used to hardcode `{ history: true }`, and because the option was invisible
+	 * in this signature, no compile error could reach the one caller. That caller is the
+	 * unattended recording import, which runs on editor mount -- so the user arrived in a
+	 * brand-new project with `past.length === 1`, and their first Ctrl+Z emptied the
+	 * timeline. A wrapper that writes has to let its caller decide, or it decides wrong on
+	 * that caller's behalf.
+	 */
+	replaceTimeline: (
+		intervals: Interval[],
+		reason: string,
+		opts: DocumentWriteOptions,
+	) => Promise<void>;
 	setSourceDuration: (sec: number) => void;
 	setCurrentTime: (sec: number) => void;
 	setPlaying: (playing: boolean) => void;
@@ -315,11 +331,26 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 		// of live/optimistic paths. Recording only in `setDocument` left `past` empty
 		// for everything the user does, so Ctrl+Z was a no-op (#433).
 		const base = historyBaseFor(opts, get().document);
+		// Read alongside it, and for the same reason: both describe the world this write
+		// is building on, and the await is where that world can change underneath it.
+		const epoch = currentWriteEpoch();
 		try {
 			const result = await nativeBridgeClient.aiEdition.save(document);
 			if (!result.success || !result.document) {
 				throw new Error(result.error ?? "Failed to save project");
 			}
+			// The undo wins, and this write is dropped -- store and history both. It was
+			// in flight when the user pressed Ctrl+Z (or switched projects), so its document
+			// is the one they just asked to leave: installing it reverted the undo on screen,
+			// and recording it put a FORWARD state on `past` and cleared `future`, so the
+			// redo they had just earned was gone.
+			//
+			// Dropped rather than reverted, because reverting is not this write's to do: the
+			// bytes are already on disk, and it is the undo's own persist -- issued from
+			// `useUndoRedoShortcuts`'s `onAfter` the moment it ran, so ordered after this one
+			// on the same IPC channel -- that puts the restored document back over them.
+			// `dirty` is deliberately left set for exactly that reason.
+			if (currentWriteEpoch() !== epoch) return false;
 			const parsed = parseDocument(result.document);
 			set({
 				document: parsed,
@@ -362,18 +393,11 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 		});
 	},
 
-	async replaceTimeline(intervals, reason) {
+	async replaceTimeline(intervals, reason, opts) {
 		const doc = get().document;
 		if (!doc) throw new Error("No project loaded");
 		const next = replaceTimelineOp(doc, intervals, reason);
-		await get().saveDocument(next, { history: true });
-	},
-
-	async restoreFullTimeline() {
-		const doc = get().document;
-		if (!doc) throw new Error("No project loaded");
-		const next = restoreFullTimelineOp(doc);
-		await get().saveDocument(next, { history: true });
+		await get().saveDocument(next, opts);
 	},
 
 	setSourceDuration(sec) {

--- a/src/lib/ai-edition/store/projectStore.ts
+++ b/src/lib/ai-edition/store/projectStore.ts
@@ -226,7 +226,16 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 	async addAsset(path, label) {
 		const { projectId } = get();
 		if (!projectId) throw new Error("No project loaded");
+		// Everything below awaits: the native add, a camera lookup, a dimension probe and a
+		// save. `clear()` and `loadProject()` can all land in those gaps, and the store write
+		// at the end is unconditional — so without this it can reinstall a deleted project's
+		// document, or drop one project's asset into the one the user switched to. Same pair
+		// `saveDocument` samples: the id says WHICH project, the epoch says whether anything
+		// superseded the write while it was in flight.
+		const epoch = currentWriteEpoch();
+		const superseded = () => get().projectId !== projectId || currentWriteEpoch() !== epoch;
 		const result = await nativeBridgeClient.aiEdition.addAsset(projectId, path, label);
+		if (superseded()) return null;
 		let document = parseDocument(result.document);
 		const addedAsset =
 			document.assets.find((a) => a.originalPath === path && (label ? a.label === label : true)) ??
@@ -306,6 +315,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 			}
 		}
 
+		if (superseded()) return null;
 		set({
 			document,
 			revision: get().revision + 1,

--- a/src/lib/ai-edition/store/projectStore.ts
+++ b/src/lib/ai-edition/store/projectStore.ts
@@ -10,12 +10,26 @@ import {
 } from "../document/timeline";
 import { type AxcutAsset, type AxcutDocument, documentSchema } from "../schema";
 import { probeVideoDimensions } from "../timeline/duration";
+import { clearHistory, pushHistory } from "./undoStack";
 
 // ponytail: thin Zustand wrapper over the native-bridge client. Keeps the
 // current project + revision counter in renderer memory; mutations round-trip
 // through the main process via the bridge so disk state stays authoritative.
 
 export type ProjectStatus = "idle" | "loading" | "ready" | "error";
+
+export interface DocumentWriteOptions {
+	/**
+	 * Record the outgoing document on the undo stack. Defaults to `true`: a write
+	 * is a user edit unless the caller says otherwise.
+	 *
+	 * Pass `false` for writes the user never asked for -- probe backfills,
+	 * transcripts arriving from a background job, the restore an undo itself
+	 * persists. Those must not become Ctrl+Z steps, and a persist that re-recorded
+	 * the document it just restored would undo the undo.
+	 */
+	history?: boolean;
+}
 
 export interface ProjectState {
 	projectId: string | null;
@@ -50,8 +64,8 @@ export interface ProjectState {
 	 * an unhandled rejection in the renderer with no toast, no log and no clue --
 	 * change a caption font on a read-only project and the edit was simply gone.
 	 */
-	saveDocument: (document: AxcutDocument) => Promise<boolean>;
-	setDocument: (document: AxcutDocument) => void;
+	saveDocument: (document: AxcutDocument, opts?: DocumentWriteOptions) => Promise<boolean>;
+	setDocument: (document: AxcutDocument, opts?: DocumentWriteOptions) => void;
 	replaceTimeline: (intervals: Interval[], reason: string) => Promise<void>;
 	restoreFullTimeline: () => Promise<void>;
 	setSourceDuration: (sec: number) => void;
@@ -63,6 +77,25 @@ export interface ProjectState {
 
 function parseDocument(value: unknown): AxcutDocument {
 	return documentSchema.parse(value);
+}
+
+/**
+ * Record `prev` as the state Ctrl+Z returns to, unless the caller opted out or
+ * this write is not a change (`commit`-style re-saves hand back the very object
+ * the store already holds, and a live drag's `setLive` then `commit` pair would
+ * otherwise take two undos to reverse one gesture).
+ *
+ * Synchronous on purpose -- see the header of `undoStack.ts` for what the
+ * deferred `import("./undo")` this replaced did to redo.
+ */
+function recordHistory(
+	prev: AxcutDocument | null,
+	next: AxcutDocument,
+	opts?: DocumentWriteOptions,
+) {
+	if (opts?.history === false) return;
+	if (!prev || prev === next) return;
+	pushHistory({ projectId: prev.project.id, doc: structuredClone(prev) });
 }
 
 export const useProjectStore = create<ProjectState>((set, get) => ({
@@ -94,7 +127,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 				dirty: false,
 				lastSavedAt: new Date(),
 			});
-			void import("./undo").then(({ clearHistory }) => clearHistory());
+			clearHistory();
 		} catch (error) {
 			set({
 				status: "error",
@@ -120,7 +153,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 				dirty: false,
 				lastSavedAt: new Date(),
 			});
-			void import("./undo").then(({ clearHistory }) => clearHistory());
+			clearHistory();
 			return document;
 		} catch (error) {
 			set({
@@ -198,7 +231,10 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 					// Only adopt the linked document if it actually reached disk -- otherwise
 					// the caller is handed a document claiming a camera link the file does not
 					// have. The store has already told the user the write failed.
-					if (await get().saveDocument(next)) document = parseDocument(next);
+					// `history: false`: linking a camera is part of adding the asset, not an
+					// edit of its own -- and `get().document` here is still the pre-add document,
+					// so recording it would make Ctrl+Z jump back past the import.
+					if (await get().saveDocument(next, { history: false })) document = parseDocument(next);
 				}
 				// success:false just means no camera was found for this asset —
 				// the normal case for a plain imported video. Nothing to surface.
@@ -239,7 +275,14 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 		});
 	},
 
-	async saveDocument(document) {
+	async saveDocument(document, opts) {
+		// Snapshot BEFORE the await, while `get().document` is still the pre-edit one.
+		// This is where undo history actually comes from: the editor writes through
+		// `saveDocument` for every user edit -- add a region, delete one, rename the
+		// project, every timeline op -- and `setDocument` is reserved for the handful
+		// of live/optimistic paths. Recording only in `setDocument` left `past` empty
+		// for everything the user does, so Ctrl+Z was a no-op (#433).
+		recordHistory(get().document, document, opts);
 		try {
 			const result = await nativeBridgeClient.aiEdition.save(document);
 			if (!result.success || !result.document) {
@@ -268,15 +311,8 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 		}
 	},
 
-	setDocument(document) {
-		const prev = get().document;
-		if (prev && prev !== document) {
-			// ponytail: push snapshot to undo history. Defer import to avoid
-			// pulling the undo module into the store at module-load time.
-			void import("./undo").then(({ pushHistory }) => {
-				pushHistory({ projectId: prev.project.id, doc: structuredClone(prev) });
-			});
-		}
+	setDocument(document, opts) {
+		recordHistory(get().document, document, opts);
 		set({
 			document,
 			revision: get().revision + 1,

--- a/src/lib/ai-edition/store/projectStore.ts
+++ b/src/lib/ai-edition/store/projectStore.ts
@@ -111,6 +111,11 @@ export interface ProjectState {
 	setCurrentTime: (sec: number) => void;
 	setPlaying: (playing: boolean) => void;
 	markClean: () => void;
+	/**
+	 * Drop the open project. Clears the undo history and supersedes every in-flight
+	 * write, the same as `loadProject` and `createProject` — this is a project
+	 * switch too, just one with nothing on the other side of it.
+	 */
 	clear: () => void;
 }
 
@@ -413,6 +418,21 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 	},
 
 	clear() {
+		// The epoch bump inside `clearHistory` is the load-bearing half, not the stack
+		// drop. `clear()`'s one production caller deletes the project that is open
+		// (`NewEditorShell`), and a background save issued a moment earlier -- a
+		// transcript, a duration probe, a dimension backfill -- was still in flight. On
+		// resolving it installed its document and set `dirty: false, lastSavedAt: now`,
+		// so the editor that had just shown the empty state and toasted "Project
+		// deleted" put the deleted project's document back on screen with
+		// `projectId: null`, claiming it was freshly saved. Superseding those writes is
+		// exactly what this moment means.
+		//
+		// Dropping the stacks is hygiene by comparison: `undo` already refuses a
+		// snapshot whose `projectId` does not match the store's, and after this `set`
+		// there is no `projectId` at all -- so a stale stack could only leak up to
+		// MAX_HISTORY cloned documents until the next project load, never restore one.
+		clearHistory();
 		set({
 			projectId: null,
 			document: null,

--- a/src/lib/ai-edition/store/transcriptionStore.ts
+++ b/src/lib/ai-edition/store/transcriptionStore.ts
@@ -318,21 +318,25 @@ async function persistPermanentFailure(
 	// Best-effort bookkeeping: `saveDocument` reports its own failures and resolves
 	// false rather than throwing, and a note on the asset is not worth a second
 	// message on top of the one the user already got.
-	const persisted = await project.saveDocument({
-		...doc,
-		assets: doc.assets.map((a) =>
-			a.id === assetId
-				? {
-						...a,
-						transcriptionFailure: {
-							kind,
-							message: failure.message,
-							at: new Date().toISOString(),
-						},
-					}
-				: a,
-		),
-	});
+	const persisted = await project.saveDocument(
+		{
+			...doc,
+			assets: doc.assets.map((a) =>
+				a.id === assetId
+					? {
+							...a,
+							transcriptionFailure: {
+								kind,
+								message: failure.message,
+								at: new Date().toISOString(),
+							},
+						}
+					: a,
+			),
+		},
+		// Bookkeeping, not an edit — it must not become an undo step.
+		{ history: false },
+	);
 	if (!persisted) {
 		console.warn("[transcription] could not persist the failure on the asset");
 	}
@@ -397,6 +401,9 @@ async function runJob(assetId: string, job: TranscriptionJob): Promise<void> {
 		}
 		// One save: the transcript, and (on a successful retry) the removal of
 		// the verdict remembered on the asset.
+		// `history: false`: a transcript landing from a background job is not an edit
+		// the user made, and making it the target of the next Ctrl+Z would both surprise
+		// them and throw the transcript away.
 		await useProjectStore.getState().saveDocument(
 			withTranscript(
 				{
@@ -407,6 +414,7 @@ async function runJob(assetId: string, job: TranscriptionJob): Promise<void> {
 				},
 				transcript,
 			),
+			{ history: false },
 		);
 		dropJob(assetId, runId);
 		if (job.manual) toast.success(toastText("mediaStage.transcriptReady"));

--- a/src/lib/ai-edition/store/undo.modalGuard.test.tsx
+++ b/src/lib/ai-edition/store/undo.modalGuard.test.tsx
@@ -10,7 +10,8 @@ import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type AxcutDocument, axcutSchemaVersion } from "../schema";
 import { useProjectStore } from "./projectStore";
-import { clearHistory, pushHistory, useUndoRedoShortcuts } from "./undo";
+import { clearHistory, useUndoRedoShortcuts } from "./undo";
+import { pushHistory } from "./undoStack";
 
 function doc(title: string): AxcutDocument {
 	return {

--- a/src/lib/ai-edition/store/undo.test.ts
+++ b/src/lib/ai-edition/store/undo.test.ts
@@ -11,7 +11,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createEmptyDocument } from "../schema";
 import { useProjectStore } from "./projectStore";
 import { clearHistory, redo, undo, useUndoRedoShortcuts } from "./undo";
-import { future, past } from "./undoStack";
+import { future, past, pushHistory } from "./undoStack";
 
 const saveMock = vi.hoisted(() => vi.fn());
 
@@ -348,7 +348,7 @@ describe("the Edit menu's undo/redo route", () => {
 		// two tests either side of this one passed without a guard.
 		const persist = vi.fn();
 		const { result } = renderHook(() => useUndoRedoShortcuts(persist));
-		past.push({ projectId: PROJECT_ID, doc: titled("Older") });
+		pushHistory({ projectId: PROJECT_ID, doc: titled("Older") });
 
 		const modal = window.document.createElement("div");
 		modal.setAttribute("aria-modal", "true");
@@ -380,7 +380,7 @@ describe("the Edit menu's undo/redo route", () => {
 		// still good for.
 		const persist = vi.fn();
 		const { result } = renderHook(() => useUndoRedoShortcuts(persist));
-		past.push({ projectId: PROJECT_ID, doc: titled("Older") });
+		pushHistory({ projectId: PROJECT_ID, doc: titled("Older") });
 
 		const input = window.document.createElement("input");
 		window.document.body.appendChild(input);

--- a/src/lib/ai-edition/store/undo.test.ts
+++ b/src/lib/ai-edition/store/undo.test.ts
@@ -6,10 +6,11 @@
 // editor actually makes (add a region, delete one, rename the project) goes
 // through `saveDocument`.
 
+import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createEmptyDocument } from "../schema";
 import { useProjectStore } from "./projectStore";
-import { clearHistory, redo, undo } from "./undo";
+import { clearHistory, redo, undo, useUndoRedoShortcuts } from "./undo";
 import { future, past } from "./undoStack";
 
 const saveMock = vi.hoisted(() => vi.fn());
@@ -45,7 +46,7 @@ describe("undo/redo", () => {
 	it("records a saveDocument edit and reverts it", async () => {
 		// The path every region add / delete / rename takes. It recorded nothing
 		// before this fix, so `past` stayed empty and `undo()` returned false.
-		await useProjectStore.getState().saveDocument(titled("Renamed"));
+		await useProjectStore.getState().saveDocument(titled("Renamed"), { history: true });
 		expect(currentTitle()).toBe("Renamed");
 		expect(past).toHaveLength(1);
 
@@ -55,7 +56,7 @@ describe("undo/redo", () => {
 
 	it("reapplies the edit on redo", async () => {
 		const renamed = titled("Renamed");
-		await useProjectStore.getState().saveDocument(renamed);
+		await useProjectStore.getState().saveDocument(renamed, { history: true });
 
 		expect(undo()).toBe(true);
 		expect(currentTitle()).toBe("Original");
@@ -69,7 +70,7 @@ describe("undo/redo", () => {
 		// after the re-entrancy guard had already been re-armed. The pre-undo document
 		// landed on `past` and `pushHistory` cleared `future`, so one Ctrl+Z turned the
 		// history into an A/B toggle with redo permanently gone.
-		await useProjectStore.getState().saveDocument(titled("Renamed"));
+		await useProjectStore.getState().saveDocument(titled("Renamed"), { history: true });
 		expect(past).toHaveLength(1);
 
 		expect(undo()).toBe(true);
@@ -83,8 +84,8 @@ describe("undo/redo", () => {
 	it("walks back more than one level", async () => {
 		// The microtask race silently capped this at one: the second Ctrl+Z replayed
 		// the document the first had just pushed back on, so undo oscillated.
-		await useProjectStore.getState().saveDocument(titled("Second"));
-		await useProjectStore.getState().saveDocument(titled("Third"));
+		await useProjectStore.getState().saveDocument(titled("Second"), { history: true });
+		await useProjectStore.getState().saveDocument(titled("Third"), { history: true });
 		expect(currentTitle()).toBe("Third");
 
 		expect(undo()).toBe(true);
@@ -114,7 +115,7 @@ describe("undo/redo", () => {
 		// What `NewEditorShell` does in `useUndoRedoShortcuts`'s callback. Without
 		// `history: false` there, the persist re-records the restored document and
 		// wipes the redo the undo just created.
-		await useProjectStore.getState().saveDocument(titled("Renamed"));
+		await useProjectStore.getState().saveDocument(titled("Renamed"), { history: true });
 		expect(undo()).toBe(true);
 
 		const restored = useProjectStore.getState().document;
@@ -127,18 +128,18 @@ describe("undo/redo", () => {
 	});
 
 	it("drops the redo stack once a new edit lands on an undone document", async () => {
-		await useProjectStore.getState().saveDocument(titled("Renamed"));
+		await useProjectStore.getState().saveDocument(titled("Renamed"), { history: true });
 		expect(undo()).toBe(true);
 		expect(future).toHaveLength(1);
 
-		await useProjectStore.getState().saveDocument(titled("Different branch"));
+		await useProjectStore.getState().saveDocument(titled("Different branch"), { history: true });
 
 		expect(future).toHaveLength(0);
 		expect(redo()).toBe(false);
 	});
 
 	it("refuses to restore a snapshot from another project", async () => {
-		await useProjectStore.getState().saveDocument(titled("Renamed"));
+		await useProjectStore.getState().saveDocument(titled("Renamed"), { history: true });
 		useProjectStore.setState({ projectId: "project_2" });
 
 		expect(undo()).toBe(false);
@@ -147,7 +148,7 @@ describe("undo/redo", () => {
 	});
 
 	it("marks the document dirty so the restore can be persisted", async () => {
-		await useProjectStore.getState().saveDocument(titled("Renamed"));
+		await useProjectStore.getState().saveDocument(titled("Renamed"), { history: true });
 		expect(useProjectStore.getState().dirty).toBe(false);
 
 		const revisionBefore = useProjectStore.getState().revision;
@@ -156,5 +157,127 @@ describe("undo/redo", () => {
 		expect(useProjectStore.getState().dirty).toBe(true);
 		// Consumers repaint off `document`; `revision` is what the agent-apply guard reads.
 		expect(useProjectStore.getState().revision).toBe(revisionBefore + 1);
+	});
+
+	describe("a write that failed", () => {
+		// `saveDocument` resolves false on a handled failure -- a read-only project --
+		// and every caller reads that as "the edit did not happen". Recording history
+		// ABOVE the await recorded it anyway, and nothing ever took it back off.
+
+		it("records no undo step, so Ctrl+Z is not left doing nothing", async () => {
+			// The exact symptom #433 was filed for, re-created by the first fix for it:
+			// `past` held a snapshot identical to the document on screen, so the next
+			// Ctrl+Z restored what was already there.
+			saveMock.mockResolvedValueOnce({ success: false, error: "EACCES" });
+
+			expect(
+				await useProjectStore.getState().saveDocument(titled("Renamed"), { history: true }),
+			).toBe(false);
+
+			expect(currentTitle()).toBe("Original");
+			expect(past).toHaveLength(0);
+			expect(undo()).toBe(false);
+		});
+
+		it("leaves the redo stack alone", async () => {
+			// Worse than a wasted step: `pushHistory` clears `future` on its way past, so
+			// a failed write destroyed a redo the user had already earned.
+			await useProjectStore.getState().saveDocument(titled("Renamed"), { history: true });
+			expect(undo()).toBe(true);
+			expect(future).toHaveLength(1);
+
+			saveMock.mockResolvedValueOnce({ success: false, error: "EACCES" });
+			expect(
+				await useProjectStore.getState().saveDocument(titled("Rejected"), { history: true }),
+			).toBe(false);
+
+			expect(future).toHaveLength(1);
+			expect(redo()).toBe(true);
+			expect(currentTitle()).toBe("Renamed");
+		});
+
+		it("records the step once a retry lands", async () => {
+			// Not recording is only correct if the record still happens when the write
+			// eventually succeeds -- otherwise the fix trades one dead Ctrl+Z for another.
+			saveMock.mockResolvedValueOnce({ success: false, error: "EACCES" });
+			await useProjectStore.getState().saveDocument(titled("Renamed"), { history: true });
+
+			await useProjectStore.getState().saveDocument(titled("Renamed"), { history: true });
+
+			expect(currentTitle()).toBe("Renamed");
+			expect(past).toHaveLength(1);
+			expect(undo()).toBe(true);
+			expect(currentTitle()).toBe("Original");
+		});
+	});
+
+	it("records the pre-drag document a commit names, not the one on screen", async () => {
+		// `historyBase`. A live drag writes every pointermove into the store with
+		// `history: false`, so by commit time the store's own "previous" document is the
+		// dragged one -- recording that would leave the gesture un-undoable.
+		const dragged = titled("Dragged");
+		const preDrag = useProjectStore.getState().document;
+		useProjectStore.getState().setDocument(dragged, { history: false });
+		expect(past).toHaveLength(0);
+
+		await useProjectStore.getState().saveDocument(dragged, { history: true, historyBase: preDrag });
+
+		expect(past).toHaveLength(1);
+		expect(undo()).toBe(true);
+		expect(currentTitle()).toBe("Original");
+	});
+});
+
+describe("the Edit menu's undo/redo route", () => {
+	// On macOS the native menu is the ONLY path Cmd+Z has to the renderer: AppKit
+	// matches the menu item's key equivalent before the key event reaches the web
+	// contents, so the keydown listener never runs. `electron/main.ts` therefore
+	// forwards `menu-undo` / `menu-redo` over IPC, and `NewEditorShell` wires them to
+	// these handlers. The Electron half is pinned in `electron/edit-menu.test.ts`.
+	beforeEach(() => {
+		useProjectStore.getState().clear();
+		clearHistory();
+		saveMock.mockReset();
+		saveMock.mockImplementation(async (document: unknown) => ({ success: true, document }));
+		useProjectStore.setState({ projectId: PROJECT_ID, document: titled("Original") });
+		window.document.body.innerHTML = "";
+	});
+
+	it("undoes the document and persists the restore", async () => {
+		const persist = vi.fn();
+		const { result } = renderHook(() => useUndoRedoShortcuts(persist));
+		await useProjectStore.getState().saveDocument(titled("Renamed"), { history: true });
+
+		act(() => {
+			result.current.runUndo();
+		});
+
+		expect(currentTitle()).toBe("Original");
+		expect(persist).toHaveBeenCalledOnce();
+
+		act(() => {
+			result.current.runRedo();
+		});
+		expect(currentTitle()).toBe("Renamed");
+	});
+
+	it("leaves a focused text field to the browser's own text undo", () => {
+		// Same rule the keydown path applies, and the one thing the `undo` role was
+		// still good for.
+		const persist = vi.fn();
+		const { result } = renderHook(() => useUndoRedoShortcuts(persist));
+		past.push({ projectId: PROJECT_ID, doc: titled("Older") });
+
+		const input = window.document.createElement("input");
+		window.document.body.appendChild(input);
+		input.focus();
+
+		act(() => {
+			result.current.runUndo();
+		});
+
+		expect(currentTitle()).toBe("Original");
+		expect(past).toHaveLength(1);
+		expect(persist).not.toHaveBeenCalled();
 	});
 });

--- a/src/lib/ai-edition/store/undo.test.ts
+++ b/src/lib/ai-edition/store/undo.test.ts
@@ -211,6 +211,84 @@ describe("undo/redo", () => {
 		});
 	});
 
+	describe("a save that was already in flight when Ctrl+Z was pressed", () => {
+		// `saveDocument` records BELOW its await, which is what makes a failed write
+		// record nothing -- and what let a save that started before the undo land on top
+		// of it. Its result installed the document the user had just asked to leave, and
+		// its record pushed a state FORWARD of the one they returned to while clearing
+		// `future`: the undo was visually reverted and the redo was gone.
+		//
+		// The undo wins. The write is dropped -- store and history both -- and the undo's
+		// own persist, issued right behind it, is what puts the restored document back
+		// over the bytes already on disk.
+
+		/** A save the test holds open, so an undo can happen underneath it. */
+		function heldSave() {
+			let release: (() => void) | undefined;
+			saveMock.mockImplementationOnce(async (document: unknown) => {
+				await new Promise<void>((resolve) => {
+					release = resolve;
+				});
+				return { success: true, document };
+			});
+			return () => release?.();
+		}
+
+		it("does not put its document back on screen", async () => {
+			const release = heldSave();
+			const inFlight = useProjectStore.getState().saveDocument(titled("In flight"), {
+				history: true,
+			});
+
+			expect(undo()).toBe(false); // nothing recorded yet -- the save has not landed
+			await useProjectStore.getState().saveDocument(titled("Landed"), { history: true });
+			expect(undo()).toBe(true);
+			expect(currentTitle()).toBe("Original");
+
+			release();
+			expect(await inFlight).toBe(false);
+
+			expect(currentTitle()).toBe("Original");
+		});
+
+		it("does not record a step forward of the one the user returned to", async () => {
+			await useProjectStore.getState().saveDocument(titled("Second"), { history: true });
+
+			const release = heldSave();
+			const inFlight = useProjectStore.getState().saveDocument(titled("Third"), { history: true });
+			expect(undo()).toBe(true);
+			expect(currentTitle()).toBe("Original");
+			expect(past).toHaveLength(0);
+			expect(future).toHaveLength(1);
+
+			release();
+			await inFlight;
+
+			// `past` held "Second" here, which is FORWARD of "Original" -- Ctrl+Z would have
+			// walked the user the wrong way -- and `pushHistory` had wiped the redo.
+			expect(past).toHaveLength(0);
+			expect(future).toHaveLength(1);
+			expect(redo()).toBe(true);
+			expect(currentTitle()).toBe("Second");
+		});
+
+		it("leaves the document dirty, so the restore still reaches disk", async () => {
+			const release = heldSave();
+			const inFlight = useProjectStore.getState().saveDocument(titled("In flight"), {
+				history: true,
+			});
+			await useProjectStore.getState().saveDocument(titled("Landed"), { history: true });
+			expect(undo()).toBe(true);
+
+			release();
+			await inFlight;
+
+			// A dropped write must not claim the document is on disk: it is the undo's
+			// document that is in memory, and only `onAfter` puts that one on disk.
+			expect(useProjectStore.getState().dirty).toBe(true);
+		});
+	});
+
 	it("records the pre-drag document a commit names, not the one on screen", async () => {
 		// `historyBase`. A live drag writes every pointermove into the store with
 		// `history: false`, so by commit time the store's own "previous" document is the
@@ -259,6 +337,42 @@ describe("the Edit menu's undo/redo route", () => {
 			result.current.runRedo();
 		});
 		expect(currentTitle()).toBe("Renamed");
+	});
+
+	it("keeps its hands off the document while a modal is open", () => {
+		// #434's bug, on the route this branch added. A modal's controls are buttons, so
+		// the text-field check waves them straight through -- and on macOS this menu route
+		// is the ONLY path Cmd+Z has, with no keydown handler upstream to stop it, so
+		// undo rewrote the document under an open Export / Edit clip / unsaved-changes
+		// dialog. The `beforeEach` above empties `document.body`, which is exactly why the
+		// two tests either side of this one passed without a guard.
+		const persist = vi.fn();
+		const { result } = renderHook(() => useUndoRedoShortcuts(persist));
+		past.push({ projectId: PROJECT_ID, doc: titled("Older") });
+
+		const modal = window.document.createElement("div");
+		modal.setAttribute("aria-modal", "true");
+		window.document.body.appendChild(modal);
+
+		act(() => {
+			result.current.runUndo();
+		});
+		expect(currentTitle()).toBe("Original");
+		expect(past).toHaveLength(1);
+
+		act(() => {
+			result.current.runRedo();
+		});
+		expect(currentTitle()).toBe("Original");
+		expect(future).toHaveLength(0);
+		expect(persist).not.toHaveBeenCalled();
+
+		// And it comes back the moment the modal closes.
+		modal.remove();
+		act(() => {
+			result.current.runUndo();
+		});
+		expect(currentTitle()).toBe("Older");
 	});
 
 	it("leaves a focused text field to the browser's own text undo", () => {

--- a/src/lib/ai-edition/store/undo.test.ts
+++ b/src/lib/ai-edition/store/undo.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+//
+// Regression cover for #433: undo/redo silently did nothing. `undo.ts` had no
+// test at all, which is exactly why CI stayed green while Ctrl+Z was dead —
+// the history stack was only ever written by `setDocument`, and every edit the
+// editor actually makes (add a region, delete one, rename the project) goes
+// through `saveDocument`.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmptyDocument } from "../schema";
+import { useProjectStore } from "./projectStore";
+import { clearHistory, redo, undo } from "./undo";
+import { future, past } from "./undoStack";
+
+const saveMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/native/client", () => ({
+	nativeBridgeClient: {
+		aiEdition: { save: saveMock },
+	},
+}));
+
+const PROJECT_ID = "project_1";
+
+function titled(title: string) {
+	return createEmptyDocument({ projectId: PROJECT_ID, title });
+}
+
+function currentTitle(): string | undefined {
+	return useProjectStore.getState().document?.project.title;
+}
+
+describe("undo/redo", () => {
+	beforeEach(() => {
+		useProjectStore.getState().clear();
+		clearHistory();
+		saveMock.mockReset();
+		// The bridge hands the document back; `saveDocument` re-parses what it returns,
+		// so the store ends up holding a structurally equal but distinct object — same
+		// as in the app.
+		saveMock.mockImplementation(async (document: unknown) => ({ success: true, document }));
+		useProjectStore.setState({ projectId: PROJECT_ID, document: titled("Original") });
+	});
+
+	it("records a saveDocument edit and reverts it", async () => {
+		// The path every region add / delete / rename takes. It recorded nothing
+		// before this fix, so `past` stayed empty and `undo()` returned false.
+		await useProjectStore.getState().saveDocument(titled("Renamed"));
+		expect(currentTitle()).toBe("Renamed");
+		expect(past).toHaveLength(1);
+
+		expect(undo()).toBe(true);
+		expect(currentTitle()).toBe("Original");
+	});
+
+	it("reapplies the edit on redo", async () => {
+		const renamed = titled("Renamed");
+		await useProjectStore.getState().saveDocument(renamed);
+
+		expect(undo()).toBe(true);
+		expect(currentTitle()).toBe("Original");
+		expect(redo()).toBe(true);
+		expect(currentTitle()).toBe("Renamed");
+	});
+
+	it("does not record the undo's own write as a new edit", async () => {
+		// The bug that made redo unreachable: the restore used to go back through
+		// `setDocument`, whose deferred `import("./undo")` pushed in a later microtask —
+		// after the re-entrancy guard had already been re-armed. The pre-undo document
+		// landed on `past` and `pushHistory` cleared `future`, so one Ctrl+Z turned the
+		// history into an A/B toggle with redo permanently gone.
+		await useProjectStore.getState().saveDocument(titled("Renamed"));
+		expect(past).toHaveLength(1);
+
+		expect(undo()).toBe(true);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(past).toHaveLength(0);
+		expect(future).toHaveLength(1);
+	});
+
+	it("walks back more than one level", async () => {
+		// The microtask race silently capped this at one: the second Ctrl+Z replayed
+		// the document the first had just pushed back on, so undo oscillated.
+		await useProjectStore.getState().saveDocument(titled("Second"));
+		await useProjectStore.getState().saveDocument(titled("Third"));
+		expect(currentTitle()).toBe("Third");
+
+		expect(undo()).toBe(true);
+		expect(currentTitle()).toBe("Second");
+		expect(undo()).toBe(true);
+		expect(currentTitle()).toBe("Original");
+		expect(undo()).toBe(false);
+
+		expect(redo()).toBe(true);
+		expect(currentTitle()).toBe("Second");
+		expect(redo()).toBe(true);
+		expect(currentTitle()).toBe("Third");
+	});
+
+	it("skips history for writes the user did not make", async () => {
+		// Probe backfills, background transcripts and the persist an undo itself
+		// triggers all opt out — a Ctrl+Z that reverted one of those would either do
+		// nothing visible or throw the transcript away.
+		await useProjectStore.getState().saveDocument(titled("Backfilled"), { history: false });
+
+		expect(past).toHaveLength(0);
+		expect(undo()).toBe(false);
+		expect(currentTitle()).toBe("Backfilled");
+	});
+
+	it("keeps the redo entry when the restored document is persisted", async () => {
+		// What `NewEditorShell` does in `useUndoRedoShortcuts`'s callback. Without
+		// `history: false` there, the persist re-records the restored document and
+		// wipes the redo the undo just created.
+		await useProjectStore.getState().saveDocument(titled("Renamed"));
+		expect(undo()).toBe(true);
+
+		const restored = useProjectStore.getState().document;
+		if (!restored) throw new Error("no document to persist");
+		await useProjectStore.getState().saveDocument(restored, { history: false });
+
+		expect(future).toHaveLength(1);
+		expect(redo()).toBe(true);
+		expect(currentTitle()).toBe("Renamed");
+	});
+
+	it("drops the redo stack once a new edit lands on an undone document", async () => {
+		await useProjectStore.getState().saveDocument(titled("Renamed"));
+		expect(undo()).toBe(true);
+		expect(future).toHaveLength(1);
+
+		await useProjectStore.getState().saveDocument(titled("Different branch"));
+
+		expect(future).toHaveLength(0);
+		expect(redo()).toBe(false);
+	});
+
+	it("refuses to restore a snapshot from another project", async () => {
+		await useProjectStore.getState().saveDocument(titled("Renamed"));
+		useProjectStore.setState({ projectId: "project_2" });
+
+		expect(undo()).toBe(false);
+		expect(past).toHaveLength(0);
+		expect(future).toHaveLength(0);
+	});
+
+	it("marks the document dirty so the restore can be persisted", async () => {
+		await useProjectStore.getState().saveDocument(titled("Renamed"));
+		expect(useProjectStore.getState().dirty).toBe(false);
+
+		const revisionBefore = useProjectStore.getState().revision;
+		expect(undo()).toBe(true);
+
+		expect(useProjectStore.getState().dirty).toBe(true);
+		// Consumers repaint off `document`; `revision` is what the agent-apply guard reads.
+		expect(useProjectStore.getState().revision).toBe(revisionBefore + 1);
+	});
+});

--- a/src/lib/ai-edition/store/undo.ts
+++ b/src/lib/ai-edition/store/undo.ts
@@ -15,7 +15,14 @@ import { useCallback, useEffect, useRef } from "react";
 import { isModalOpen } from "../modalGuard";
 import type { AxcutDocument } from "../schema";
 import { useProjectStore } from "./projectStore";
-import { clearHistory, future, past, supersedeInFlightWrites } from "./undoStack";
+import {
+	clearHistory,
+	popFuture,
+	popPast,
+	pushFuture,
+	pushPast,
+	supersedeInFlightWrites,
+} from "./undoStack";
 
 export { clearHistory } from "./undoStack";
 
@@ -36,7 +43,7 @@ function restore(doc: unknown) {
 }
 
 export function undo(): boolean {
-	const prev = past.pop();
+	const prev = popPast();
 	if (!prev) return false;
 	const state = useProjectStore.getState();
 	if (!state.projectId || state.projectId !== prev.projectId) {
@@ -44,13 +51,13 @@ export function undo(): boolean {
 		return false;
 	}
 	const doc = state.document;
-	if (doc) future.push({ projectId: prev.projectId, doc: structuredClone(doc) });
+	if (doc) pushFuture({ projectId: prev.projectId, doc: structuredClone(doc) });
 	restore(prev.doc);
 	return true;
 }
 
 export function redo(): boolean {
-	const next = future.pop();
+	const next = popFuture();
 	if (!next) return false;
 	const state = useProjectStore.getState();
 	if (!state.projectId || state.projectId !== next.projectId) {
@@ -58,7 +65,7 @@ export function redo(): boolean {
 		return false;
 	}
 	const doc = state.document;
-	if (doc) past.push({ projectId: doc.project.id, doc: structuredClone(doc) });
+	if (doc) pushPast({ projectId: doc.project.id, doc: structuredClone(doc) });
 	restore(next.doc);
 	return true;
 }

--- a/src/lib/ai-edition/store/undo.ts
+++ b/src/lib/ai-edition/store/undo.ts
@@ -1,31 +1,33 @@
-// Lightweight undo/redo for the project document. The store fires
-// `documentChanged` whenever `setDocument` is called; subscribers record
-// snapshots up to a bounded history. Cmd+Z / Cmd+Shift+Z use the snapshot
-// stack to roll back / roll forward. Designed to be small and side-effect
-// free so it works in any renderer.
+// Lightweight undo/redo for the project document. Every write that goes through
+// `projectStore`'s `saveDocument` / `setDocument` records the outgoing document
+// on the stack in `undoStack.ts` (callers opt out with `{ history: false }` for
+// background writes). Ctrl+Z / Ctrl+Shift+Z / Ctrl+Y walk that stack.
+//
+// The restore writes `useProjectStore.setState` DIRECTLY rather than calling
+// back into `setDocument`, which is what makes redo work: routing it through a
+// recording write meant an undo re-recorded the document it had just replaced
+// and cleared `future` on the way past, so redo was gone before the user could
+// reach for it and Ctrl+Z degraded into an A/B toggle. Writing the state is also
+// all a repaint needs — the timeline, preview and shell all subscribe to
+// `s.document`.
 
 import { useEffect, useRef } from "react";
 import { isModalOpen } from "../modalGuard";
+import type { AxcutDocument } from "../schema";
 import { useProjectStore } from "./projectStore";
+import { clearHistory, future, past } from "./undoStack";
 
-type Snapshot = { projectId: string; doc: unknown };
+export { clearHistory, pushHistory } from "./undoStack";
 
-const MAX_HISTORY = 50;
-const past: Snapshot[] = [];
-const future: Snapshot[] = [];
-
-let enabled = true;
-
-export function pushHistory(snapshot: Snapshot) {
-	if (!enabled) return;
-	past.push(snapshot);
-	if (past.length > MAX_HISTORY) past.shift();
-	future.length = 0;
-}
-
-export function clearHistory() {
-	past.length = 0;
-	future.length = 0;
+/** Put a snapshot back on screen without recording it as a new edit. `dirty` is
+ *  set because the document on disk is no longer the one in memory — the caller
+ *  of `useUndoRedoShortcuts` persists it. */
+function restore(doc: unknown) {
+	useProjectStore.setState((state) => ({
+		document: doc as AxcutDocument,
+		revision: state.revision + 1,
+		dirty: true,
+	}));
 }
 
 export function undo(): boolean {
@@ -38,9 +40,7 @@ export function undo(): boolean {
 	}
 	const doc = state.document;
 	if (doc) future.push({ projectId: prev.projectId, doc: structuredClone(doc) });
-	enabled = false;
-	state.setDocument(prev.doc as never);
-	enabled = true;
+	restore(prev.doc);
 	return true;
 }
 
@@ -54,9 +54,7 @@ export function redo(): boolean {
 	}
 	const doc = state.document;
 	if (doc) past.push({ projectId: doc.project.id, doc: structuredClone(doc) });
-	enabled = false;
-	state.setDocument(next.doc as never);
-	enabled = true;
+	restore(next.doc);
 	return true;
 }
 
@@ -82,7 +80,9 @@ export function useUndoRedoShortcuts(onAfter: () => void) {
 				if (redo()) onAfterRef.current();
 				return;
 			}
-			if (ctrl && e.key === "z") {
+			// `toLowerCase()`, like the two branches above: with Caps Lock on the browser
+			// reports "Z", and the bare `=== "z"` here fell through to nothing at all.
+			if (ctrl && e.key.toLowerCase() === "z") {
 				e.preventDefault();
 				if (undo()) onAfterRef.current();
 				return;

--- a/src/lib/ai-edition/store/undo.ts
+++ b/src/lib/ai-edition/store/undo.ts
@@ -11,7 +11,7 @@
 // all a repaint needs — the timeline, preview and shell all subscribe to
 // `s.document`.
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { isModalOpen } from "../modalGuard";
 import type { AxcutDocument } from "../schema";
 import { useProjectStore } from "./projectStore";
@@ -58,13 +58,36 @@ export function redo(): boolean {
 	return true;
 }
 
-export function useUndoRedoShortcuts(onAfter: () => void) {
+/**
+ * Whether the document undo must keep its hands off: inside a text field the
+ * browser's own text undo is the one the user means. The keydown path checks the
+ * event target, the menu path checks `activeElement` — same rule, two entry
+ * points, so it lives in one function.
+ */
+function isTextEditingTarget(node: EventTarget | null): boolean {
+	if (node instanceof HTMLTextAreaElement || node instanceof HTMLInputElement) return true;
+	return node instanceof HTMLElement && node.isContentEditable;
+}
+
+export interface UndoRedoHandlers {
+	/**
+	 * Undo, applying the same text-field rule the keyboard path applies.
+	 *
+	 * Wired to the native Edit menu, which on macOS is the ONLY route Cmd+Z has:
+	 * AppKit matches the menu's key equivalent before the key event reaches the web
+	 * contents, so the keydown listener below never runs there. See
+	 * `electron/edit-menu.ts`.
+	 */
+	runUndo: () => void;
+	runRedo: () => void;
+}
+
+export function useUndoRedoShortcuts(onAfter: () => void): UndoRedoHandlers {
 	const onAfterRef = useRef(onAfter);
 	onAfterRef.current = onAfter;
 	useEffect(() => {
 		const onKey = (e: KeyboardEvent) => {
-			if (e.target instanceof HTMLTextAreaElement || e.target instanceof HTMLInputElement) return;
-			if (e.target instanceof HTMLElement && e.target.isContentEditable) return;
+			if (isTextEditingTarget(e.target)) return;
 			// `NewEditorShell` hands Ctrl+Z / Ctrl+Y to this listener instead of handling them,
 			// so its modal guard never runs for them: without this one, undo kept rewriting the
 			// document under every open modal, including the ones the shell does suppress.
@@ -91,4 +114,26 @@ export function useUndoRedoShortcuts(onAfter: () => void) {
 		window.addEventListener("keydown", onKey);
 		return () => window.removeEventListener("keydown", onKey);
 	}, []);
+
+	// `execCommand` is the only handle the renderer has on the browser's text undo,
+	// and it is what the `undo` menu ROLE reached through `webContents.undo()`. It is
+	// deprecated and absent under jsdom, hence the optional call: losing text undo in
+	// a field is survivable, a TypeError from a menu click is not.
+	const runUndo = useCallback(() => {
+		if (isTextEditingTarget(window.document.activeElement)) {
+			window.document.execCommand?.("undo");
+			return;
+		}
+		if (undo()) onAfterRef.current();
+	}, []);
+
+	const runRedo = useCallback(() => {
+		if (isTextEditingTarget(window.document.activeElement)) {
+			window.document.execCommand?.("redo");
+			return;
+		}
+		if (redo()) onAfterRef.current();
+	}, []);
+
+	return { runUndo, runRedo };
 }

--- a/src/lib/ai-edition/store/undo.ts
+++ b/src/lib/ai-edition/store/undo.ts
@@ -15,14 +15,19 @@ import { useCallback, useEffect, useRef } from "react";
 import { isModalOpen } from "../modalGuard";
 import type { AxcutDocument } from "../schema";
 import { useProjectStore } from "./projectStore";
-import { clearHistory, future, past } from "./undoStack";
+import { clearHistory, future, past, supersedeInFlightWrites } from "./undoStack";
 
-export { clearHistory, pushHistory } from "./undoStack";
+export { clearHistory } from "./undoStack";
 
 /** Put a snapshot back on screen without recording it as a new edit. `dirty` is
  *  set because the document on disk is no longer the one in memory — the caller
  *  of `useUndoRedoShortcuts` persists it. */
 function restore(doc: unknown) {
+	// Before the state write, so a save that resolves between here and the caller's
+	// persist cannot slip its result in. See `undoStack.ts`: a save already in flight
+	// when Ctrl+Z was pressed used to install its document over the restored one and
+	// push a FORWARD state onto `past`, wiping the redo the undo had just created.
+	supersedeInFlightWrites();
 	useProjectStore.setState((state) => ({
 		document: doc as AxcutDocument,
 		revision: state.revision + 1,
@@ -124,6 +129,13 @@ export function useUndoRedoShortcuts(onAfter: () => void): UndoRedoHandlers {
 			window.document.execCommand?.("undo");
 			return;
 		}
+		// AFTER the text-field check, so a rename dialog's input still gets the browser's
+		// own text undo. Before it, this route rewrote the DOCUMENT under an open modal:
+		// a modal's controls are buttons, so `isTextEditingTarget` waves them through, and
+		// on macOS the menu is the only path Cmd+Z has -- there is no keydown handler
+		// upstream of this one to stop it. See `../modalGuard`, and #434, which fixes the
+		// same hole on the keydown path.
+		if (isModalOpen()) return;
 		if (undo()) onAfterRef.current();
 	}, []);
 
@@ -132,6 +144,7 @@ export function useUndoRedoShortcuts(onAfter: () => void): UndoRedoHandlers {
 			window.document.execCommand?.("redo");
 			return;
 		}
+		if (isModalOpen()) return;
 		if (redo()) onAfterRef.current();
 	}, []);
 

--- a/src/lib/ai-edition/store/undoStack.ts
+++ b/src/lib/ai-edition/store/undoStack.ts
@@ -31,4 +31,34 @@ export function pushHistory(snapshot: Snapshot) {
 export function clearHistory() {
 	past.length = 0;
 	future.length = 0;
+	supersedeInFlightWrites();
+}
+
+// The write epoch. `saveDocument` reads it before its `await` and again after,
+// and throws its result away if it moved.
+//
+// Without it, a save that was ALREADY IN FLIGHT when the user pressed Ctrl+Z
+// landed on top of the undo: `saveDocument` records below the await, so it put
+// the pre-save document on `past` (which is FORWARD of where the user asked to
+// go) and cleared `future` on the way past, then installed its own document in
+// the store. The undo was visually reverted and redo was gone -- for a write the
+// user had superseded a moment earlier.
+//
+// Everything that replaces the document out from under an in-flight write bumps
+// it: `undo`, `redo` (both via `restore`), and `clearHistory`, which is a project
+// switch -- a save of the OLD project resolving after `loadProject` would
+// otherwise overwrite the new one.
+let writeEpoch = 0;
+
+/** The epoch a write should still belong to when it lands. */
+export function currentWriteEpoch(): number {
+	return writeEpoch;
+}
+
+/**
+ * Declare that the document on screen is no longer the one any in-flight write
+ * was building on, so those writes must not install their result.
+ */
+export function supersedeInFlightWrites() {
+	writeEpoch += 1;
 }

--- a/src/lib/ai-edition/store/undoStack.ts
+++ b/src/lib/ai-edition/store/undoStack.ts
@@ -16,25 +16,63 @@
 // keeps the audit in `documentWriteAudit.test.ts` honest: `recordHistory` in
 // `projectStore` is its only production caller, and a second import path would
 // be a second way to record history without saying so at the call site.
+//
+// The arrays themselves are module-private for the same reason. They used to be
+// exported as `Snapshot[]`, and `const` binds the reference, not the contents --
+// so `past.push(...)` from any importer was a second way to record history that
+// the audit could not see at all: it keys on the callee NAME, and the name there
+// is `push`. The exported `past` / `future` are `readonly` views, and every
+// mutation is a named function the audit can count call sites of.
 
 export type Snapshot = { projectId: string; doc: unknown };
 
 const MAX_HISTORY = 50;
 
-export const past: Snapshot[] = [];
-export const future: Snapshot[] = [];
+const pastStack: Snapshot[] = [];
+const futureStack: Snapshot[] = [];
+
+/** The undo stack, read-only. Mutate it through the functions below, which is
+ *  what makes `documentWriteAudit.test.ts` able to enumerate the writers. */
+export const past: readonly Snapshot[] = pastStack;
+/** The redo stack, on the same terms as `past`. */
+export const future: readonly Snapshot[] = futureStack;
 
 /** Record a document as the state to return to. Drops the redo stack: history
  *  branched the moment a new edit landed on top of an undone one. */
 export function pushHistory(snapshot: Snapshot) {
-	past.push(snapshot);
-	if (past.length > MAX_HISTORY) past.shift();
-	future.length = 0;
+	pastStack.push(snapshot);
+	if (pastStack.length > MAX_HISTORY) pastStack.shift();
+	futureStack.length = 0;
+}
+
+/**
+ * Put the document a REDO is replacing back on `past`, so the redo is itself
+ * undoable.
+ *
+ * Not `pushHistory`: that one clears `future`, which is right for a new edit
+ * (history branched) and wrong here, where the remaining redo steps are still
+ * ahead of the user and the entry being pushed is one they just walked past.
+ */
+export function pushPast(snapshot: Snapshot) {
+	pastStack.push(snapshot);
+}
+
+/** Put the document an UNDO is leaving on `future`, so redo can get back to it. */
+export function pushFuture(snapshot: Snapshot) {
+	futureStack.push(snapshot);
+}
+
+export function popPast(): Snapshot | undefined {
+	return pastStack.pop();
+}
+
+export function popFuture(): Snapshot | undefined {
+	return futureStack.pop();
 }
 
 export function clearHistory() {
-	past.length = 0;
-	future.length = 0;
+	pastStack.length = 0;
+	futureStack.length = 0;
 	supersedeInFlightWrites();
 }
 

--- a/src/lib/ai-edition/store/undoStack.ts
+++ b/src/lib/ai-edition/store/undoStack.ts
@@ -1,0 +1,34 @@
+// The undo/redo snapshot stacks, in their own module so `projectStore` can push
+// to them with a STATIC import.
+//
+// `setDocument` used to `void import("./undo").then(({ pushHistory }) => ...)`,
+// which put the push in a LATER microtask. `undo()` restored its snapshot inside
+// a synchronous `enabled = false` / `enabled = true` bracket, so by the time the
+// deferred push ran the guard was armed again: an undo's own write was recorded
+// as a fresh edit, `pushHistory` wiped `future`, and redo could never fire. The
+// import bought nothing either — `NewEditorShell` already pulls `undo.ts` into
+// the same chunk statically.
+//
+// This module deliberately imports nothing from the store, so `projectStore ->
+// undoStack` is a leaf edge and there is no cycle to reason about. `undo.ts`
+// re-exports `pushHistory` / `clearHistory` from here for existing callers.
+
+export type Snapshot = { projectId: string; doc: unknown };
+
+const MAX_HISTORY = 50;
+
+export const past: Snapshot[] = [];
+export const future: Snapshot[] = [];
+
+/** Record a document as the state to return to. Drops the redo stack: history
+ *  branched the moment a new edit landed on top of an undone one. */
+export function pushHistory(snapshot: Snapshot) {
+	past.push(snapshot);
+	if (past.length > MAX_HISTORY) past.shift();
+	future.length = 0;
+}
+
+export function clearHistory() {
+	past.length = 0;
+	future.length = 0;
+}

--- a/src/lib/ai-edition/store/undoStack.ts
+++ b/src/lib/ai-edition/store/undoStack.ts
@@ -11,7 +11,11 @@
 //
 // This module deliberately imports nothing from the store, so `projectStore ->
 // undoStack` is a leaf edge and there is no cycle to reason about. `undo.ts`
-// re-exports `pushHistory` / `clearHistory` from here for existing callers.
+// re-exports `clearHistory` from here for existing callers; `pushHistory` is NOT
+// re-exported -- import it from this module directly. Keeping it off `undo.ts`
+// keeps the audit in `documentWriteAudit.test.ts` honest: `recordHistory` in
+// `projectStore` is its only production caller, and a second import path would
+// be a second way to record history without saying so at the call site.
 
 export type Snapshot = { projectId: string; doc: unknown };
 

--- a/src/lib/ai-edition/store/useCaptions.test.ts
+++ b/src/lib/ai-edition/store/useCaptions.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+//
+// `useEditorSettings.test.ts`'s two cases, on the hook that shares its live/commit
+// split. Both hooks hold the pre-drag document in `liveBaseRef` until a commit
+// records it, both are driven by the same `SliderCell` — which fires `commit` from
+// a bare mouseup, with no `onChange` in front of it — and neither `set` empties
+// the refs, so a drag that never commits leaves a base behind for that click to
+// pick up.
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getCaptionSettings } from "../captions";
+import type { AxcutDocument } from "../schema";
+import { axcutSchemaVersion } from "../schema";
+import { useProjectStore } from "./projectStore";
+import { clearHistory, undo } from "./undo";
+import { past } from "./undoStack";
+import { useCaptions } from "./useCaptions";
+
+const bridgeMocks = vi.hoisted(() => ({
+	get: vi.fn(),
+	create: vi.fn(),
+	save: vi.fn(),
+	addAsset: vi.fn(),
+	removeAsset: vi.fn(),
+	listProjects: vi.fn(),
+}));
+
+vi.mock("@/native/client", () => ({
+	nativeBridgeClient: {
+		aiEdition: {
+			get: bridgeMocks.get,
+			create: bridgeMocks.create,
+			save: bridgeMocks.save,
+			addAsset: bridgeMocks.addAsset,
+			removeAsset: bridgeMocks.removeAsset,
+			listProjects: bridgeMocks.listProjects,
+		},
+	},
+}));
+
+const docA: AxcutDocument = {
+	schemaVersion: axcutSchemaVersion,
+	project: {
+		id: "proj_a",
+		title: "A",
+		createdAt: "2026-06-25T10:00:00.000Z",
+		updatedAt: "2026-06-25T10:00:00.000Z",
+		primaryAssetId: "asset_1",
+	},
+	assets: [
+		{
+			id: "asset_1",
+			kind: "video",
+			label: "screen.webm",
+			originalPath: "/tmp/screen.webm",
+			durationSec: 30,
+			video: { codec: "unknown", width: 1920, height: 1080, fps: 0 },
+			cameraTrack: null,
+		},
+	],
+	transcript: null,
+	transcripts: [],
+	timeline: {
+		clips: [],
+		gaps: [],
+		trimRanges: [],
+		muteRanges: [],
+		speedRanges: [],
+		captionRanges: [],
+	},
+	annotations: [],
+	zoomRanges: [],
+	legacyEditor: null,
+};
+
+const docB: AxcutDocument = {
+	...docA,
+	project: { ...docA.project, id: "proj_b", title: "B" },
+};
+
+/** `fontSize` of the document a snapshot holds. 48 is the untouched default, so
+ *  reading it back says "this is the pre-drag document" in one number. */
+const fontSizeOf = (doc: unknown) => getCaptionSettings(doc as AxcutDocument).fontSize;
+
+describe("useCaptions drag snapshots", () => {
+	beforeEach(() => {
+		useProjectStore.getState().clear();
+		clearHistory();
+		for (const mock of Object.values(bridgeMocks)) mock.mockReset();
+		bridgeMocks.save.mockImplementation(async (doc: AxcutDocument) => ({
+			success: true,
+			document: doc,
+		}));
+		useProjectStore.setState({
+			projectId: "proj_a",
+			document: docA,
+			revision: 1,
+			status: "ready",
+			error: null,
+		});
+	});
+
+	afterEach(() => {
+		clearHistory();
+		vi.clearAllMocks();
+	});
+
+	it("does not record a snapshot of the project the user left", async () => {
+		const { result, rerender } = renderHook(() => useCaptions());
+
+		act(() => result.current.setLive({ width: 60 }));
+
+		act(() => {
+			useProjectStore.setState({ projectId: "proj_b", document: docB });
+		});
+		rerender();
+
+		await act(async () => {
+			await result.current.set({ fontSize: 30 });
+		});
+		expect(past.map((s) => s.projectId)).toEqual(["proj_b"]);
+
+		await act(async () => {
+			await result.current.commit();
+		});
+
+		expect(past.map((s) => s.projectId)).toEqual(["proj_b"]);
+		// A foreign snapshot costs more than the one bogus step: `undo` answers a
+		// projectId that is not the store's by clearing the whole stack.
+		expect(undo()).toBe(true);
+		expect(fontSizeOf(useProjectStore.getState().document)).toBe(48);
+	});
+
+	it("does not hand a bare commit a base the edits since have already buried", async () => {
+		const { result } = renderHook(() => useCaptions());
+
+		act(() => result.current.setLive({ width: 60 }));
+
+		await act(async () => {
+			await result.current.set({ fontSize: 30 });
+		});
+		await act(async () => {
+			await result.current.set({ fontSize: 20 });
+		});
+		expect(past).toHaveLength(2);
+
+		await act(async () => {
+			await result.current.commit();
+		});
+
+		expect(past).toHaveLength(2);
+		expect(undo()).toBe(true);
+		expect(fontSizeOf(useProjectStore.getState().document)).toBe(30);
+	});
+
+	it("still records the pre-drag document when the drag does reach its commit", async () => {
+		const { result } = renderHook(() => useCaptions());
+
+		act(() => result.current.setLive({ fontSize: 60 }));
+		act(() => result.current.setLive({ fontSize: 72 }));
+		await act(async () => {
+			await result.current.commit();
+		});
+
+		expect(past).toHaveLength(1);
+		expect(undo()).toBe(true);
+		expect(fontSizeOf(useProjectStore.getState().document)).toBe(48);
+	});
+});

--- a/src/lib/ai-edition/store/useCaptions.ts
+++ b/src/lib/ai-edition/store/useCaptions.ts
@@ -4,7 +4,7 @@
 // writes only (for sliders), `commit` flushes. The document stays the single
 // source of truth — nothing is cached here.
 
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
 	type CaptionCue,
 	type CaptionSettings,
@@ -44,6 +44,7 @@ export interface UseCaptionsResult {
 
 export function useCaptions(): UseCaptionsResult {
 	const document = useProjectStore((s) => s.document);
+	const projectId = useProjectStore((s) => s.projectId);
 	const setDocument = useProjectStore((s) => s.setDocument);
 	const saveDocument = useProjectStore((s) => s.saveDocument);
 
@@ -81,6 +82,15 @@ export function useCaptions(): UseCaptionsResult {
 	const liveDocRef = useRef<AxcutDocument | null>(null);
 	const liveBaseRef = useRef<AxcutDocument | null>(null);
 
+	// The same release `useEditorSettings` does, for the same reason: a drag that never
+	// commits leaves these holding two whole documents for the lifetime of the hook
+	// instance. `commit` below is what keeps a stale one off the undo stack.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: projectId is the trigger, not a read — the body only clears refs.
+	useEffect(() => {
+		liveDocRef.current = null;
+		liveBaseRef.current = null;
+	}, [projectId]);
+
 	const setLive = useCallback(
 		(patch: CaptionSettingsPatch) => {
 			const doc = useProjectStore.getState().document;
@@ -96,7 +106,9 @@ export function useCaptions(): UseCaptionsResult {
 	const commit = useCallback(async () => {
 		const doc = useProjectStore.getState().document;
 		if (!doc) return;
-		const base = liveBaseRef.current;
+		// See `useEditorSettings.commit`: a base is only worth recording while the
+		// document on screen is still the one this hook's live writes produced.
+		const base = liveDocRef.current === doc ? liveBaseRef.current : null;
 		liveBaseRef.current = null;
 		liveDocRef.current = null;
 		await saveDocument(doc, { history: true, historyBase: base });

--- a/src/lib/ai-edition/store/useCaptions.ts
+++ b/src/lib/ai-edition/store/useCaptions.ts
@@ -4,7 +4,7 @@
 // writes only (for sliders), `commit` flushes. The document stays the single
 // source of truth — nothing is cached here.
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import {
 	type CaptionCue,
 	type CaptionSettings,
@@ -17,6 +17,7 @@ import {
 	putCaptionTranslation,
 	removeCaptionTranslation,
 } from "../captions";
+import type { AxcutDocument } from "../schema";
 import { useProjectStore } from "./projectStore";
 
 export interface UseCaptionsResult {
@@ -70,11 +71,18 @@ export function useCaptions(): UseCaptionsResult {
 		[setDocument, saveDocument],
 	);
 
+	// See `useEditorSettings.setLive`: one undo step per slider drag, not one per
+	// pointer move. `liveDocRef` holds what this hook last wrote, so only a write
+	// landing on someone else's document opens a new history entry.
+	const liveDocRef = useRef<AxcutDocument | null>(null);
+
 	const setLive = useCallback(
 		(patch: CaptionSettingsPatch) => {
 			const doc = useProjectStore.getState().document;
 			if (!doc) return;
-			setDocument(patchCaptionSettings(doc, patch));
+			const next = patchCaptionSettings(doc, patch);
+			setDocument(next, { history: liveDocRef.current !== doc });
+			liveDocRef.current = next;
 		},
 		[setDocument],
 	);

--- a/src/lib/ai-edition/store/useCaptions.ts
+++ b/src/lib/ai-edition/store/useCaptions.ts
@@ -65,23 +65,29 @@ export function useCaptions(): UseCaptionsResult {
 			const doc = useProjectStore.getState().document;
 			if (!doc) return;
 			const next = patchCaptionSettings(doc, patch);
-			setDocument(next);
-			await saveDocument(next);
+			// The optimistic write is not the edit — the save is. Only the one that can
+			// fail records, and it names `doc` as what Ctrl+Z returns to because by then
+			// the store already holds `next`.
+			setDocument(next, { history: false });
+			await saveDocument(next, { history: true, historyBase: doc });
 		},
 		[setDocument, saveDocument],
 	);
 
 	// See `useEditorSettings.setLive`: one undo step per slider drag, not one per
 	// pointer move. `liveDocRef` holds what this hook last wrote, so only a write
-	// landing on someone else's document opens a new history entry.
+	// landing on someone else's document opens a new history entry -- and that entry
+	// is `liveBaseRef`, handed to the commit rather than recorded on the spot.
 	const liveDocRef = useRef<AxcutDocument | null>(null);
+	const liveBaseRef = useRef<AxcutDocument | null>(null);
 
 	const setLive = useCallback(
 		(patch: CaptionSettingsPatch) => {
 			const doc = useProjectStore.getState().document;
 			if (!doc) return;
 			const next = patchCaptionSettings(doc, patch);
-			setDocument(next, { history: liveDocRef.current !== doc });
+			if (liveDocRef.current !== doc) liveBaseRef.current = doc;
+			setDocument(next, { history: false });
 			liveDocRef.current = next;
 		},
 		[setDocument],
@@ -90,7 +96,10 @@ export function useCaptions(): UseCaptionsResult {
 	const commit = useCallback(async () => {
 		const doc = useProjectStore.getState().document;
 		if (!doc) return;
-		await saveDocument(doc);
+		const base = liveBaseRef.current;
+		liveBaseRef.current = null;
+		liveDocRef.current = null;
+		await saveDocument(doc, { history: true, historyBase: base });
 	}, [saveDocument]);
 
 	const saveTranslation = useCallback<UseCaptionsResult["saveTranslation"]>(
@@ -98,8 +107,8 @@ export function useCaptions(): UseCaptionsResult {
 			const doc = useProjectStore.getState().document;
 			if (!doc) return;
 			const next = putCaptionTranslation(doc, input);
-			setDocument(next);
-			await saveDocument(next);
+			setDocument(next, { history: false });
+			await saveDocument(next, { history: true, historyBase: doc });
 		},
 		[setDocument, saveDocument],
 	);
@@ -115,8 +124,8 @@ export function useCaptions(): UseCaptionsResult {
 				getCaptionSettings(cleared).language === language
 					? patchCaptionSettings(cleared, { language: null })
 					: cleared;
-			setDocument(next);
-			await saveDocument(next);
+			setDocument(next, { history: false });
+			await saveDocument(next, { history: true, historyBase: doc });
 		},
 		[setDocument, saveDocument],
 	);

--- a/src/lib/ai-edition/store/useEditorSettings.test.ts
+++ b/src/lib/ai-edition/store/useEditorSettings.test.ts
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+//
+// What a slider drag is allowed to put on the undo stack, and — the part that
+// went wrong — what it is allowed to still be holding once the drag is over.
+//
+// `liveBaseRef` is the document a drag started from, kept until the commit that
+// records it. Nothing else emptied it: `set` leaves it alone, and a drag does not
+// always reach a commit (the gradient editor's is a 400ms timer its own unmount
+// cleanup cancels). `SliderCell` then wires mouseup/touchend/keyup straight to
+// `commit` with no `onChange` in front, so a bare click on a thumb is enough to
+// hand that leftover on as `historyBase`.
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AxcutDocument } from "../schema";
+import { axcutSchemaVersion } from "../schema";
+import { getEditorSettings } from "./editorSettings";
+import { useProjectStore } from "./projectStore";
+import { clearHistory, undo } from "./undo";
+import { past } from "./undoStack";
+import { useEditorSettings } from "./useEditorSettings";
+
+const bridgeMocks = vi.hoisted(() => ({
+	get: vi.fn(),
+	create: vi.fn(),
+	save: vi.fn(),
+	addAsset: vi.fn(),
+	removeAsset: vi.fn(),
+	listProjects: vi.fn(),
+}));
+
+vi.mock("@/native/client", () => ({
+	nativeBridgeClient: {
+		aiEdition: {
+			get: bridgeMocks.get,
+			create: bridgeMocks.create,
+			save: bridgeMocks.save,
+			addAsset: bridgeMocks.addAsset,
+			removeAsset: bridgeMocks.removeAsset,
+			listProjects: bridgeMocks.listProjects,
+		},
+	},
+}));
+
+const docA: AxcutDocument = {
+	schemaVersion: axcutSchemaVersion,
+	project: {
+		id: "proj_a",
+		title: "A",
+		createdAt: "2026-06-25T10:00:00.000Z",
+		updatedAt: "2026-06-25T10:00:00.000Z",
+		primaryAssetId: "asset_1",
+	},
+	assets: [
+		{
+			id: "asset_1",
+			kind: "video",
+			label: "screen.webm",
+			originalPath: "/tmp/screen.webm",
+			durationSec: 30,
+			video: { codec: "unknown", width: 1920, height: 1080, fps: 0 },
+			cameraTrack: null,
+		},
+	],
+	transcript: null,
+	transcripts: [],
+	timeline: {
+		clips: [],
+		gaps: [],
+		trimRanges: [],
+		muteRanges: [],
+		speedRanges: [],
+		captionRanges: [],
+	},
+	annotations: [],
+	zoomRanges: [],
+	legacyEditor: null,
+};
+
+const docB: AxcutDocument = {
+	...docA,
+	project: { ...docA.project, id: "proj_b", title: "B" },
+};
+
+/** `borderRadius` of the document a snapshot holds. The defaults are the tell:
+ *  40 is what nobody has touched, so an assertion on it says "this is the
+ *  pre-drag document" without spelling the whole fixture out again. */
+const radiusOf = (doc: unknown) => getEditorSettings(doc as AxcutDocument).borderRadius;
+
+describe("useEditorSettings drag snapshots", () => {
+	beforeEach(() => {
+		useProjectStore.getState().clear();
+		clearHistory();
+		for (const mock of Object.values(bridgeMocks)) mock.mockReset();
+		bridgeMocks.save.mockImplementation(async (doc: AxcutDocument) => ({
+			success: true,
+			document: doc,
+		}));
+		useProjectStore.setState({
+			projectId: "proj_a",
+			document: docA,
+			revision: 1,
+			status: "ready",
+			error: null,
+		});
+	});
+
+	afterEach(() => {
+		clearHistory();
+		vi.clearAllMocks();
+	});
+
+	it("does not record a snapshot of the project the user left", async () => {
+		const { result, rerender } = renderHook(() => useEditorSettings());
+
+		// The drag that never commits. `liveBaseRef` now holds project A's document.
+		act(() => result.current.setLive({ padding: 80 }));
+
+		act(() => {
+			useProjectStore.setState({ projectId: "proj_b", document: docB });
+		});
+		rerender();
+
+		// One real edit in project B, so the stack has something to lose.
+		await act(async () => {
+			await result.current.set({ borderRadius: 10 });
+		});
+		expect(past.map((s) => s.projectId)).toEqual(["proj_b"]);
+
+		// The bare click on a slider thumb.
+		await act(async () => {
+			await result.current.commit();
+		});
+
+		expect(past.map((s) => s.projectId)).toEqual(["proj_b"]);
+		// And what the foreign snapshot cost is more than one step: `undo` answers a
+		// projectId that is not the store's by throwing the WHOLE stack away, so the
+		// user loses this edit's undo as well as the bogus one.
+		expect(undo()).toBe(true);
+		expect(radiusOf(useProjectStore.getState().document)).toBe(40);
+	});
+
+	it("does not hand a bare commit a base the edits since have already buried", async () => {
+		const { result } = renderHook(() => useEditorSettings());
+
+		act(() => result.current.setLive({ padding: 80 }));
+
+		// Two edits the user makes next, each recording its own step.
+		await act(async () => {
+			await result.current.set({ borderRadius: 10 });
+		});
+		await act(async () => {
+			await result.current.set({ borderRadius: 20 });
+		});
+		expect(past).toHaveLength(2);
+
+		await act(async () => {
+			await result.current.commit();
+		});
+
+		// Same project, so no clearing happens — the cost here is that one Ctrl+Z
+		// jumps over both edits and lands on the document the abandoned drag started
+		// from (radius 40, the untouched default).
+		expect(past).toHaveLength(2);
+		expect(undo()).toBe(true);
+		expect(radiusOf(useProjectStore.getState().document)).toBe(10);
+	});
+
+	it("still records the pre-drag document when the drag does reach its commit", async () => {
+		// The guards above must not cost the feature they are guarding: a drag that
+		// ends the way a drag normally ends is still ONE undo step, back to before it.
+		const { result } = renderHook(() => useEditorSettings());
+
+		act(() => result.current.setLive({ borderRadius: 12 }));
+		act(() => result.current.setLive({ borderRadius: 14 }));
+		await act(async () => {
+			await result.current.commit();
+		});
+
+		expect(past).toHaveLength(1);
+		expect(undo()).toBe(true);
+		expect(radiusOf(useProjectStore.getState().document)).toBe(40);
+	});
+});

--- a/src/lib/ai-edition/store/useEditorSettings.ts
+++ b/src/lib/ai-edition/store/useEditorSettings.ts
@@ -69,11 +69,26 @@ export function useEditorSettings(): UseEditorSettingsResult {
 
 	// A drag does not always end in a commit -- the gradient editor's is a 400ms timer
 	// its own unmount cleanup cancels -- and nothing else empties these, so left alone
-	// they pin two whole documents for the lifetime of the hook instance. The editor
-	// mounts six `useEditorSettings()` at once and annotations can carry base64 image
-	// data URLs, so that is not a small pin. Release them when the project changes,
-	// which is the guard `useTimeline` carries, keyed on the same thing, for the same
-	// reason. What it is NOT is the reason a snapshot of the project the user left
+	// they pin two whole documents for the lifetime of the hook instance, and
+	// annotations can carry base64 image data URLs. What the pin is worth, since a
+	// count is easy to get wrong here: ten components call `useEditorSettings()`, at
+	// most FIVE are mounted together (`PreviewCanvas` with `VirtualPreview` and
+	// `WebcamOverlay` inside it, `V4Timeline`, and one inspector body), and of those
+	// only two can ever fill these refs, because only `PreviewCanvas` and the pane the
+	// inspector is showing call `setLive` -- the five `RightPanes` exports are
+	// `FacetBody`'s mutually exclusive branches, so one at a time. Two instances, two
+	// documents each.
+	//
+	// Release them when the project changes, which is the guard `useTimeline` carries,
+	// keyed on the same thing, for the same reason -- and its two drag commits carry
+	// the identity test below too, so the pair is symmetric in shape. It is not
+	// symmetric in what a stale snapshot COSTS: `commitZoomFocus` and
+	// `commitAnnotationChange` also write theirs back into the store when the save
+	// fails, so a stale one there is a DOCUMENT and silently drops every edit since.
+	// This hook has no rollback path, so the same staleness costs a history step and
+	// nothing else.
+	//
+	// What this effect is NOT is the reason a snapshot of the project the user left
 	// cannot reach the undo stack: `commit` below decides that, and decides it for a
 	// project that never changed too.
 	// biome-ignore lint/correctness/useExhaustiveDependencies: projectId is the trigger, not a read — the body only clears refs.

--- a/src/lib/ai-edition/store/useEditorSettings.ts
+++ b/src/lib/ai-edition/store/useEditorSettings.ts
@@ -12,7 +12,8 @@
 // the patch through `patchEditorSettings`, and persists via the store. No
 // extra state, no caches — the document is the single source of truth.
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
+import type { AxcutDocument } from "../schema";
 import {
 	type EditorSettingsPatch,
 	type EditorSettingsSnapshot,
@@ -53,11 +54,19 @@ export function useEditorSettings(): UseEditorSettingsResult {
 		[setDocument, saveDocument],
 	);
 
+	// The document this hook's own last `setLive` produced. A slider drag fires one
+	// `setLive` per pointer move, and recording each of them buried the real history
+	// under sixty one-pixel steps; only the first write of a drag — the one editing a
+	// document this callback did not produce — is a state worth returning to.
+	const liveDocRef = useRef<AxcutDocument | null>(null);
+
 	const setLive = useCallback(
 		(patch: EditorSettingsPatch) => {
 			const doc = useProjectStore.getState().document;
 			if (!doc) return;
-			setDocument(patchEditorSettings(doc, patch));
+			const next = patchEditorSettings(doc, patch);
+			setDocument(next, { history: liveDocRef.current !== doc });
+			liveDocRef.current = next;
 		},
 		[setDocument],
 	);

--- a/src/lib/ai-edition/store/useEditorSettings.ts
+++ b/src/lib/ai-edition/store/useEditorSettings.ts
@@ -48,8 +48,11 @@ export function useEditorSettings(): UseEditorSettingsResult {
 			const doc = useProjectStore.getState().document;
 			if (!doc) return;
 			const next = patchEditorSettings(doc, patch);
-			setDocument(next);
-			await saveDocument(next);
+			// The optimistic write is not the edit — the save is. Only the one that can
+			// fail records, and it names `doc` as what Ctrl+Z returns to because by then
+			// the store already holds `next`.
+			setDocument(next, { history: false });
+			await saveDocument(next, { history: true, historyBase: doc });
 		},
 		[setDocument, saveDocument],
 	);
@@ -57,15 +60,19 @@ export function useEditorSettings(): UseEditorSettingsResult {
 	// The document this hook's own last `setLive` produced. A slider drag fires one
 	// `setLive` per pointer move, and recording each of them buried the real history
 	// under sixty one-pixel steps; only the first write of a drag — the one editing a
-	// document this callback did not produce — is a state worth returning to.
+	// document this callback did not produce — is a state worth returning to. It is
+	// held in `liveBaseRef` and recorded by `commit`, not here: a snapshot pushed
+	// mid-drag is on the stack whether or not the commit that follows ever lands.
 	const liveDocRef = useRef<AxcutDocument | null>(null);
+	const liveBaseRef = useRef<AxcutDocument | null>(null);
 
 	const setLive = useCallback(
 		(patch: EditorSettingsPatch) => {
 			const doc = useProjectStore.getState().document;
 			if (!doc) return;
 			const next = patchEditorSettings(doc, patch);
-			setDocument(next, { history: liveDocRef.current !== doc });
+			if (liveDocRef.current !== doc) liveBaseRef.current = doc;
+			setDocument(next, { history: false });
 			liveDocRef.current = next;
 		},
 		[setDocument],
@@ -74,7 +81,10 @@ export function useEditorSettings(): UseEditorSettingsResult {
 	const commit = useCallback(async () => {
 		const doc = useProjectStore.getState().document;
 		if (!doc) return;
-		await saveDocument(doc);
+		const base = liveBaseRef.current;
+		liveBaseRef.current = null;
+		liveDocRef.current = null;
+		await saveDocument(doc, { history: true, historyBase: base });
 	}, [saveDocument]);
 
 	return { settings, hasDocument, set, setLive, commit };

--- a/src/lib/ai-edition/store/useEditorSettings.ts
+++ b/src/lib/ai-edition/store/useEditorSettings.ts
@@ -12,7 +12,7 @@
 // the patch through `patchEditorSettings`, and persists via the store. No
 // extra state, no caches — the document is the single source of truth.
 
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { AxcutDocument } from "../schema";
 import {
 	type EditorSettingsPatch,
@@ -36,6 +36,7 @@ export interface UseEditorSettingsResult {
 
 export function useEditorSettings(): UseEditorSettingsResult {
 	const document = useProjectStore((s) => s.document);
+	const projectId = useProjectStore((s) => s.projectId);
 	const setDocument = useProjectStore((s) => s.setDocument);
 	const saveDocument = useProjectStore((s) => s.saveDocument);
 
@@ -66,6 +67,21 @@ export function useEditorSettings(): UseEditorSettingsResult {
 	const liveDocRef = useRef<AxcutDocument | null>(null);
 	const liveBaseRef = useRef<AxcutDocument | null>(null);
 
+	// A drag does not always end in a commit -- the gradient editor's is a 400ms timer
+	// its own unmount cleanup cancels -- and nothing else empties these, so left alone
+	// they pin two whole documents for the lifetime of the hook instance. The editor
+	// mounts six `useEditorSettings()` at once and annotations can carry base64 image
+	// data URLs, so that is not a small pin. Release them when the project changes,
+	// which is the guard `useTimeline` carries, keyed on the same thing, for the same
+	// reason. What it is NOT is the reason a snapshot of the project the user left
+	// cannot reach the undo stack: `commit` below decides that, and decides it for a
+	// project that never changed too.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: projectId is the trigger, not a read — the body only clears refs.
+	useEffect(() => {
+		liveDocRef.current = null;
+		liveBaseRef.current = null;
+	}, [projectId]);
+
 	const setLive = useCallback(
 		(patch: EditorSettingsPatch) => {
 			const doc = useProjectStore.getState().document;
@@ -81,7 +97,16 @@ export function useEditorSettings(): UseEditorSettingsResult {
 	const commit = useCallback(async () => {
 		const doc = useProjectStore.getState().document;
 		if (!doc) return;
-		const base = liveBaseRef.current;
+		// The base counts only while the document on screen is still the one this hook's
+		// last `setLive` produced -- `setLive`'s own identity test, read the other way
+		// round. `SliderCell` fires `commit` from a bare mouseup with no `onChange` in
+		// front of it, so a click on a thumb arrives here carrying whatever base a drag
+		// that never committed left behind, and every recording write since has already
+		// put the states in between on the stack: handing that base on made one Ctrl+Z
+		// step over the lot of them. Across a project switch it is worse than a wrong
+		// step -- the snapshot names the OLD project, and `undo` answers a projectId
+		// that is not the store's by throwing the whole stack away.
+		const base = liveDocRef.current === doc ? liveBaseRef.current : null;
 		liveBaseRef.current = null;
 		liveDocRef.current = null;
 		await saveDocument(doc, { history: true, historyBase: base });

--- a/src/lib/ai-edition/store/useSequentialTimelineOps.test.ts
+++ b/src/lib/ai-edition/store/useSequentialTimelineOps.test.ts
@@ -99,8 +99,8 @@ describe("useSequentialTimelineOps", () => {
 		};
 
 		await act(async () => {
-			const r1 = result.current.apply(op1);
-			const r2 = result.current.apply(op2);
+			const r1 = result.current.apply(op1, { history: true });
+			const r2 = result.current.apply(op2, { history: true });
 			await Promise.all([r1, r2]);
 		});
 
@@ -152,8 +152,8 @@ describe("useSequentialTimelineOps", () => {
 		let firstResult: AxcutDocument | null | undefined;
 		let secondResult: AxcutDocument | null | undefined;
 		await act(async () => {
-			const p1 = result.current.apply(op1);
-			const p2 = result.current.apply(op2);
+			const p1 = result.current.apply(op1, { history: true });
+			const p2 = result.current.apply(op2, { history: true });
 			firstResult = await p1;
 			secondResult = await p2;
 		});
@@ -182,13 +182,16 @@ describe("useSequentialTimelineOps", () => {
 		// it runs. On its own queue this would still be the pre-op count.
 		let trimsSeenByTask = -1;
 		await act(async () => {
-			const opPromise = result.current.apply({
-				type: "add_trim_range" as const,
-				assetId: "asset_1",
-				startSec: 1,
-				endSec: 2,
-				reason: "ahead of the insertion",
-			});
+			const opPromise = result.current.apply(
+				{
+					type: "add_trim_range" as const,
+					assetId: "asset_1",
+					startSec: 1,
+					endSec: 2,
+					reason: "ahead of the insertion",
+				},
+				{ history: true },
+			);
 			const taskPromise = result.current.enqueue(() => {
 				trimsSeenByTask = useProjectStore.getState().document?.timeline.trimRanges.length ?? -1;
 			});
@@ -248,7 +251,7 @@ describe("useSequentialTimelineOps", () => {
 
 		let resolved: AxcutDocument | null | undefined;
 		await act(async () => {
-			resolved = await result.current.apply(op);
+			resolved = await result.current.apply(op, { history: true });
 		});
 
 		expect(resolved).toBeNull();
@@ -279,12 +282,43 @@ describe("useSequentialTimelineOps", () => {
 
 		let returned: AxcutDocument | null | undefined;
 		await act(async () => {
-			returned = await result.current.apply(op);
+			returned = await result.current.apply(op, { history: true });
 		});
 
 		expect(returned).toBeDefined();
 		expect(returned?.timeline.trimRanges).toHaveLength(1);
 		expect(returned?.timeline.trimRanges[0]?.startSec).toBe(1);
 		expect(returned?.timeline.trimRanges[0]?.endSec).toBe(2);
+	});
+
+	it("hands the caller's write options through instead of picking them", async () => {
+		// This used to hardcode `{ history: true }`, which was right for both of today's
+		// callers and invisible to any future one. That is the exact shape of the #433
+		// regression `projectStore.replaceTimeline` shipped with: a wrapper whose
+		// signature hides the option decides it, so no compile error can reach the call
+		// site that got it wrong. `documentWriteAudit.test.ts` pins the shape; this pins
+		// the behaviour.
+		const seed = makeDocWithAsset();
+		useProjectStore.setState({ document: seed });
+		const saveDocument = vi.fn(async () => true);
+
+		const { result } = renderHook(() =>
+			useSequentialTimelineOps({ fallbackDocument: seed, saveDocument }),
+		);
+
+		await act(async () => {
+			await result.current.apply(
+				{
+					type: "add_trim_range" as const,
+					assetId: "asset_1",
+					startSec: 1,
+					endSec: 2,
+					reason: "a background job, not the user",
+				},
+				{ history: false },
+			);
+		});
+
+		expect(saveDocument).toHaveBeenCalledWith(expect.anything(), { history: false });
 	});
 });

--- a/src/lib/ai-edition/store/useSequentialTimelineOps.test.ts
+++ b/src/lib/ai-edition/store/useSequentialTimelineOps.test.ts
@@ -74,7 +74,7 @@ describe("useSequentialTimelineOps", () => {
 			// Mirror the real store: write the saved doc back so the next
 			// call in the queue sees the latest committed state, and report
 			// success the way `projectStore.saveDocument` does.
-			useProjectStore.getState().setDocument(doc);
+			useProjectStore.getState().setDocument(doc, { history: true });
 			callOrder.push(doc.timeline.trimRanges[0]?.startSec.toString() ?? "empty");
 			return true;
 		});
@@ -128,7 +128,7 @@ describe("useSequentialTimelineOps", () => {
 			.fn<(doc: AxcutDocument) => Promise<boolean>>()
 			.mockResolvedValueOnce(false)
 			.mockImplementationOnce(async (doc) => {
-				useProjectStore.getState().setDocument(doc);
+				useProjectStore.getState().setDocument(doc, { history: true });
 				return true;
 			});
 
@@ -162,7 +162,7 @@ describe("useSequentialTimelineOps", () => {
 		expect(secondResult).not.toBeNull();
 		// The queue survived the first failure — both saves were attempted.
 		expect(saveDocument).toHaveBeenCalledTimes(2);
-		expect(saveDocument).toHaveBeenNthCalledWith(2, secondResult);
+		expect(saveDocument).toHaveBeenNthCalledWith(2, secondResult, { history: true });
 	});
 
 	it("runs an enqueued write after the op ahead of it has committed", async () => {
@@ -170,7 +170,7 @@ describe("useSequentialTimelineOps", () => {
 		useProjectStore.setState({ document: seed });
 
 		const saveDocument = vi.fn(async (doc: AxcutDocument) => {
-			useProjectStore.getState().setDocument(doc);
+			useProjectStore.getState().setDocument(doc, { history: true });
 			return true;
 		});
 
@@ -203,7 +203,7 @@ describe("useSequentialTimelineOps", () => {
 		useProjectStore.setState({ document: seed });
 
 		const saveDocument = vi.fn(async (doc: AxcutDocument) => {
-			useProjectStore.getState().setDocument(doc);
+			useProjectStore.getState().setDocument(doc, { history: true });
 			return true;
 		});
 
@@ -261,7 +261,7 @@ describe("useSequentialTimelineOps", () => {
 		useProjectStore.setState({ document: seed });
 
 		const saveDocument = vi.fn(async (doc: AxcutDocument) => {
-			useProjectStore.getState().setDocument(doc);
+			useProjectStore.getState().setDocument(doc, { history: true });
 			return true;
 		});
 

--- a/src/lib/ai-edition/store/useSequentialTimelineOps.ts
+++ b/src/lib/ai-edition/store/useSequentialTimelineOps.ts
@@ -30,7 +30,7 @@
 import { useCallback, useRef } from "react";
 import type { AxcutTimelineOperation } from "@/lib/ai-edition/document/operations";
 import type { AxcutDocument } from "@/lib/ai-edition/schema";
-import { useProjectStore } from "./projectStore";
+import { type DocumentWriteOptions, useProjectStore } from "./projectStore";
 
 export interface SequentialTimelineOps {
 	/**
@@ -63,8 +63,12 @@ export function useSequentialTimelineOps(options: {
 	/** Used only when the project store has no document yet. */
 	fallbackDocument: AxcutDocument | null;
 	/** Persist a document, resolving false if the write failed (already reported).
-	 *  The hook awaits this before unblocking the queue. */
-	saveDocument: (doc: AxcutDocument) => Promise<boolean>;
+	 *  The hook awaits this before unblocking the queue.
+	 *
+	 *  Typed with the store's own options parameter rather than a one-argument
+	 *  narrowing of it: every queued op here is a user edit, and the hook has to be
+	 *  able to say so. */
+	saveDocument: (doc: AxcutDocument, opts: DocumentWriteOptions) => Promise<boolean>;
 }): SequentialTimelineOps {
 	const { fallbackDocument, saveDocument } = options;
 	const saveQueueRef = useRef<Promise<unknown>>(Promise.resolve());
@@ -94,7 +98,7 @@ export function useSequentialTimelineOps(options: {
 				const doc = useProjectStore.getState().document ?? fallbackDocument;
 				if (!doc) return null;
 				const applied = applyTimelineOperation(doc, op);
-				return (await saveDocument(applied.document)) ? applied.document : null;
+				return (await saveDocument(applied.document, { history: true })) ? applied.document : null;
 			}),
 		[enqueue, fallbackDocument, saveDocument],
 	);

--- a/src/lib/ai-edition/store/useSequentialTimelineOps.ts
+++ b/src/lib/ai-edition/store/useSequentialTimelineOps.ts
@@ -41,11 +41,17 @@ export interface SequentialTimelineOps {
 	 *
 	 * Returns the saved document, or `null` for either of two different things:
 	 * no project document is loaded (store empty AND no fallback supplied), which
-	 * is a silent no-op, or the save failed, which the user has already been told
-	 * about. Both call sites `void` the result, so they are not distinguished; a
-	 * caller that needs to tell them apart has to widen this return type first.
+	 * is a silent no-op, or the write did not take effect -- see `saveDocument` for
+	 * the two ways that happens, neither of which needs anything said here. Both call
+	 * sites `void` the result, so they are not distinguished; a caller that needs to
+	 * tell them apart has to widen this return type first.
+	 *
+	 * `opts` is forwarded verbatim to `saveDocument`, and is required for the same
+	 * reason `history` itself is: a wrapper that picks the value on its caller's
+	 * behalf hides the decision from the compiler. Both of today's callers are user
+	 * gestures and pass `{ history: true }`; the next one might not be.
 	 */
-	apply: (op: AxcutTimelineOperation) => Promise<AxcutDocument | null>;
+	apply: (op: AxcutTimelineOperation, opts: DocumentWriteOptions) => Promise<AxcutDocument | null>;
 
 	/**
 	 * Queue a document mutation that isn't an `AxcutTimelineOperation` on
@@ -88,7 +94,7 @@ export function useSequentialTimelineOps(options: {
 	}, []);
 
 	const apply = useCallback(
-		(op: AxcutTimelineOperation): Promise<AxcutDocument | null> =>
+		(op: AxcutTimelineOperation, opts: DocumentWriteOptions): Promise<AxcutDocument | null> =>
 			enqueue(async () => {
 				const { applyTimelineOperation } = await import("@/lib/ai-edition/document/operations");
 				// Read the doc inside the chain. The store holds the
@@ -98,7 +104,7 @@ export function useSequentialTimelineOps(options: {
 				const doc = useProjectStore.getState().document ?? fallbackDocument;
 				if (!doc) return null;
 				const applied = applyTimelineOperation(doc, op);
-				return (await saveDocument(applied.document, { history: true })) ? applied.document : null;
+				return (await saveDocument(applied.document, opts)) ? applied.document : null;
 			}),
 		[enqueue, fallbackDocument, saveDocument],
 	);

--- a/src/lib/ai-edition/store/useTimeline.test.ts
+++ b/src/lib/ai-edition/store/useTimeline.test.ts
@@ -5,6 +5,8 @@ import { I18nProvider } from "@/contexts/I18nContext";
 import type { AxcutDocument } from "../schema";
 import { axcutSchemaVersion } from "../schema";
 import { useProjectStore } from "./projectStore";
+import { clearHistory, redo, undo } from "./undo";
+import { future, past } from "./undoStack";
 import { useTimeline } from "./useTimeline";
 
 /**
@@ -896,5 +898,197 @@ describe("useTimeline save failures", () => {
 
 		expect(added).toBe(0);
 		expect(useProjectStore.getState().document?.zoomRanges).toHaveLength(0);
+	});
+});
+
+describe("useTimeline undo history", () => {
+	// `addAsset` (electron/ai-edition/document-service.ts) never writes `durationSec`,
+	// so EVERY freshly imported asset lands at the 60s placeholder and fires the
+	// background probe. Anything the probe records is therefore on the undo stack of
+	// every single drop, which is what makes these two the common case and not an
+	// edge one.
+	const unprobed = {
+		id: "asset_3",
+		kind: "video" as const,
+		label: "fresh-import.mp4",
+		originalPath: "/tmp/fresh-import.mp4",
+		durationSec: undefined,
+		// No `video` either: that is what `addAsset` produces, and it is what makes
+		// `probeAndCorrectClip` save even once the clip it came for is gone.
+		cameraTrack: null,
+	};
+
+	const docWithZoom: AxcutDocument = {
+		...sampleDoc,
+		zoomRanges: [
+			{
+				id: "zoom_a",
+				startMs: 1000,
+				endMs: 3000,
+				depth: 3,
+				focus: { cx: 0.5, cy: 0.5 },
+				focusMode: "manual",
+				clipId: "clip_a",
+				sourceStartSec: 1,
+				sourceEndSec: 3,
+			},
+		],
+	};
+
+	beforeEach(() => {
+		useProjectStore.getState().clear();
+		clearHistory();
+		for (const mock of Object.values(bridgeMocks)) mock.mockReset();
+		probeVideoDurationMock.mockReset();
+		probeVideoDimensionsMock.mockResolvedValue({ width: 1920, height: 1080 });
+		bridgeMocks.save.mockImplementation(async (doc: typeof sampleDoc) => ({
+			success: true,
+			document: doc,
+		}));
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	function seed(document: AxcutDocument) {
+		useProjectStore.setState({
+			projectId: "proj_test",
+			document,
+			revision: 1,
+			status: "ready",
+			error: null,
+		});
+	}
+
+	it("keeps the background duration probe off the undo stack", async () => {
+		// Without `{ history: false }` on `probeAndCorrectClip`'s save, dropping a clip
+		// left `past` = [beforeDrop, dropWithPlaceholderClip]: the first Ctrl+Z snapped
+		// the clip back to a 60s placeholder instead of removing it.
+		seed({ ...sampleDoc, assets: [...sampleDoc.assets, unprobed] });
+		probeVideoDurationMock.mockResolvedValue(5);
+		const { result } = renderTimeline();
+
+		await act(async () => {
+			await result.current.insertClipAt("asset_3", 1);
+		});
+		await waitFor(() => {
+			const inserted = useProjectStore
+				.getState()
+				.document?.timeline.clips.find((c) => c.assetId === "asset_3");
+			expect(inserted?.sourceEndSec).toBe(5);
+		});
+
+		// One step for the drop the user made, none for the probe that corrected it.
+		expect(past).toHaveLength(1);
+		act(() => {
+			expect(undo()).toBe(true);
+		});
+		expect(useProjectStore.getState().document?.timeline.clips).toHaveLength(1);
+	});
+
+	it("does not let a probe landing after an undo destroy the redo", async () => {
+		// The probe is detached from the drop, so it can resolve at any point — including
+		// after the user has already pressed Ctrl+Z. A recording save there ran
+		// `pushHistory`, which clears `future` on its way past: redo was gone, wiped by a
+		// write the user never made and never saw.
+		seed({ ...sampleDoc, assets: [...sampleDoc.assets, unprobed] });
+		let landProbe!: (durationSec: number) => void;
+		probeVideoDurationMock.mockReturnValue(
+			new Promise<number>((resolvePromise) => {
+				landProbe = resolvePromise;
+			}),
+		);
+		const { result } = renderTimeline();
+
+		await act(async () => {
+			await result.current.insertClipAt("asset_3", 1);
+		});
+		expect(past).toHaveLength(1);
+
+		act(() => {
+			expect(undo()).toBe(true);
+		});
+		expect(useProjectStore.getState().document?.timeline.clips).toHaveLength(1);
+		expect(future).toHaveLength(1);
+
+		await act(async () => {
+			landProbe(5);
+			// The clip is gone, so only the dimensions half of the probe still has
+			// anything to write — and that is exactly the write that used to be recorded.
+			await new Promise((resolveTick) => setTimeout(resolveTick, 0));
+		});
+
+		expect(past).toHaveLength(0);
+		expect(future).toHaveLength(1);
+		act(() => {
+			expect(redo()).toBe(true);
+		});
+		expect(useProjectStore.getState().document?.timeline.clips).toHaveLength(2);
+	});
+
+	it("leaves no undo step behind a focus drag whose commit failed", async () => {
+		// The drag used to push its pre-drag document from the FIRST `setDocument`. When
+		// the commit then failed, `commitZoomFocus` restored that same document through
+		// `setState` — which cannot pop the entry. `past` was left holding a snapshot
+		// identical to what was on screen (a Ctrl+Z that visibly does nothing) and
+		// `future` had already been wiped by the push.
+		seed(docWithZoom);
+		const { result } = renderTimeline();
+
+		// An edit and an undo, so there is a redo entry to lose.
+		await act(async () => {
+			await result.current.updateZoomDepth("zoom_a", 5);
+		});
+		act(() => {
+			expect(undo()).toBe(true);
+		});
+		expect(past).toHaveLength(0);
+		expect(future).toHaveLength(1);
+
+		const beforeDrag = useProjectStore.getState().document;
+		bridgeMocks.save.mockResolvedValue({ success: false, error: "disk full" });
+		act(() => {
+			result.current.updateZoomFocusLive("zoom_a", { cx: 0.2, cy: 0.3 });
+			result.current.updateZoomFocusLive("zoom_a", { cx: 0.25, cy: 0.35 });
+		});
+		await act(async () => {
+			await result.current.commitZoomFocus();
+		});
+
+		expect(useProjectStore.getState().document).toBe(beforeDrag);
+		expect(past).toHaveLength(0);
+		expect(future).toHaveLength(1);
+		act(() => {
+			expect(redo()).toBe(true);
+		});
+		expect(useProjectStore.getState().document?.zoomRanges[0].depth).toBe(5);
+	});
+
+	it("records one undo step for a whole focus drag once it commits", async () => {
+		// The other half of the same change: moving the record to the commit must not
+		// lose it. Sixty pointermoves, one Ctrl+Z, back to where the drag started.
+		seed(docWithZoom);
+		const { result } = renderTimeline();
+
+		act(() => {
+			for (let i = 0; i < 60; i++) {
+				result.current.updateZoomFocusLive("zoom_a", { cx: 0.2 + i / 1000, cy: 0.3 });
+			}
+		});
+		expect(past).toHaveLength(0);
+
+		await act(async () => {
+			await result.current.commitZoomFocus();
+		});
+
+		expect(past).toHaveLength(1);
+		act(() => {
+			expect(undo()).toBe(true);
+		});
+		expect(useProjectStore.getState().document?.zoomRanges[0].focus).toEqual({
+			cx: 0.5,
+			cy: 0.5,
+		});
 	});
 });

--- a/src/lib/ai-edition/store/useTimeline.test.ts
+++ b/src/lib/ai-edition/store/useTimeline.test.ts
@@ -1098,8 +1098,9 @@ describe("useTimeline undo history", () => {
 // `zoomFocusRollbackRef` / `annotationRollbackRef` hold the document a drag started
 // from, kept until the commit that records it. A drag does not always reach a commit,
 // and both commits are reachable without one: the inspector's annotation `<textarea>`
-// writes live on every keystroke and commits `onBlur`, so closing the panel or deleting
-// the region removes the focused node without ever firing blur -- and `SliderCell` wires
+// writes live on every keystroke and commits `onBlur`, so closing the panel unmounts the
+// focused node before blur can fire (the region's own delete button is an `onClick`, which
+// runs after blur, so that route does not reach here) -- and `SliderCell` wires
 // mouseup/touchend/keyup straight to `onCommit` with no `onChange` in front, so a bare
 // click on a stroke-width thumb reaches `commitAnnotationChange()` carrying that
 // leftover. `NewEditorShell` builds ONE `useTimeline()` and hands it to the inspector,

--- a/src/lib/ai-edition/store/useTimeline.test.ts
+++ b/src/lib/ai-edition/store/useTimeline.test.ts
@@ -1092,3 +1092,195 @@ describe("useTimeline undo history", () => {
 		});
 	});
 });
+
+// What a drag's snapshot is allowed to still be holding once the drag is over.
+//
+// `zoomFocusRollbackRef` / `annotationRollbackRef` hold the document a drag started
+// from, kept until the commit that records it. A drag does not always reach a commit,
+// and both commits are reachable without one: the inspector's annotation `<textarea>`
+// writes live on every keystroke and commits `onBlur`, so closing the panel or deleting
+// the region removes the focused node without ever firing blur -- and `SliderCell` wires
+// mouseup/touchend/keyup straight to `onCommit` with no `onChange` in front, so a bare
+// click on a stroke-width thumb reaches `commitAnnotationChange()` carrying that
+// leftover. `NewEditorShell` builds ONE `useTimeline()` and hands it to the inspector,
+// so the abandonable live write and the bare commit share an instance.
+describe("useTimeline drag snapshots", () => {
+	const docWithRegions: AxcutDocument = {
+		...sampleDoc,
+		zoomRanges: [
+			{
+				id: "zoom_a",
+				startMs: 1000,
+				endMs: 3000,
+				depth: 3,
+				focus: { cx: 0.5, cy: 0.5 },
+				focusMode: "manual",
+				clipId: "clip_a",
+				sourceStartSec: 1,
+				sourceEndSec: 3,
+			},
+		],
+		annotations: [
+			{
+				id: "ann_a",
+				startMs: 1000,
+				endMs: 3000,
+				clipId: "clip_a",
+				sourceStartSec: 1,
+				sourceEndSec: 3,
+				type: "text",
+				content: "before",
+				textContent: "",
+				position: { x: 50, y: 50 },
+				size: { width: 30, height: 20 },
+				style: {
+					color: "#ffffff",
+					backgroundColor: "transparent",
+					fontSize: 32,
+					fontFamily: "Inter",
+					fontWeight: "bold",
+					fontStyle: "normal",
+					textDecoration: "none",
+					textAlign: "center",
+					textAnimation: "none",
+				},
+				zIndex: 1,
+			},
+		],
+	};
+
+	beforeEach(() => {
+		useProjectStore.getState().clear();
+		clearHistory();
+		for (const mock of Object.values(bridgeMocks)) mock.mockReset();
+		probeVideoDimensionsMock.mockResolvedValue({ width: 1920, height: 1080 });
+		bridgeMocks.save.mockImplementation(async (doc: typeof sampleDoc) => ({
+			success: true,
+			document: doc,
+		}));
+		useProjectStore.setState({
+			projectId: "proj_test",
+			document: docWithRegions,
+			revision: 1,
+			status: "ready",
+			error: null,
+		});
+	});
+
+	afterEach(() => {
+		clearHistory();
+		vi.clearAllMocks();
+	});
+
+	/** Two recording edits between the abandoned live write and the bare commit, so the
+	 *  stale snapshot is one the stack has already buried. */
+	async function twoZoomDepthEdits(result: { current: ReturnType<typeof useTimeline> }) {
+		await act(async () => {
+			await result.current.updateZoomDepth("zoom_a", 4);
+		});
+		await act(async () => {
+			await result.current.updateZoomDepth("zoom_a", 5);
+		});
+	}
+
+	it("does not hand a bare annotation commit a base the edits since have buried", async () => {
+		const { result } = renderTimeline();
+
+		// The keystrokes that never reach their `onBlur`.
+		act(() => result.current.updateAnnotationLive("ann_a", { content: "typed" }));
+		await twoZoomDepthEdits(result);
+		expect(past).toHaveLength(2);
+
+		// The bare click on a slider thumb.
+		await act(async () => {
+			await result.current.commitAnnotationChange();
+		});
+
+		// Same project, so nothing is cleared -- the cost is that one Ctrl+Z jumps over
+		// BOTH zoom edits and lands on the document the abandoned typing started from.
+		expect(past).toHaveLength(2);
+		act(() => {
+			expect(undo()).toBe(true);
+		});
+		const doc = useProjectStore.getState().document;
+		expect(doc?.zoomRanges[0].depth).toBe(4);
+		expect(doc?.annotations[0].content).toBe("typed");
+	});
+
+	it("does not restore a buried document when a bare annotation commit fails", async () => {
+		// The worse half: `rollback` is used as a DOCUMENT here, not only as a
+		// `historyBase`, so a failed bare commit wrote the stale snapshot back into the
+		// store and both zoom edits were silently gone.
+		const { result } = renderTimeline();
+
+		act(() => result.current.updateAnnotationLive("ann_a", { content: "typed" }));
+		await twoZoomDepthEdits(result);
+
+		const onScreen = useProjectStore.getState().document;
+		bridgeMocks.save.mockResolvedValueOnce({ success: false, error: "disk full" });
+		await act(async () => {
+			await result.current.commitAnnotationChange();
+		});
+
+		expect(useProjectStore.getState().document).toBe(onScreen);
+		expect(onScreen?.zoomRanges[0].depth).toBe(5);
+		expect(onScreen?.annotations[0].content).toBe("typed");
+	});
+
+	it("does not hand a bare focus commit a base the edits since have buried", async () => {
+		// `ZoomFocusOverlay.handlePointerDown` sets `draggingRef` BEFORE its live write,
+		// and that write returns early on a zero-size overlay rect -- so `endDrag` fires
+		// `commitZoomFocus()` with nothing in front of it.
+		const { result } = renderTimeline();
+
+		act(() => result.current.updateZoomFocusLive("zoom_a", { cx: 0.8, cy: 0.2 }));
+		await twoZoomDepthEdits(result);
+		expect(past).toHaveLength(2);
+
+		await act(async () => {
+			await result.current.commitZoomFocus();
+		});
+
+		expect(past).toHaveLength(2);
+		act(() => {
+			expect(undo()).toBe(true);
+		});
+		const doc = useProjectStore.getState().document;
+		expect(doc?.zoomRanges[0].depth).toBe(4);
+		expect(doc?.zoomRanges[0].focus).toEqual({ cx: 0.8, cy: 0.2 });
+	});
+
+	it("does not restore a buried document when a bare focus commit fails", async () => {
+		const { result } = renderTimeline();
+
+		act(() => result.current.updateZoomFocusLive("zoom_a", { cx: 0.8, cy: 0.2 }));
+		await twoZoomDepthEdits(result);
+
+		const onScreen = useProjectStore.getState().document;
+		bridgeMocks.save.mockResolvedValueOnce({ success: false, error: "disk full" });
+		await act(async () => {
+			await result.current.commitZoomFocus();
+		});
+
+		expect(useProjectStore.getState().document).toBe(onScreen);
+		expect(onScreen?.zoomRanges[0].depth).toBe(5);
+	});
+
+	it("still records the pre-drag document when an annotation drag reaches its commit", async () => {
+		// The guard must not cost the feature it guards: a drag that ends the way a drag
+		// normally ends is still ONE undo step, back to before it.
+		const { result } = renderTimeline();
+
+		act(() => result.current.updateAnnotationLive("ann_a", { content: "ty" }));
+		act(() => result.current.updateAnnotationLive("ann_a", { content: "typed" }));
+		await act(async () => {
+			await result.current.commitAnnotationChange();
+		});
+
+		expect(past).toHaveLength(1);
+		act(() => {
+			expect(undo()).toBe(true);
+		});
+		expect(useProjectStore.getState().document?.annotations[0].content).toBe("before");
+	});
+});

--- a/src/lib/ai-edition/store/useTimeline.ts
+++ b/src/lib/ai-edition/store/useTimeline.ts
@@ -712,8 +712,12 @@ export function useTimeline() {
 		// See `commitZoomFocus`: the snapshot counts only while the document on screen is
 		// still the one this hook's live writes produced. This is the reachable half.
 		// The inspector's annotation `<textarea>` calls `updateAnnotationLive` on every
-		// keystroke and commits `onBlur`, and closing the panel or deleting the region
-		// removes the focused node without firing blur; `SliderCell` then wires mouseup
+		// keystroke and commits `onBlur`, and closing the panel unmounts the focused node
+		// before blur can fire: `V4Timeline`'s `startScrub` clears the selection from a
+		// pointerdown handler, and React flushes discrete events synchronously, so the
+		// textarea is gone before mousedown moves focus. (Deleting the region does NOT
+		// reach here — its button is an `onClick`, which runs after blur has committed.)
+		// `SliderCell` then wires mouseup
 		// straight to `onCommit`, so a bare click on a stroke-width thumb lands here
 		// carrying the typing's base. `NewEditorShell` builds one `useTimeline()` for
 		// both, so it is one instance's ref.

--- a/src/lib/ai-edition/store/useTimeline.ts
+++ b/src/lib/ai-edition/store/useTimeline.ts
@@ -241,7 +241,7 @@ export function useTimeline() {
 				...document,
 				zoomRanges: [...document.zoomRanges, ...anchored] as AxcutDocument["zoomRanges"],
 			};
-			await saveDocument(next);
+			await saveDocument(next, { history: true });
 		},
 		[document, saveDocument],
 	);
@@ -273,7 +273,7 @@ export function useTimeline() {
 				...document,
 				zoomRanges: [...document.zoomRanges, ...anchored] as AxcutDocument["zoomRanges"],
 			};
-			if (!(await saveDocument(next))) return 0;
+			if (!(await saveDocument(next, { history: true }))) return 0;
 			return suggestions.length;
 		},
 		[document, saveDocument],
@@ -314,7 +314,7 @@ export function useTimeline() {
 					],
 				},
 			};
-			await saveDocument(next);
+			await saveDocument(next, { history: true });
 		},
 		[document, saveDocument],
 	);
@@ -361,7 +361,7 @@ export function useTimeline() {
 					...created,
 				] as unknown as AxcutDocument["annotations"],
 			};
-			if (!(await saveDocument(next))) return;
+			if (!(await saveDocument(next, { history: true }))) return;
 			// Select the freshly added annotation so its inspector opens and it shows a
 			// selection box on the canvas, ready to be retyped over.
 			const newId = created[0]?.id ?? ann.id;
@@ -394,7 +394,7 @@ export function useTimeline() {
 					],
 				},
 			};
-			await saveDocument(next);
+			await saveDocument(next, { history: true });
 		},
 		[document, saveDocument],
 	);
@@ -433,7 +433,7 @@ export function useTimeline() {
 					],
 				},
 			};
-			await saveDocument(next);
+			await saveDocument(next, { history: true });
 		},
 		[document, saveDocument],
 	);
@@ -469,7 +469,7 @@ export function useTimeline() {
 					),
 				},
 			};
-			await saveDocument(nextDoc);
+			await saveDocument(nextDoc, { history: true });
 		},
 		[document, saveDocument],
 	);
@@ -512,10 +512,13 @@ export function useTimeline() {
 					origin: prev?.origin ?? ("user" as const),
 				};
 			});
-			await saveDocument({
-				...doc,
-				timeline: { ...doc.timeline, trimRanges: [...others, ...rebuilt] },
-			});
+			await saveDocument(
+				{
+					...doc,
+					timeline: { ...doc.timeline, trimRanges: [...others, ...rebuilt] },
+				},
+				{ history: true },
+			);
 		},
 		[saveDocument],
 	);
@@ -540,7 +543,7 @@ export function useTimeline() {
 					() => createId("zoom"),
 				) as AxcutDocument["zoomRanges"],
 			};
-			await saveDocument(next);
+			await saveDocument(next, { history: true });
 		},
 		[document, saveDocument],
 	);
@@ -555,18 +558,20 @@ export function useTimeline() {
 			const doc = useProjectStore.getState().document;
 			if (!doc) return;
 			// The first live write of a drag is the one editing a document this callback
-			// did not itself produce — so it is the pre-drag state, and the only one worth
-			// recording. Without the flag a pointermove-frequency drag pushed ~60 snapshots
-			// a second and evicted the real history behind it.
-			const dragStart = zoomFocusLiveRef.current !== doc;
-			if (dragStart) zoomFocusRollbackRef.current = doc;
+			// did not itself produce, so it is the pre-drag state — the one thing worth
+			// returning to. It is remembered, not recorded: `commitZoomFocus` hands it to
+			// `saveDocument` as `historyBase`, so the whole gesture becomes ONE undo step
+			// and only once the write landed. Recording it here instead left the entry
+			// behind when the commit failed and rolled the document back to that very
+			// document — a Ctrl+Z that visibly did nothing, with `future` already wiped.
+			if (zoomFocusLiveRef.current !== doc) zoomFocusRollbackRef.current = doc;
 			const next: AxcutDocument = {
 				...doc,
 				zoomRanges: patchPillById(doc.zoomRanges, id, {
 					focus: { cx: finiteFraction(focus.cx), cy: finiteFraction(focus.cy) },
 				}) as AxcutDocument["zoomRanges"],
 			};
-			setDocument(next, { history: dragStart });
+			setDocument(next, { history: false });
 			zoomFocusLiveRef.current = next;
 		},
 		[setDocument],
@@ -578,7 +583,10 @@ export function useTimeline() {
 		const rollback = zoomFocusRollbackRef.current;
 		zoomFocusRollbackRef.current = null;
 		zoomFocusLiveRef.current = null;
-		if (!(await saveDocument(doc)) && rollback) {
+		// `historyBase: rollback` — the pre-drag document, not the one the store holds
+		// (that is the dragged one, written live). `null` when no live write happened,
+		// which records nothing, which is right: nothing changed.
+		if (!(await saveDocument(doc, { history: true, historyBase: rollback })) && rollback) {
 			useProjectStore.setState((state) =>
 				// `dirty` is deliberately NOT cleared. The rollback target is the last document
 				// this drag started from, which is not the same as the last SAVED one: with two
@@ -602,7 +610,7 @@ export function useTimeline() {
 					depth,
 				}) as AxcutDocument["zoomRanges"],
 			};
-			await saveDocument(next);
+			await saveDocument(next, { history: true });
 		},
 		[document, saveDocument],
 	);
@@ -621,7 +629,7 @@ export function useTimeline() {
 					rotationPreset,
 				}) as AxcutDocument["zoomRanges"],
 			};
-			await saveDocument(next);
+			await saveDocument(next, { history: true });
 		},
 		[document, saveDocument],
 	);
@@ -643,7 +651,7 @@ export function useTimeline() {
 					focusMode,
 				}) as AxcutDocument["zoomRanges"],
 			};
-			await saveDocument(next);
+			await saveDocument(next, { history: true });
 		},
 		[document, saveDocument],
 	);
@@ -664,7 +672,7 @@ export function useTimeline() {
 					() => createId("ann"),
 				),
 			};
-			await saveDocument(next);
+			await saveDocument(next, { history: true });
 		},
 		[document, saveDocument],
 	);
@@ -676,15 +684,14 @@ export function useTimeline() {
 		(id: string, patch: Partial<AxcutDocument["annotations"][number]>) => {
 			const doc = useProjectStore.getState().document;
 			if (!doc) return;
-			// One undo step per drag, not per pointermove — same reasoning as
-			// `updateZoomFocusLive` above.
-			const dragStart = annotationLiveRef.current !== doc;
-			if (dragStart) annotationRollbackRef.current = doc;
+			// One undo step per drag, recorded by the commit once it lands — same
+			// reasoning, and the same failed-commit hole, as `updateZoomFocusLive` above.
+			if (annotationLiveRef.current !== doc) annotationRollbackRef.current = doc;
 			const next: AxcutDocument = {
 				...doc,
 				annotations: patchPillById(doc.annotations, id, patch),
 			};
-			setDocument(next, { history: dragStart });
+			setDocument(next, { history: false });
 			annotationLiveRef.current = next;
 		},
 		[setDocument],
@@ -696,7 +703,9 @@ export function useTimeline() {
 		const rollback = annotationRollbackRef.current;
 		annotationRollbackRef.current = null;
 		annotationLiveRef.current = null;
-		if (!(await saveDocument(doc)) && rollback) {
+		// See `commitZoomFocus`: the pre-drag document is the undo target, and it is
+		// recorded only if this write succeeds.
+		if (!(await saveDocument(doc, { history: true, historyBase: rollback })) && rollback) {
 			useProjectStore.setState((state) =>
 				// `dirty` is deliberately NOT cleared. The rollback target is the last document
 				// this drag started from, which is not the same as the last SAVED one: with two
@@ -734,7 +743,7 @@ export function useTimeline() {
 					),
 				},
 			};
-			await saveDocument(next);
+			await saveDocument(next, { history: true });
 		},
 		[document, saveDocument],
 	);
@@ -764,7 +773,7 @@ export function useTimeline() {
 					),
 				},
 			};
-			await saveDocument(next);
+			await saveDocument(next, { history: true });
 		},
 		[document, saveDocument],
 	);
@@ -786,7 +795,7 @@ export function useTimeline() {
 					speedRegions: patchPillById(prev, id, { speed }),
 				},
 			};
-			await saveDocument(next);
+			await saveDocument(next, { history: true });
 		},
 		[document, saveDocument],
 	);
@@ -795,7 +804,8 @@ export function useTimeline() {
 		async (kind: RegionKind, id: string) => {
 			if (!document) return;
 			// One shared mutator with the agent's removeTrim / removeModifier tools.
-			if (!(await saveDocument(removeRegionInDocument(document, kind, id)))) return;
+			if (!(await saveDocument(removeRegionInDocument(document, kind, id), { history: true })))
+				return;
 			if (selection?.id === id) setSelection(null);
 			setMultiSelection((prev) => prev.filter((h) => h.id !== id));
 		},
@@ -846,7 +856,7 @@ export function useTimeline() {
 						? { ...legacy, speedRegions: prevSpeed, cameraFullscreenRegions: prevCameraFullscreen }
 						: document.legacyEditor,
 			};
-			if (!(await saveDocument(next))) return;
+			if (!(await saveDocument(next, { history: true }))) return;
 			setSelection(null);
 			setMultiSelection([]);
 		},
@@ -931,7 +941,7 @@ export function useTimeline() {
 								),
 							},
 						};
-			await saveDocument(next);
+			await saveDocument(next, { history: true });
 		},
 		[saveDocument],
 	);
@@ -996,11 +1006,20 @@ export function useTimeline() {
 					...(needsDims ? { video: { codec: "unknown", fps: 0, ...a.video, ...probedDims } } : {}),
 				};
 			});
-			await state.saveDocument({
-				...doc,
-				assets: nextAssets,
-				timeline: { ...doc.timeline, clips: nextClips },
-			});
+			// `history: false`. Nothing about this write is a user action: `addAsset` never
+			// populates `durationSec`, so EVERY freshly imported asset lands at the 60s
+			// placeholder and fires this probe. Recording it put a placeholder-length clip
+			// on the undo stack a beat after the drop, so the first Ctrl+Z snapped the clip
+			// back to 60s instead of removing it — and a probe resolving after the user
+			// had already undone wiped `future`, destroying redo from a background write.
+			await state.saveDocument(
+				{
+					...doc,
+					assets: nextAssets,
+					timeline: { ...doc.timeline, clips: nextClips },
+				},
+				{ history: false },
+			);
 		},
 		[],
 	);
@@ -1047,7 +1066,7 @@ export function useTimeline() {
 				timeline: { ...currentDoc.timeline, clips: newClips },
 			};
 			const finalDoc = rederiveRegionMs(next, newClips);
-			if (!(await saveDocument(finalDoc))) return;
+			if (!(await saveDocument(finalDoc, { history: true }))) return;
 			setClipSelection(newClip.id);
 
 			// If we used the placeholder, kick off the probe in the background.
@@ -1076,7 +1095,7 @@ export function useTimeline() {
 		async (clipId: string, toIndex: number) => {
 			if (!document) return;
 			if (!document.timeline.clips.some((c) => c.id === clipId)) return;
-			await saveDocument(moveClipInDocument(document, clipId, toIndex));
+			await saveDocument(moveClipInDocument(document, clipId, toIndex), { history: true });
 		},
 		[document, saveDocument],
 	);
@@ -1092,7 +1111,7 @@ export function useTimeline() {
 			// original, so its index in the result is the original's index + 1.
 			const insertedIndex = document.timeline.clips.findIndex((c) => c.id === clipId) + 1;
 			const next = duplicateClipInDocument(document, clipId, "user", "Duplicated clip");
-			if (!(await saveDocument(next))) return;
+			if (!(await saveDocument(next, { history: true }))) return;
 			setClipSelection(next.timeline.clips[insertedIndex]?.id ?? null);
 		},
 		[document, saveDocument],
@@ -1102,7 +1121,7 @@ export function useTimeline() {
 		async (clipId: string) => {
 			if (!document) return;
 			// One shared mutator with the agent's removeClip tool: reflow survivors + rederive pills.
-			if (!(await saveDocument(removeClipInDocument(document, clipId)))) return;
+			if (!(await saveDocument(removeClipInDocument(document, clipId), { history: true }))) return;
 			if (clipSelection === clipId) setClipSelection(null);
 		},
 		[document, clipSelection, saveDocument],

--- a/src/lib/ai-edition/store/useTimeline.ts
+++ b/src/lib/ai-edition/store/useTimeline.ts
@@ -580,7 +580,16 @@ export function useTimeline() {
 	const commitZoomFocus = useCallback(async () => {
 		const doc = useProjectStore.getState().document;
 		if (!doc) return;
-		const rollback = zoomFocusRollbackRef.current;
+		// The snapshot counts only while the document on screen is still the one this
+		// hook's last live write produced -- `updateZoomFocusLive`'s own identity test,
+		// read the other way round. Without it a commit that arrives with no live write
+		// in front of it picks up whatever an abandoned drag left behind, and every
+		// recording write since has already put the states in between on the stack: as a
+		// `historyBase` that makes one Ctrl+Z step over the lot, and on the failure path
+		// below it puts that buried document back on screen, silently dropping them.
+		// `handlePointerDown` sets `draggingRef` BEFORE its live write and that write
+		// returns early on a zero-size overlay rect, so `endDrag` can reach here bare.
+		const rollback = zoomFocusLiveRef.current === doc ? zoomFocusRollbackRef.current : null;
 		zoomFocusRollbackRef.current = null;
 		zoomFocusLiveRef.current = null;
 		// `historyBase: rollback` — the pre-drag document, not the one the store holds
@@ -700,11 +709,19 @@ export function useTimeline() {
 	const commitAnnotationChange = useCallback(async () => {
 		const doc = useProjectStore.getState().document;
 		if (!doc) return;
-		const rollback = annotationRollbackRef.current;
+		// See `commitZoomFocus`: the snapshot counts only while the document on screen is
+		// still the one this hook's live writes produced. This is the reachable half.
+		// The inspector's annotation `<textarea>` calls `updateAnnotationLive` on every
+		// keystroke and commits `onBlur`, and closing the panel or deleting the region
+		// removes the focused node without firing blur; `SliderCell` then wires mouseup
+		// straight to `onCommit`, so a bare click on a stroke-width thumb lands here
+		// carrying the typing's base. `NewEditorShell` builds one `useTimeline()` for
+		// both, so it is one instance's ref.
+		const rollback = annotationLiveRef.current === doc ? annotationRollbackRef.current : null;
 		annotationRollbackRef.current = null;
 		annotationLiveRef.current = null;
-		// See `commitZoomFocus`: the pre-drag document is the undo target, and it is
-		// recorded only if this write succeeds.
+		// The pre-drag document is the undo target, and it is recorded only if this write
+		// succeeds.
 		if (!(await saveDocument(doc, { history: true, historyBase: rollback })) && rollback) {
 			useProjectStore.setState((state) =>
 				// `dirty` is deliberately NOT cleared. The rollback target is the last document

--- a/src/lib/ai-edition/store/useTimeline.ts
+++ b/src/lib/ai-edition/store/useTimeline.ts
@@ -137,10 +137,11 @@ export function useTimeline() {
 	// (collectNativeFormats), the output resolution (referenceClipDims) and the export badges all
 	// read it, so an unpopulated one silently drops that clip from ALL of them — which is why a
 	// cropped clip could show under ORIGINAL while an un-probed 16:9 sibling was missing entirely.
-	// Probe once on load and persist via saveDocument (which doesn't touch undo/dirty), so the fix
-	// sticks and every consumer agrees without each re-probing on its own (what the export dialog
-	// used to do). Attempt each asset at most once per session, even on failure, so a file that
-	// can't be probed doesn't spin the effect on every document change.
+	// Probe once on load and persist via saveDocument with `history: false` (a write the user
+	// never made must not be what the next Ctrl+Z reverses), so the fix sticks and every consumer
+	// agrees without each re-probing on its own (what the export dialog used to do). Attempt each
+	// asset at most once per session, even on failure, so a file that can't be probed doesn't
+	// spin the effect on every document change.
 	const probedAssetIdsRef = useRef<Set<string>>(new Set());
 	useEffect(() => {
 		if (!document) return;
@@ -185,22 +186,27 @@ export function useTimeline() {
 			// Re-read fresh state so a concurrent edit made while probing isn't stomped.
 			const current = useProjectStore.getState().document;
 			if (!current) return;
-			await useProjectStore.getState().saveDocument({
-				...current,
-				assets: current.assets.map((a) => {
-					const found = probed[a.id];
-					if (!found) return a;
-					return {
-						...a,
-						...(found.video
-							? { video: { codec: "unknown", fps: 0, ...a.video, ...found.video } }
-							: {}),
-						...(found.camera && a.cameraTrack
-							? { cameraTrack: { ...a.cameraTrack, ...found.camera } }
-							: {}),
-					};
-				}),
-			});
+			// `history: false` — see the comment above: a backfill nobody asked for must
+			// not become the thing the next Ctrl+Z reverses.
+			await useProjectStore.getState().saveDocument(
+				{
+					...current,
+					assets: current.assets.map((a) => {
+						const found = probed[a.id];
+						if (!found) return a;
+						return {
+							...a,
+							...(found.video
+								? { video: { codec: "unknown", fps: 0, ...a.video, ...found.video } }
+								: {}),
+							...(found.camera && a.cameraTrack
+								? { cameraTrack: { ...a.cameraTrack, ...found.camera } }
+								: {}),
+						};
+					}),
+				},
+				{ history: false },
+			);
 		})();
 		return () => {
 			cancelled = true;
@@ -548,14 +554,19 @@ export function useTimeline() {
 		(id: string, focus: { cx: number; cy: number }) => {
 			const doc = useProjectStore.getState().document;
 			if (!doc) return;
-			if (zoomFocusLiveRef.current !== doc) zoomFocusRollbackRef.current = doc;
+			// The first live write of a drag is the one editing a document this callback
+			// did not itself produce — so it is the pre-drag state, and the only one worth
+			// recording. Without the flag a pointermove-frequency drag pushed ~60 snapshots
+			// a second and evicted the real history behind it.
+			const dragStart = zoomFocusLiveRef.current !== doc;
+			if (dragStart) zoomFocusRollbackRef.current = doc;
 			const next: AxcutDocument = {
 				...doc,
 				zoomRanges: patchPillById(doc.zoomRanges, id, {
 					focus: { cx: finiteFraction(focus.cx), cy: finiteFraction(focus.cy) },
 				}) as AxcutDocument["zoomRanges"],
 			};
-			setDocument(next);
+			setDocument(next, { history: dragStart });
 			zoomFocusLiveRef.current = next;
 		},
 		[setDocument],
@@ -665,12 +676,15 @@ export function useTimeline() {
 		(id: string, patch: Partial<AxcutDocument["annotations"][number]>) => {
 			const doc = useProjectStore.getState().document;
 			if (!doc) return;
-			if (annotationLiveRef.current !== doc) annotationRollbackRef.current = doc;
+			// One undo step per drag, not per pointermove — same reasoning as
+			// `updateZoomFocusLive` above.
+			const dragStart = annotationLiveRef.current !== doc;
+			if (dragStart) annotationRollbackRef.current = doc;
 			const next: AxcutDocument = {
 				...doc,
 				annotations: patchPillById(doc.annotations, id, patch),
 			};
-			setDocument(next);
+			setDocument(next, { history: dragStart });
 			annotationLiveRef.current = next;
 		},
 		[setDocument],


### PR DESCRIPTION
Ctrl+Z did nothing in the v4 editor. On macOS it did nothing for a second, independent reason.

Rebased onto `main` @ `1cc63df4`, so this now sits on top of the merged #437.

## Root cause

**The write path that users actually hit never recorded anything.**

`undo.ts` walked a snapshot stack that only `projectStore.setDocument` ever pushed to. But `setDocument` is the *optimistic, in-memory* writer, reserved for a handful of live paths — caption edits mid-typing, editor settings, the two `useTimeline` drag paths, the agent apply. Every ordinary edit goes through `saveDocument`, which round-trips to disk, and `saveDocument` **never recorded at all**. So `past` was empty for the edits users make, and Ctrl+Z had nothing to pop.

Where the stack *was* non-empty, redo was broken too. `setDocument` pushed via `void import("./undo").then(({ pushHistory }) => …)`, which lands in a **later microtask**. `undo()` restored its snapshot inside a synchronous `enabled = false` / `enabled = true` bracket, so by the time the deferred push ran the guard was armed again: the undo's own write was recorded as a fresh edit, that push cleared `future`, and redo was gone before the user could reach for it. Ctrl+Z degraded into an A/B toggle.

**On macOS the key never reached the renderer.**

Edit ▸ Undo was a bare `{ role: "undo" }` (`electron/main.ts:278` on `main`; there is no `registerAccelerator` field anywhere in the tree). An Electron role registers its standard accelerator, so the item owned Cmd+Z / Ctrl+Z. On darwin, AppKit matches a menu item's key equivalent inside `-[NSApplication sendEvent:]` *before* the key event is delivered to the web contents, so the renderer's keydown handler never ran. What the role ran instead — `webContents.undo()` — is the *web-editing* undo, which does nothing outside a focused text field. So Cmd+Z was swallowed by a menu item that could not have serviced it anyway.

(A smaller one, found on the way: the plain-undo branch tested `e.key === "z"`. With Caps Lock on, the browser reports `"Z"`, and the branch fell through to nothing. The redo branches already lowercased.)

## What changed

**Recording moved to the writers, and every call site has to say why.**

- `pushHistory` moved out of `undo.ts` into a new leaf module `undoStack.ts` that imports nothing from the store, so `projectStore → undoStack` is a static edge with no cycle and no deferred import. The microtask race is gone by construction.
- Both writers now record through one module-private `recordHistory` in `projectStore.ts`.
- `saveDocument` records **after the write lands**, not before — a failed save now records nothing, so a rollback has nothing to pop.
- `DocumentWriteOptions.history` is **required and deliberately not defaulted**. Omitting it is a compile error. A default is a decision nobody makes: defaulting to `true` is how a background duration probe pushed itself onto the stack, and defaulting to `false` would recreate #433 the next time somebody added an edit.
- `historyBase` handles live drags: a drag writes every pointermove with `history: false`, so at pointerup the store's "previous" document is the dragged one. The commit passes the pre-drag document instead.
- A write epoch (`currentWriteEpoch` / `supersedeInFlightWrites`) closes a race the fix itself opened: a save already in flight when Ctrl+Z was pressed used to install its document over the restored one and push a *forward* state onto `past`, wiping the redo the undo had just created.
- `undo()`/`redo()` restore by writing `useProjectStore.setState` directly rather than routing back through a recording writer.

**Structural closure — this is the part that matters more than the fix.**

#433 produced the *same* defect three times: a write the user never made recording itself as the thing their next Ctrl+Z reverses. Each round the fix was aimed at the instance. The third round is instructive: `replaceTimeline(intervals, reason)` hardcoded `{ history: true }` **inside itself**, so the option never appeared in the signature its callers see and no compile error could reach them. Its one caller is the unattended recording import that runs on editor mount — so a user landed in a brand-new project with `past.length === 1` and their first Ctrl+Z emptied their timeline.

So the closure is three-part:

1. **`pushHistory` has exactly one production caller.** `recordHistory`, and nothing else reaches it.
2. **Wrappers forward, they do not decide.** `replaceTimeline` and `useSequentialTimelineOps.apply` take `opts` and hand it through verbatim. A wrapper that writes has to let its caller decide, or it decides wrong on that caller's behalf.
3. **`documentWriteAudit.test.ts` pins all of it.** It parses `src/` with the TypeScript AST, finds every `saveDocument`/`setDocument` call, classifies each as `gesture` / `automatic` / `forwarded` (the last checked *structurally* — the identifier passed on must be a parameter of the enclosing function), and diffs the result against a hand-written table of **62 declared write sites** (43 gesture, 17 automatic, 2 forwarded). Two further tests pin that `recordHistory` is called only by `saveDocument` and `setDocument`, and that `pushHistory` is reached only from `recordHistory` — which is what makes the table the whole surface rather than a sample of it. Add, move or reclassify a write and this fails with a plain diff.

**The macOS route.**

`electron/edit-menu.ts` (split out of `main.ts` so it is testable) gives Undo/Redo explicit `CmdOrCtrl+Z` / `Shift+CmdOrCtrl+Z` accelerators instead of roles, on every platform, and forwards clicks to `menu-undo` / `menu-redo`. `main.ts` routes those to the focused window; if that window is not the editor it falls through to `webContents.undo()`, which is the right answer there, and it never *creates* an editor window — Cmd+Z is not a request to open the editor. The renderer exposes `runUndo` / `runRedo` from `useUndoRedoShortcuts`, which apply the same rule the keydown path applies: a focused text field gets the browser's own text undo, anything else gets the document undo. The clipboard items keep their roles — they act on the focused selection, which is exactly what the roles do.

**It carries the modal guard on that route, which is what makes it safe next to #434.**

#437 fixed the keydown hole. This branch adds a *second* entry point to the same document undo, and that entry point needed the same guard — arguably more urgently. A modal's controls are buttons, so the text-field check waves them straight through; and on macOS the menu is the only path Cmd+Z has, with no keydown handler upstream to stop it. So `runUndo`/`runRedo` call `isModalOpen()` **after** the text-field check (a rename dialog's input still gets text undo) and before touching the document. Same predicate, same module (`lib/ai-edition/modalGuard`) — this branch and #437 converged on a byte-identical `modalGuard.ts`, so the rebase took main's copy unchanged.

## Verification

Rebased onto `origin/main` (`1cc63df4`) and run there:

```
npx tsc --noEmit                            exit 0, no output
npx tsc -p tsconfig.test.json --noEmit      exit 0, no output
npm run lint                                exit 0 — Checked 676 files, 13 warnings
npx vitest --run src/lib/ai-edition src/components/ai-edition \
                 src/contexts src/components/ui electron
  Test Files  114 passed (114)
  Tests       1399 passed | 4 skipped (1403)
```

The 13 lint warnings and the 4 skips are pre-existing on `main` and live in files this branch does not touch.

New cover, beyond the audit table:
- `store/undo.test.ts` — undo/redo actually apply and repaint; redo survives an undo; a save in flight across a Ctrl+Z cannot clobber the restore; the menu route's text-field rule; the modal guard (an `aria-modal="true"` node in the body, `runUndo` leaves the document untouched, `past` and `future` unmoved, no persist — and it comes back when the node is removed).
- `electron/edit-menu.test.ts` — the items own their accelerators, carry no `role` and no `registerAccelerator`, and dispatch `menu-undo` / `menu-redo`.
- Regression cover in `useTimeline`, `useSequentialTimelineOps`, `agentDocumentApply`, `recordingImport` and `projectStore` tests for the specific writes that used to record and must not.

## What this does not prove

**The honest limitation, stated plainly.** TypeScript cannot express *"this code ran because the user did something."* `history: true` on an automatic write is a **type-correct lie** — it compiles, it type-checks, and it is wrong. The required option forces a *direct* call site to decide; it cannot see that the function doing the deciding had no business deciding, which is exactly how round 3 above got through. The audit table is a **speed bump backed by a hard failure**, not a proof: it makes an undeclared or reclassified write fail CI with a diff somebody has to read and resolve by writing down a judgement. It does not make the wrong judgement impossible — someone can still write `"gesture"` next to a background job and go green.

The version that would be airtight is a **UserGesture-token refactor**: make the option take a token that can only be minted in an event handler, so "the user did this" becomes something the type system carries rather than something a comment asserts. That is a much larger change across every write site and every wrapper signature, and it was **deliberately left out of scope here**. This PR buys the structural property that makes it feasible later — one recording chokepoint, wrappers that forward — without attempting it.

**Untested paths**, named rather than glossed:
- **Real macOS AppKit key routing.** `edit-menu.test.ts` asserts the menu *descriptor* — accelerator string, absence of `role`, the dispatch on click — in isolation under node. It does not, and cannot here, verify that AppKit delivers the key equivalent to that item on a real Mac, or that the IPC round-trip lands in the editor renderer. The reasoning about `-[NSApplication sendEvent:]` and the `@platform linux,win32` annotation is from Electron's own type declarations and the observed symptom; it wants a manual check on macOS before release.
- **The browser text-undo fallback.** `document.execCommand("undo")` is absent under jsdom, hence the optional call. The tests assert the document undo *stays out of the way* when a text field has focus; they do not assert the browser's text undo then happens.
- No end-to-end run of the Edit menu against a packaged build on any platform.

Fixes #433


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1540383170703261778 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable undo and redo across editor actions, including native Edit menu commands on macOS.
  * Added history-aware handling for timeline edits, captions, settings, drag operations, and project saves.
  * Combined clip source-range and crop changes into a single undoable edit.
* **Bug Fixes**
  * Prevented background updates and recording imports from creating unwanted undo steps.
  * Improved failed and overlapping save handling without losing user edits or redo history.
  * Prevented stale drag states from affecting later edits or projects.
* **Tests**
  * Added comprehensive coverage for undo/redo behavior, save races, native menu actions, and timeline operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->