### PR TITLE
test(ai-edition): share one base document in the addZoom invariant

### DIFF
--- a/electron/ai-edition/agent-tools.test.ts
+++ b/electron/ai-edition/agent-tools.test.ts
@@ -1761,9 +1761,16 @@ describe("addZoom answers for the focus it was given", () => {
 		// that can read telemetry and one written by a runtime that cannot must be
 		// the same zoom, in the same place, described to the user the same way.
 		const args = JSON.stringify({ startSec: 2, endSec: 6, focus: { cx: 0.2, cy: 0.1 } });
-		const blind = executeAgentTool(fixtureDocument(), "addZoom", args);
+		// ponytail: ONE base for both runs. Two `fixtureDocument()` calls are two
+		// different inputs — `createEmptyDocument` stamps `createdAt`/`updatedAt`
+		// with the wall clock, so the pair differs whenever the calls straddle a
+		// millisecond, and this assertion was a coin flip on a loaded runner. The
+		// invariant is about the same document written by two runtimes; handing them
+		// the same document is what states it.
+		const base = fixtureDocument();
+		const blind = executeAgentTool(base, "addZoom", args);
 		const seeing = executeAgentTool(
-			fixtureDocument(),
+			base,
 			"addZoom",
 			args,
 			withTrack(parkedSamples(2, 6, 0.8, 0.7)),


### PR DESCRIPTION
## Summary

`main` has a flaky test. It just failed CI on an unrelated PR (#440, which touches only `workbench/`) with a one-digit diff:

```
"createdAt":"…T15:37:58.275Z"   vs   "createdAt":"…T15:37:58.276Z"
```

`addZoom answers for the focus it was given > reports; it does not place` calls `fixtureDocument()` **twice**, and `createEmptyDocument` stamps `createdAt`/`updatedAt` from the wall clock. So the two runs it compares start from two different documents, and `withoutIds` normalises zoom ids but not timestamps. The assertion holds only while both calls land in the same millisecond — a coin flip on a loaded runner.

Handing both runs the **same** document is also the invariant the test means to state: one zoom, written by a runtime that can read telemetry and one that cannot, must come out identical. Comparing the outputs of two different inputs was never that claim. `executeAgentTool` returns a new document rather than mutating its argument, and the shared-base pattern is already used elsewhere in this file.

Arrived with #431; not specific to anything in flight.

## Related issue

Refs #431

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [x] No release note needed

## Desktop impact
- [x] Not platform-specific

## Testing

- `npx vitest --run electron/ai-edition/agent-tools.test.ts` — 82 passed, run **8 times** consecutively, green every time.
- `npx tsc -p tsconfig.test.json --noEmit` — clean.
- `npx biome check` — clean.

The flake is timing-dependent, so a green run does not prove much on its own; the argument is the removed dependency on two wall-clock reads landing in the same millisecond, not the run count.

<!-- discord-thread-id:1540386438259015801 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for zoom-related telemetry checks.
  * Ensured comparisons use consistent fixture data and are not affected by timestamp differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->