### PR TITLE
fix(editor): treat a malformed legacyEditor envelope as absent, not as a crash

### DIFF
--- a/src/lib/ai-edition/document/timeline.test.ts
+++ b/src/lib/ai-edition/document/timeline.test.ts
@@ -1518,3 +1518,82 @@ describe("removeClip — delete a clip, close the gap, drop its pills", () => {
 		expect(next).toBe(before);
 	});
 });
+
+// #356: `legacyEditorSchema` is `z.object({}).passthrough()`, so a project file whose
+// envelope holds a non-array where a region collection belongs is schema-valid and loads
+// without a word. Every clip edit — delete / move / duplicate / source-range — walks those
+// collections through `mapAllRegionCollections`, which used to call `.filter()` on whatever
+// it found and take the whole editor down with `regions.filter is not a function`. The
+// malformed value is left exactly as it was found (the same call `upgradeV4DocumentToV5`
+// makes): the rest of the document still edits, and nothing the user had is discarded.
+describe("a malformed legacyEditor envelope", () => {
+	const doc = (legacyEditor: AxcutDocument["legacyEditor"]) =>
+		makeDoc({
+			timeline: {
+				...makeDoc().timeline,
+				clips: [
+					makeClip({ id: "clip_a", sourceStartSec: 0, sourceEndSec: 10, timelineEndSec: 10 }),
+					makeClip({
+						id: "clip_b",
+						sourceStartSec: 0,
+						sourceEndSec: 10,
+						timelineStartSec: 10,
+						timelineEndSec: 20,
+					}),
+				],
+			},
+			legacyEditor,
+		});
+
+	it("deletes a clip instead of throwing, and keeps the sibling collection working", () => {
+		const before = doc({
+			speedRegions: "oops",
+			cameraFullscreenRegions: [
+				{
+					id: "cam_b",
+					clipId: "clip_b",
+					sourceStartSec: 2,
+					sourceEndSec: 4,
+					startMs: 12000,
+					endMs: 14000,
+				},
+			],
+		});
+
+		const next = removeClip(before, "clip_a");
+
+		expect(next.timeline.clips.map((c) => c.id)).toEqual(["clip_b"]);
+		const legacy = next.legacyEditor as {
+			speedRegions: unknown;
+			cameraFullscreenRegions: Array<{ id: string; startMs: number; endMs: number }>;
+		};
+		// Untouched, not dropped — we cannot walk it, which is not a reason to delete it.
+		expect(legacy.speedRegions).toBe("oops");
+		// The well-formed neighbour is still rederived: clip_b slid 10s to the front.
+		expect(legacy.cameraFullscreenRegions).toEqual([
+			expect.objectContaining({ id: "cam_b", startMs: 2000, endMs: 4000 }),
+		]);
+	});
+
+	it("passes the envelope through by reference when no collection is walkable", () => {
+		const before = doc({ speedRegions: "oops", cameraFullscreenRegions: { id: "not_a_list" } });
+
+		const next = removeClip(before, "clip_a");
+
+		expect(next.timeline.clips.map((c) => c.id)).toEqual(["clip_b"]);
+		expect(next.legacyEditor).toBe(before.legacyEditor);
+		expect(next.legacyEditor).toEqual({
+			speedRegions: "oops",
+			cameraFullscreenRegions: { id: "not_a_list" },
+		});
+	});
+
+	it("edits a clip's source range instead of throwing", () => {
+		const before = doc({ speedRegions: null, cameraFullscreenRegions: 42 });
+
+		const next = setClipSourceRange(before, "clip_a", 2, 5);
+
+		expect(next.timeline.clips[0]).toMatchObject({ sourceStartSec: 2, sourceEndSec: 5 });
+		expect(next.legacyEditor).toEqual({ speedRegions: null, cameraFullscreenRegions: 42 });
+	});
+});

--- a/src/lib/ai-edition/document/timeline.ts
+++ b/src/lib/ai-edition/document/timeline.ts
@@ -235,8 +235,19 @@ function mapAllRegionCollections(
 	fn: (regions: StoredRegion[], prefix: string) => StoredRegion[],
 ): AxcutDocument {
 	const legacy = document.legacyEditor as Record<string, unknown> | null;
-	const speedRegions = legacy?.speedRegions as StoredRegion[] | undefined;
-	const cameraFullscreenRegions = legacy?.cameraFullscreenRegions as StoredRegion[] | undefined;
+	// The envelope is `z.object({}).passthrough()`, so zod validates NOTHING inside it: a
+	// project file whose `speedRegions` is a string loads clean and only detonates here, on
+	// the first clip edit (`regions.filter is not a function` — #356). Guard exactly as
+	// `upgradeV4DocumentToV5` already does, and for the same reason: a non-array is not a
+	// collection we can walk. Treating it as absent leaves it in place via the `...legacy`
+	// spread below, so the rest of the document still edits normally and nothing the user
+	// had is thrown away on our way past it.
+	const speedRegions = Array.isArray(legacy?.speedRegions)
+		? (legacy?.speedRegions as StoredRegion[])
+		: undefined;
+	const cameraFullscreenRegions = Array.isArray(legacy?.cameraFullscreenRegions)
+		? (legacy?.cameraFullscreenRegions as StoredRegion[])
+		: undefined;
 
 	return {
 		...document,


### PR DESCRIPTION
`legacyEditorSchema` is `z.object({}).passthrough()`, so zod validates nothing inside it. A project file whose `speedRegions` is a string loads clean and only detonates on the first clip edit, with `regions.filter is not a function`. Every clip delete / move / duplicate / source-range edit routes through `mapAllRegionCollections`, so the editor is stuck until the file is repaired by hand.

## The fix

Guard the two envelope fields the function walks exactly as `upgradeV4DocumentToV5` already guards them — the migration path has known better all along, the runtime path just never caught up.

**Preserved, not dropped.** A non-array is not a collection we can walk, but it is also not ours to delete: treating it as absent leaves it in place through the `...legacy` spread, so the rest of the document edits normally and nothing the user had is thrown away on the way past it. When neither field is walkable the function returns `document.legacyEditor` by reference, so the envelope comes out bit-identical.

## Tests

Three cases in `timeline.test.ts`, all confirmed to fail on the pre-fix code (`TypeError: regions.flatMap is not a function`): a malformed field alongside a well-formed neighbour, both fields malformed (asserting the *same reference* comes back, which pins "preserved" rather than "rebuilt to look the same"), and a second route into the same function via `setClipSourceRange`.

## Scope

Tightening `legacyEditorSchema` so these arrays are validated at load time is the deeper fix and is deliberately not in here. Worth noting for whoever picks that up: `anchoredRegionsOf` makes the same unchecked cast on the same two fields. It cannot crash — `.flat()` does not flatten a non-array and `hasCompleteClipAnchor` rejects a string — but it is the same latent assumption.

Fixes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1540394546834448475 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed clip deletion and source-range edits failing when legacy region collections contain malformed, non-array values.
  * Preserved malformed collection values while continuing to update valid region collections.
  * Preserved the editor data when no valid collections can be processed.

* **Tests**
  * Added regression coverage for malformed legacy region collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->