### PR TITLE
feat(export): keep "Show in folder" on the success panel, not only in the toast

### DIFF
--- a/src/components/ai-edition/ExportDialog.showInFolder.test.tsx
+++ b/src/components/ai-edition/ExportDialog.showInFolder.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+// The export dialog's done panel keeps a "Show in folder" action around after a successful
+// export. The success toast has always offered one, but a toast is gone in five seconds — the
+// panel's button is the persistent affordance (issue #268).
+import "@testing-library/jest-dom";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner", () => ({
+	toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/native", () => ({
+	exportMultiNative: vi.fn(async () => ({ videoDurationS: 12, wallS: 3 })),
+	exportGifNative: vi.fn(async () => ({ videoDurationS: 12, wallS: 3 })),
+	useIsCpuCompositor: () => false,
+}));
+
+vi.mock("@/native/sceneDescription", () => ({
+	buildSceneDescription: () => ({}),
+	resolveVisibleClips: (doc: AxcutDocument) => doc.timeline.clips,
+}));
+
+import { toast } from "sonner";
+import { I18nProvider } from "@/contexts/I18nContext";
+import { type AxcutDocument, axcutSchemaVersion } from "@/lib/ai-edition/schema";
+import { ExportDialog } from "./ExportDialog";
+
+type ElectronAPI = Window["electronAPI"];
+
+const SAVED_PATH = "/tmp/openscreen/Test_project.mp4";
+
+const noop = () => undefined;
+
+const DOC: AxcutDocument = {
+	schemaVersion: axcutSchemaVersion,
+	project: {
+		id: "proj_1",
+		title: "Test project",
+		createdAt: "2026-06-26T10:00:00Z",
+		updatedAt: "2026-06-26T10:00:00Z",
+		primaryAssetId: "a1",
+	},
+	assets: [
+		{
+			id: "a1",
+			kind: "video",
+			label: "asset",
+			originalPath: "/tmp/a.mp4",
+			cameraTrack: null,
+			video: { codec: "h264", width: 1920, height: 1080, fps: 30 },
+		},
+	],
+	transcript: null,
+	transcripts: [],
+	timeline: {
+		clips: [
+			{
+				id: "c1",
+				assetId: "a1",
+				sourceStartSec: 0,
+				sourceEndSec: 10,
+				timelineStartSec: 0,
+				timelineEndSec: 10,
+				wordRefs: [],
+				origin: "user",
+				reason: "",
+			},
+		],
+		gaps: [],
+		trimRanges: [],
+		muteRanges: [],
+		speedRanges: [],
+		captionRanges: [],
+	},
+	annotations: [],
+	zoomRanges: [],
+	legacyEditor: null,
+};
+
+let revealInFolder: ReturnType<typeof vi.fn>;
+
+/** Only what one successful MP4 export touches — anything else the dialog reaches for is
+ *  absent, which is the point. */
+function stubElectronAPI(reveal: () => Promise<unknown>) {
+	revealInFolder = vi.fn(reveal);
+	window.electronAPI = {
+		pickExportSavePath: vi.fn(async () => ({ path: SAVED_PATH })),
+		onNativeExportProgress: vi.fn(() => noop),
+		revealInFolder,
+	} as unknown as ElectronAPI;
+}
+
+/** Runs an export to completion and hands back the done panel's reveal button. */
+async function exportAndFindRevealButton() {
+	render(
+		<I18nProvider>
+			<ExportDialog open={true} onClose={noop} document={DOC} />
+		</I18nProvider>,
+	);
+	fireEvent.click(screen.getByRole("button", { name: /export mp4/i }));
+	return await screen.findByTestId("export-show-in-folder");
+}
+
+describe("ExportDialog done panel — show in folder", () => {
+	beforeEach(() => {
+		stubElectronAPI(async () => ({ success: true }));
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+		vi.restoreAllMocks();
+	});
+
+	it("reveals the exported file from the persistent done panel, not just the toast", async () => {
+		const button = await exportAndFindRevealButton();
+
+		// The reused `exportDialog.showInFolder` key, next to the path the export wrote.
+		expect(button).toHaveTextContent(/show in folder/i);
+		expect(screen.getByText(SAVED_PATH)).toBeInTheDocument();
+
+		fireEvent.click(button);
+
+		expect(revealInFolder).toHaveBeenCalledWith(SAVED_PATH);
+	});
+
+	it("logs a rejected reveal instead of raising a second error toast", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(noop);
+		stubElectronAPI(async () => {
+			throw new Error("no such file");
+		});
+
+		fireEvent.click(await exportAndFindRevealButton());
+
+		await waitFor(() => expect(warn).toHaveBeenCalled());
+		// The export itself succeeded; only opening the folder failed.
+		expect(toast.error).not.toHaveBeenCalled();
+	});
+
+	it("logs a `success: false` result — the main handler's fallback failed too", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(noop);
+		stubElectronAPI(async () => ({ success: false, error: "ENOENT" }));
+
+		fireEvent.click(await exportAndFindRevealButton());
+
+		await waitFor(() =>
+			expect(warn).toHaveBeenCalledWith(expect.stringContaining("folder"), "ENOENT"),
+		);
+		expect(toast.error).not.toHaveBeenCalled();
+	});
+});

--- a/src/components/ai-edition/ExportDialog.tsx
+++ b/src/components/ai-edition/ExportDialog.tsx
@@ -8,7 +8,7 @@
 // used by the legacy VideoEditor; this one is a compact surface tuned for
 // the new shell's modal style.
 
-import { Download, FileVideo, Loader2 } from "lucide-react";
+import { Download, FileVideo, FolderOpen, Loader2 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useScopedT } from "@/contexts/I18nContext";
@@ -49,6 +49,29 @@ function formatHms(totalSeconds: number): string {
 	const m = Math.floor((s % 3600) / 60);
 	const sec = s % 60;
 	return [h, m, sec].map((v) => v.toString().padStart(2, "0")).join(":");
+}
+
+/** Opens the exported file's containing folder, selecting the file itself where the OS supports
+ *  it. The main handler owns the fallback (`shell.openPath` on the parent directory) for the
+ *  cases `showItemInFolder` rejects — a file moved or deleted since the export, or a platform
+ *  that cannot reveal — so nothing here has to pre-check that the file still exists.
+ *
+ *  Shared by the success toast's action and the done panel's button so the two can't drift.
+ *  `revealInFolder` is a bare ipcRenderer.invoke, so it rejects when the main handler throws,
+ *  and resolves `{ success: false }` when even the fallback failed. The export already
+ *  succeeded — failing to open the folder is not worth a second error toast, but it is worth
+ *  a line. */
+function revealExportedFile(filePath: string): void {
+	void window.electronAPI
+		?.revealInFolder?.(filePath)
+		.then((result) => {
+			if (!result?.success) {
+				console.warn("[export] could not open the exported file's folder:", result?.error);
+			}
+		})
+		.catch((err) => {
+			console.warn("[export] failed to reveal the file in its folder:", err);
+		});
 }
 
 /** Maps the document's timeline to the native multiclip export contract: ordered,
@@ -313,14 +336,9 @@ export function ExportDialog({ open, onClose, document }: ExportDialogProps) {
 					description: `${pickedPath} · ${formatHms(stats.videoDurationS)} ${t("exportDialog.exportedVideoOf")} ${formatHms(stats.wallS)}`,
 					action: {
 						label: t("exportDialog.showInFolder"),
-						onClick: () => {
-							// `revealInFolder` is a bare ipcRenderer.invoke, so it rejects when
-							// the main handler throws. The export already succeeded — failing to
-							// open the folder is not worth a second toast, but it is worth a line.
-							void window.electronAPI?.revealInFolder?.(pickedPath).catch((err) => {
-								console.warn("[export] failed to reveal the file in its folder:", err);
-							});
-						},
+						// The toast is gone in five seconds; the done panel below keeps the same
+						// action around for as long as the dialog is open.
+						onClick: () => revealExportedFile(pickedPath),
 					},
 				});
 			} catch (err) {
@@ -746,10 +764,27 @@ function ProgressBlock({
 					background: "var(--success-soft)",
 					color: "var(--fg-2)",
 					font: "500 12px var(--font-body)",
+					display: "flex",
+					flexDirection: "column",
+					alignItems: "flex-start",
+					gap: 12,
 				}}
 			>
-				{t("exportDialog.savedTo")}{" "}
-				<span style={{ fontFamily: "var(--font-mono)" }}>{savedPath}</span>
+				<div>
+					{t("exportDialog.savedTo")}{" "}
+					<span style={{ fontFamily: "var(--font-mono)" }}>{savedPath}</span>
+				</div>
+				{savedPath ? (
+					<button
+						type="button"
+						data-testid="export-show-in-folder"
+						className={`${styles.btn} ${styles.btnSecondary}`}
+						onClick={() => revealExportedFile(savedPath)}
+					>
+						<FolderOpen size={14} />
+						{t("exportDialog.showInFolder")}
+					</button>
+				) : null}
 			</div>
 		);
 	}


### PR DESCRIPTION
The export dialog already offered to reveal the file, but only as an action on the success toast — which is gone in five seconds, while the dialog stays open showing the path the user now has to navigate to by hand.

## The fix

Put the same action on the done panel, and route both entry points through one `revealExportedFile` helper so the two cannot drift.

**No new i18n key.** `exportDialog.showInFolder` already exists in all 13 locales for the toast, so the button reuses it and `npm run i18n:check` passes untouched.

**No renderer-side existence check.** The main handler already falls back to opening the parent directory when `showItemInFolder` rejects — a file moved or deleted since the export, or a platform that cannot reveal — so the "file no longer exists" acceptance criterion is met where the fallback already lives. Two failure modes are logged and neither raises a second toast: the export succeeded, and failing to open a folder is not worth shouting about. The one the previous code missed is the invoke *resolving* `{ success: false }`, i.e. the fallback itself failed; only the rejection was handled before.

## Tests

New `ExportDialog.showInFolder.test.tsx` renders the real dialog under `I18nProvider` — so the reused key is genuinely resolved rather than stubbed — drives an export to `done`, and asserts the button calls `revealInFolder` with the saved path and that neither failure mode raises `toast.error`.

## Not verified

The button's **appearance** on the green success panel has no eyes on it. It reuses the dialog's own `btn`/`btnSecondary` classes and is asserted through the DOM, but every path to a pixel-level check was closed off: the dev app and a locally packaged build are both filtered out of automated screenshots, which only cover installed applications. Worth a glance during review.

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1540394785309728920 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a persistent **Show in Folder** action after successful MP4 exports.
  - Displays the exported file path in the completed export panel.
  - Opens the exported file’s containing folder when selected.

- **Bug Fixes**
  - Handles folder-opening failures gracefully without displaying duplicate error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->