### PR TITLE
test(ai-edition): pin the fixture clock instead of racing it

### DIFF
--- a/electron/ai-edition/agent-tools.test.ts
+++ b/electron/ai-edition/agent-tools.test.ts
@@ -7,8 +7,21 @@ import {
 import { ZOOM_DEPTH_SCALES } from "../../src/lib/ai-edition/timeline/zoom-scale";
 import { executeAgentTool, isMutatingTool, MUTATING_TOOL_NAMES } from "./agent-tools";
 
+/** ponytail: every fixture in this file starts from the SAME instant.
+ *  `createEmptyDocument` reads the wall clock when a caller hands it no
+ *  `createdAt`, so two documents built by two calls carry different
+ *  `createdAt`/`updatedAt` whenever the calls straddle a millisecond — and any
+ *  assertion that compares two of them is a coin flip on a loaded runner. That
+ *  already failed a PR touching none of this code. No test here reads the value,
+ *  so pinning it costs nothing and makes every document in the file comparable. */
+const FIXTURE_CREATED_AT = "2026-01-01T00:00:00.000Z";
+
 function fixtureDocument(): AxcutDocument {
-	const base = createEmptyDocument({ title: "Test", projectId: "proj_1" });
+	const base = createEmptyDocument({
+		title: "Test",
+		projectId: "proj_1",
+		createdAt: FIXTURE_CREATED_AT,
+	});
 	return documentSchema.parse({
 		...base,
 		project: { ...base.project, primaryAssetId: "asset_1" },
@@ -75,7 +88,11 @@ function fixtureDocument(): AxcutDocument {
 /** One clip whose end is NOT a round number — the real recording length that
  * made the clamp visible (24.703979 s of source, stored as 24 704 ms). */
 function shortSingleClip(): AxcutDocument {
-	const base = createEmptyDocument({ title: "Short", projectId: "proj_short" });
+	const base = createEmptyDocument({
+		title: "Short",
+		projectId: "proj_short",
+		createdAt: FIXTURE_CREATED_AT,
+	});
 	return documentSchema.parse({
 		...base,
 		project: { ...base.project, primaryAssetId: "asset_1" },
@@ -1133,7 +1150,11 @@ describe("replaceTimeline refuses what it would destroy", () => {
 	/** The workbench's `twoClipsWithTrim`: clips placed by the AGENT, which is
 	 *  exactly what the old `origin === "user"` guard could not see. */
 	function twoAgentClipsWithTrim(): AxcutDocument {
-		const base = createEmptyDocument({ title: "Two clips", projectId: "proj_two" });
+		const base = createEmptyDocument({
+			title: "Two clips",
+			projectId: "proj_two",
+			createdAt: FIXTURE_CREATED_AT,
+		});
 		return documentSchema.parse({
 			...base,
 			project: { ...base.project, primaryAssetId: "asset_1" },
@@ -1267,7 +1288,11 @@ describe("replaceTimeline refuses what it would destroy", () => {
 
 describe("moveClip — the tool the prompt used to promise", () => {
 	function twoClips(): AxcutDocument {
-		const base = createEmptyDocument({ title: "Two clips", projectId: "proj_move" });
+		const base = createEmptyDocument({
+			title: "Two clips",
+			projectId: "proj_move",
+			createdAt: FIXTURE_CREATED_AT,
+		});
 		return documentSchema.parse({
 			...base,
 			project: { ...base.project, primaryAssetId: "asset_1" },
@@ -1673,7 +1698,11 @@ function withTrack(
  *  from IDENTICAL source windows, which is what makes reading one asset's track
  *  as if it described the other silently plausible. */
 function twoAssetDocument(): AxcutDocument {
-	const base = createEmptyDocument({ title: "Two", projectId: "proj_two" });
+	const base = createEmptyDocument({
+		title: "Two",
+		projectId: "proj_two",
+		createdAt: FIXTURE_CREATED_AT,
+	});
 	return documentSchema.parse({
 		...base,
 		project: { ...base.project, primaryAssetId: "asset_1" },
@@ -1761,12 +1790,11 @@ describe("addZoom answers for the focus it was given", () => {
 		// that can read telemetry and one written by a runtime that cannot must be
 		// the same zoom, in the same place, described to the user the same way.
 		const args = JSON.stringify({ startSec: 2, endSec: 6, focus: { cx: 0.2, cy: 0.1 } });
-		// ponytail: ONE base for both runs. Two `fixtureDocument()` calls are two
-		// different inputs — `createEmptyDocument` stamps `createdAt`/`updatedAt`
-		// with the wall clock, so the pair differs whenever the calls straddle a
-		// millisecond, and this assertion was a coin flip on a loaded runner. The
-		// invariant is about the same document written by two runtimes; handing them
-		// the same document is what states it.
+		// ponytail: ONE base for both runs. The invariant is about the same document
+		// written by two runtimes, and comparing the outputs of two separate
+		// `fixtureDocument()` calls was never that claim. (The wall-clock stamps that
+		// made the two-call form flake are pinned at `FIXTURE_CREATED_AT` now — the
+		// argument for one base is the invariant, not the flake.)
 		const base = fixtureDocument();
 		const blind = executeAgentTool(base, "addZoom", args);
 		const seeing = executeAgentTool(

--- a/electron/ai-edition/deep-agent/service.test.ts
+++ b/electron/ai-edition/deep-agent/service.test.ts
@@ -78,8 +78,20 @@ const ARGS: Record<string, unknown> = {
 	removeClip: { clipId: "clip_1" },
 };
 
+/** ponytail: the fixture starts from a FIXED instant. `createEmptyDocument` reads
+ *  the wall clock when a caller hands it no `createdAt`, so two documents built by
+ *  two calls carry different `createdAt`/`updatedAt` whenever the calls straddle a
+ *  millisecond — which is what made an assertion over in `agent-tools.test.ts` fail
+ *  a PR that touched none of it. Nothing here compares two documents yet; pinning is
+ *  what keeps the one that does from being a coin flip on a loaded runner. */
+const FIXTURE_CREATED_AT = "2026-01-01T00:00:00.000Z";
+
 function fixtureDocument(): AxcutDocument {
-	const base = createEmptyDocument({ title: "Test", projectId: "proj_1" });
+	const base = createEmptyDocument({
+		title: "Test",
+		projectId: "proj_1",
+		createdAt: FIXTURE_CREATED_AT,
+	});
 	return documentSchema.parse({
 		...base,
 		project: { ...base.project, primaryAssetId: "asset_1" },


### PR DESCRIPTION
## Summary

`createEmptyDocument` stamps `createdAt`/`updatedAt` from the wall clock unless the caller passes `createdAt`, and every document fixture in `electron/ai-edition/agent-tools.test.ts` and `electron/ai-edition/deep-agent/service.test.ts` took that default. Two fixtures built by two calls therefore differ whenever the calls straddle a millisecond, so any assertion comparing two of them is a coin flip on a loaded runner — which is exactly how the `addZoom` invariant failed a PR that touched none of this code.

6d667000 fixed that one assertion by handing both runs the same document, which is also the invariant it means to state, so that stays. This removes the hazard at the source instead: the fixtures pass a fixed ISO string (`FIXTURE_CREATED_AT`) and stop reading the clock at all — five call sites in `agent-tools.test.ts`, one in `deep-agent/service.test.ts`. The value matches the existing precedent in `chat-compaction.test.ts`.

Nothing in either file reads `createdAt`/`updatedAt`, and `executeAgentTool` never restamps `updatedAt`, so the fixture was the only clock in play. Pinning it costs nothing and makes every document in both files comparable.

The inline note on the invariant is rewritten to match: it still claimed the wall-clock stamps were live at that call site, and after this they are not. The argument for one base is the invariant, not the flake.

The other test files that call `createEmptyDocument` were checked for the same trigger — two independently built documents deep-compared — and none has one; their assertions are `toMatchObject` on sub-objects or scalar checks. Left alone rather than pinned on speculation.

## Related issue

No issue — the flake was caught running the suite under load, on a branch that touches none of this code.

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation
- [x] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [ ] Patch
- [ ] Minor
- [ ] Major / breaking change
- [x] No release note needed

## Desktop impact
- [ ] Windows
- [ ] macOS
- [ ] Linux
- [ ] Installer / packaging
- [x] Not platform-specific

## Screenshots / video

None — test-only change, no user-visible surface.

## Testing

Windows 11, Node 22.22.1, fresh `npm ci` in the worktree.

| Check | Result |
| --- | --- |
| `npx vitest --run electron` ×5 consecutive | 42 files, 568 passed / 4 skipped — green every run |
| `npx vitest --run src/lib/ai-edition src/components/ai-edition electron` ×3 (the scope the flake reproduced in, roughly 1 run in 3) | 111 files, 1373 passed / 4 skipped — green every run |
| `npx tsc -p tsconfig.test.json --noEmit` | clean |
| `npx tsc --noEmit` | clean |
| `npm run lint` | 0 errors; 13 pre-existing warnings, none in the touched files |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1540419466658062377 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by using consistent timestamps in document fixtures.
  * Prevented intermittent failures caused by tiny timing differences between test runs.
  * Updated test comments to reflect the deterministic fixture behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->