### PR TITLE
fix(hud): dismiss the HUD popovers when the window loses focus

### DIFF
--- a/src/components/launch/LaunchWindow.test.tsx
+++ b/src/components/launch/LaunchWindow.test.tsx
@@ -303,6 +303,7 @@ function resetLaunchMocks() {
 	i18nState.value.acceptSystemLocaleSuggestion.mockClear();
 	i18nState.value.dismissSystemLocaleSuggestion.mockClear();
 	i18nState.value.resolveSystemLocaleSuggestion.mockClear();
+	i18nState.value.setLocale.mockClear();
 	linuxHelperAvailable.value = true;
 	appInfoState.value = { version: "1.9.6", canCheckForUpdates: true };
 	updateCheckMock.mockReset();
@@ -826,6 +827,126 @@ describe("LaunchWindow language menu", () => {
 		expect(menu.parentElement?.parentElement).toContainElement(
 			screen.getByTestId("hud-drag-handle"),
 		);
+	});
+});
+
+describe("LaunchWindow popover dismissal", () => {
+	beforeEach(() => {
+		platformState.value = "darwin";
+		resetLaunchMocks();
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.unstubAllGlobals();
+	});
+
+	/** Opens the language menu the way a user does, and hands back its panel. */
+	async function openLanguageMenu() {
+		fireEvent.click(await screen.findByRole("button", { name: "English" }));
+		return await screen.findByTestId("hud-language-menu");
+	}
+
+	/** Same for the device-settings panel. */
+	async function openDeviceSettings() {
+		fireEvent.click(await screen.findByTestId("launch-device-settings-button"));
+		return await screen.findByTestId("hud-device-settings");
+	}
+
+	it("closes the language menu on Escape without changing the locale", async () => {
+		renderLaunchWindow();
+		await openLanguageMenu();
+
+		fireEvent.keyDown(window, { key: "Escape" });
+
+		await waitFor(() => {
+			expect(screen.queryByTestId("hud-language-menu")).not.toBeInTheDocument();
+		});
+		// Escape dismisses; it must never pick whatever entry happened to be under
+		// the cursor or focused.
+		expect(i18nState.value.setLocale).not.toHaveBeenCalled();
+		expect(i18nState.value.resolveSystemLocaleSuggestion).not.toHaveBeenCalled();
+	});
+
+	it("closes the language menu on a pointerdown outside the trigger and the panel", async () => {
+		renderLaunchWindow();
+		await openLanguageMenu();
+
+		// The HUD window is mostly empty reserve above the bar; a press there is a
+		// real DOM pointerdown on the root, and it has to dismiss.
+		fireEvent.pointerDown(document.body);
+
+		await waitFor(() => {
+			expect(screen.queryByTestId("hud-language-menu")).not.toBeInTheDocument();
+		});
+		expect(i18nState.value.setLocale).not.toHaveBeenCalled();
+	});
+
+	it("keeps the language menu open for a pointerdown inside the panel", async () => {
+		renderLaunchWindow();
+		const menu = await openLanguageMenu();
+
+		fireEvent.pointerDown(menu);
+
+		expect(screen.getByTestId("hud-language-menu")).toBeInTheDocument();
+	});
+
+	it("closes the language menu when the HUD window loses focus", async () => {
+		renderLaunchWindow();
+		await openLanguageMenu();
+
+		// A click that lands beyond the HUD's native window produces no pointerdown
+		// in this renderer at all — the only signal it gets is the window blur. And
+		// once focus is gone, Escape can no longer be delivered here either, so this
+		// is the one listener that can unstick that state (issue #435).
+		fireEvent.blur(window);
+
+		await waitFor(() => {
+			expect(screen.queryByTestId("hud-language-menu")).not.toBeInTheDocument();
+		});
+		expect(i18nState.value.setLocale).not.toHaveBeenCalled();
+	});
+
+	it("closes the device-settings panel on Escape", async () => {
+		renderLaunchWindow();
+		await openDeviceSettings();
+
+		fireEvent.keyDown(window, { key: "Escape" });
+
+		await waitFor(() => {
+			expect(screen.queryByTestId("hud-device-settings")).not.toBeInTheDocument();
+		});
+	});
+
+	it("closes the device-settings panel on a pointerdown outside the trigger and the panel", async () => {
+		renderLaunchWindow();
+		await openDeviceSettings();
+
+		fireEvent.pointerDown(document.body);
+
+		await waitFor(() => {
+			expect(screen.queryByTestId("hud-device-settings")).not.toBeInTheDocument();
+		});
+	});
+
+	it("closes the device-settings panel when the HUD window loses focus", async () => {
+		renderLaunchWindow();
+		await openDeviceSettings();
+
+		fireEvent.blur(window);
+
+		await waitFor(() => {
+			expect(screen.queryByTestId("hud-device-settings")).not.toBeInTheDocument();
+		});
+	});
+
+	it("leaves a key that is not Escape alone", async () => {
+		renderLaunchWindow();
+		await openLanguageMenu();
+
+		fireEvent.keyDown(window, { key: "a" });
+
+		expect(screen.getByTestId("hud-language-menu")).toBeInTheDocument();
 	});
 });
 

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -284,7 +284,7 @@ export function LaunchWindow() {
 	}, []);
 
 	// One dismiss handler for both floating surfaces — they're mutually exclusive,
-	// so a single pointerdown/Escape listener covers the pair instead of two.
+	// so a single pointerdown/Escape/blur listener covers the pair instead of two.
 	const closePopovers = useCallback(() => {
 		setIsDeviceSettingsOpen(false);
 		setIsLanguageMenuOpen(false);
@@ -311,10 +311,21 @@ export function LaunchWindow() {
 
 		window.addEventListener("pointerdown", handlePointerDown);
 		window.addEventListener("keydown", handleEscape);
+		// The third dismiss path, and the one that made issue #435: the HUD's native
+		// window is only 904x698, so a click anywhere else on screen reaches this
+		// renderer as nothing at all — no pointerdown to hit-test — while still taking
+		// keyboard focus away. Escape is then undeliverable here, and the popover was
+		// stuck open until the trigger was found again. `blur` is the one signal that
+		// crosses, so it closes the pair; after this the "popover open in a window
+		// that has no focus" state simply doesn't exist. Bubble phase on purpose:
+		// element blur doesn't bubble, so this only ever fires for the window itself
+		// and never when focus moves between the menu's own buttons.
+		window.addEventListener("blur", closePopovers);
 
 		return () => {
 			window.removeEventListener("pointerdown", handlePointerDown);
 			window.removeEventListener("keydown", handleEscape);
+			window.removeEventListener("blur", closePopovers);
 		};
 	}, [closePopovers, isPopoverOpen]);
 


### PR DESCRIPTION
## What

A HUD popover — the language menu or the device-settings panel — stays open when you click anywhere outside the HUD's own window, and cannot then be dismissed by any means except finding its trigger again.

Fixes #435.

One listener:

```ts
window.addEventListener("blur", closePopovers);
```

## Root cause

The HUD's native window is ~904×698, centred at the bottom of the primary display. A click that lands beyond that rectangle reaches this renderer **as nothing at all** — there is no DOM `pointerdown` to hit-test, so no renderer-side listener can ever see it. The same click takes keyboard focus away, which makes `Escape` undeliverable here too. The popover is then stuck: both dismiss paths the component owns are, by construction, unreachable from that state.

`blur` is the one signal that does cross. The renderer receives it — measured on a packaged build, not assumed — and nothing anywhere in the app acted on it: `grep` for a `blur` listener over `src/components/launch/` and `electron/` returns none, and `createHudOverlayWindow` never wires `BrowserWindow`'s.

Closing on blur removes the state rather than patching its symptoms: after this, "a popover is open in a window that has no keyboard focus" cannot occur, so the two existing paths only ever have to work while the window *is* focused — which they do.

Bubble phase is deliberate. Element `blur` does not bubble, so a window-level bubble listener fires only for the window itself and never while focus moves between the menu's own buttons. Capture phase would have broken keyboard navigation inside the menu.

## Escape is not broken — and the issue title used to say it was

Worth stating plainly, because this branch was reviewed once against the old title and refused for not touching the `Escape` path. It should not touch it.

`handleEscape` works. A maintainer pressing `Esc` on a real keyboard closes the menu. Two automated passes concluded otherwise; both were measuring their own tooling.

Settled with a probe attached to the HUD renderer over the remote debugging port — observation only, recording every `keydown` in capture, bubble and document-capture phases, then driving the HUD with the same synthetic input:

| Key sent | Recorded by the renderer |
| --- | --- |
| `a` | **yes** — all three phases, `isTrusted: true`, `hasFocus: true`, target `BUTTON` |
| `Escape`, immediately after | **nothing at all** |

So synthetic keys reach the HUD and `Escape` specifically is swallowed upstream of the app. The control key is what makes that reading conclusive: without sending `a` alongside, the same data reads as "no key gets through".

The issue has been re-titled to the behaviour that does reproduce.

## Verification

Measured on the packaged 1.9.6 build with real OS input, `LaunchWindow.tsx` / `HudControls.tsx` byte-identical to `main`:

- click inside the HUD window but outside the menu → **closes** (the `pointerdown` path is fine)
- click beyond the window rect → **stays open**, and `Escape` cannot recover it — the bug
- HUD ex-style `0x00200000` with a popover open, i.e. `WS_EX_TRANSPARENT` cleared, confirming the window really is input-opaque at that moment and a click reached it rather than passing through

Gates on the rebased branch (`origin/main` @ `1cc63df4`):

```
npx tsc --noEmit                          exit 0
npx tsc -p tsconfig.test.json --noEmit    exit 0
npx biome check <both files>              no findings
npx vitest --run src/components/launch    8 files, 100 tests passed
```

Eight new tests in `LaunchWindow.test.tsx` cover all three dismiss paths for both surfaces, and that Escape leaves the locale unchanged. **They are jsdom-dispatched**, so per AGENTS.md they pin renderer wiring and prove nothing about real reachability on a click-through window. They are necessary, not sufficient; the real-input results above are the other half.

## What this does not cover

- **macOS.** The renderer `blur` was measured firing on Windows. Nobody has checked that it fires when a click lands outside the HUD on macOS, or on a Spaces switch. If it turns out not to, the belt-and-braces fix is a `win.on("blur")` in `createHudOverlayWindow` forwarded over IPC — deliberately not added here, since the renderer event demonstrably arrives on the platform this was measured on and a second code path for a signal that already comes through is not free.
- **One behaviour change, named rather than buried.** "Check for updates" in the device-settings panel opens a native message box that `electron/main.ts` parents to the focused window. A parented modal blurs its owner, so that panel now closes behind the dialog instead of staying open underneath it. The dialog carries the verdict and the panel is one click away, so this seems acceptable — but it is a real difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1540467144456671253 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Language and device-settings menus now close when the launch window loses focus.
  * Menus consistently dismiss when pressing Escape or clicking outside.
  * Interactions inside the language menu no longer close it unexpectedly.
  * Language selection remains unchanged when dismissing the menu.
  * Other keyboard keys no longer trigger unintended menu dismissal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->