### PR TITLE
fix(editor): remove the redundant top-bar settings button (cherry-pick for 1.10.0-rc.2)

### DIFF
--- a/src/components/ai-edition/v4/EditorTopBar.tsx
+++ b/src/components/ai-edition/v4/EditorTopBar.tsx
@@ -10,7 +10,6 @@ import {
 	PanelLeft,
 	RefreshCw,
 	Save,
-	Settings,
 	Sparkles,
 	Sun,
 } from "lucide-react";
@@ -181,15 +180,6 @@ export function EditorTopBar({
 				onClick={toggleTheme}
 			>
 				{theme === "dark" ? <Moon size={16} /> : <Sun size={16} />}
-			</button>
-			<button
-				type="button"
-				className={styles.iconBtn}
-				title={t("topbar.settings")}
-				aria-label={t("topbar.settings")}
-				onClick={actions.openSettings}
-			>
-				<Settings size={16} />
 			</button>
 			<button
 				type="button"

--- a/src/i18n/locales/ar/editor.json
+++ b/src/i18n/locales/ar/editor.json
@@ -87,7 +87,6 @@
 		"switchToLightTheme": "التبديل إلى المظهر الفاتح",
 		"switchToDarkTheme": "التبديل إلى المظهر الداكن",
 		"toggleTheme": "تبديل المظهر",
-		"settings": "الإعدادات",
 		"export": "تصدير",
 		"renameProject": "إعادة تسمية المشروع",
 		"noProject": "لا يوجد مشروع",

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -87,7 +87,6 @@
 		"switchToLightTheme": "Switch to light theme",
 		"switchToDarkTheme": "Switch to dark theme",
 		"toggleTheme": "Toggle theme",
-		"settings": "Settings",
 		"export": "Export",
 		"renameProject": "Rename project",
 		"noProject": "No project",

--- a/src/i18n/locales/es/editor.json
+++ b/src/i18n/locales/es/editor.json
@@ -87,7 +87,6 @@
 		"switchToLightTheme": "Cambiar a tema claro",
 		"switchToDarkTheme": "Cambiar a tema oscuro",
 		"toggleTheme": "Alternar tema",
-		"settings": "Ajustes",
 		"export": "Exportar",
 		"renameProject": "Renombrar proyecto",
 		"noProject": "Sin proyecto",

--- a/src/i18n/locales/fr/editor.json
+++ b/src/i18n/locales/fr/editor.json
@@ -87,7 +87,6 @@
 		"switchToLightTheme": "Passer au thème clair",
 		"switchToDarkTheme": "Passer au thème sombre",
 		"toggleTheme": "Changer de thème",
-		"settings": "Réglages",
 		"export": "Exporter",
 		"renameProject": "Renommer le projet",
 		"noProject": "Aucun projet",

--- a/src/i18n/locales/it/editor.json
+++ b/src/i18n/locales/it/editor.json
@@ -87,7 +87,6 @@
 		"switchToLightTheme": "Passa al tema chiaro",
 		"switchToDarkTheme": "Passa al tema scuro",
 		"toggleTheme": "Cambia tema",
-		"settings": "Impostazioni",
 		"export": "Esporta",
 		"renameProject": "Rinomina progetto",
 		"noProject": "Nessun progetto",

--- a/src/i18n/locales/ja-JP/editor.json
+++ b/src/i18n/locales/ja-JP/editor.json
@@ -87,7 +87,6 @@
 		"switchToLightTheme": "ライトテーマに切り替え",
 		"switchToDarkTheme": "ダークテーマに切り替え",
 		"toggleTheme": "テーマを切り替え",
-		"settings": "設定",
 		"export": "エクスポート",
 		"renameProject": "プロジェクト名を変更",
 		"noProject": "プロジェクトなし",

--- a/src/i18n/locales/ko-KR/editor.json
+++ b/src/i18n/locales/ko-KR/editor.json
@@ -87,7 +87,6 @@
 		"switchToLightTheme": "라이트 테마로 전환",
 		"switchToDarkTheme": "다크 테마로 전환",
 		"toggleTheme": "테마 전환",
-		"settings": "설정",
 		"export": "내보내기",
 		"renameProject": "프로젝트 이름 변경",
 		"noProject": "프로젝트 없음",

--- a/src/i18n/locales/pt-BR/editor.json
+++ b/src/i18n/locales/pt-BR/editor.json
@@ -87,7 +87,6 @@
 		"switchToLightTheme": "Mudar para tema claro",
 		"switchToDarkTheme": "Mudar para tema escuro",
 		"toggleTheme": "Alternar tema",
-		"settings": "Configurações",
 		"export": "Exportar",
 		"renameProject": "Renomear projeto",
 		"noProject": "Nenhum projeto",

--- a/src/i18n/locales/ru/editor.json
+++ b/src/i18n/locales/ru/editor.json
@@ -87,7 +87,6 @@
 		"switchToLightTheme": "Переключить на светлую тему",
 		"switchToDarkTheme": "Переключить на тёмную тему",
 		"toggleTheme": "Переключить тему",
-		"settings": "Настройки",
 		"export": "Экспорт",
 		"renameProject": "Переименовать проект",
 		"noProject": "Нет проекта",

--- a/src/i18n/locales/tr/editor.json
+++ b/src/i18n/locales/tr/editor.json
@@ -87,7 +87,6 @@
 		"switchToLightTheme": "Açık temaya geç",
 		"switchToDarkTheme": "Koyu temaya geç",
 		"toggleTheme": "Temayı değiştir",
-		"settings": "Ayarlar",
 		"export": "Dışa aktar",
 		"renameProject": "Projeyi yeniden adlandır",
 		"noProject": "Proje yok",

--- a/src/i18n/locales/vi/editor.json
+++ b/src/i18n/locales/vi/editor.json
@@ -87,7 +87,6 @@
 		"switchToLightTheme": "Chuyển sang giao diện sáng",
 		"switchToDarkTheme": "Chuyển sang giao diện tối",
 		"toggleTheme": "Đổi giao diện",
-		"settings": "Cài đặt",
 		"export": "Xuất",
 		"renameProject": "Đổi tên dự án",
 		"noProject": "Không có dự án",

--- a/src/i18n/locales/zh-CN/editor.json
+++ b/src/i18n/locales/zh-CN/editor.json
@@ -87,7 +87,6 @@
 		"switchToLightTheme": "切换到浅色主题",
 		"switchToDarkTheme": "切换到深色主题",
 		"toggleTheme": "切换主题",
-		"settings": "设置",
 		"export": "导出",
 		"renameProject": "重命名项目",
 		"noProject": "无项目",

--- a/src/i18n/locales/zh-TW/editor.json
+++ b/src/i18n/locales/zh-TW/editor.json
@@ -87,7 +87,6 @@
 		"switchToLightTheme": "切換至淺色主題",
 		"switchToDarkTheme": "切換至深色主題",
 		"toggleTheme": "切換主題",
-		"settings": "設定",
 		"export": "匯出",
 		"renameProject": "重新命名專案",
 		"noProject": "無專案",

--- a/technical-documentation/testing/manual-e2e-checklist.md
+++ b/technical-documentation/testing/manual-e2e-checklist.md
@@ -304,7 +304,6 @@ The agent may only call the fixed tool set in [ai-agent.md](../architecture/ai-a
 
 ## Settings, shortcuts, themes, i18n
 
-- [ ] Activate the top-bar settings control by its `aria-label` and confirm the shortcuts configuration dialog opens.
 - [ ] Change one shortcut, save it, use the new key in the editor, and confirm it triggers the configured action.
 - [ ] Confirm `Ctrl/Cmd+S` saves the current project.
 - [ ] Confirm `Ctrl/Cmd+O` opens the project dialog.
@@ -330,7 +329,7 @@ The agent may only call the fixed tool set in [ai-agent.md](../architecture/ai-a
 - [ ] On Windows and Linux, open the editor, hold Alt, and confirm the Help menu lists Check for Updates and About OpenScreen.
 - [ ] In the editor, click the OpenScreen wordmark in the top bar and confirm it opens a menu listing Keyboard Shortcuts, AI settings, Check for Updates and About OpenScreen. This is the discoverable path on Windows and Linux, where the two above are not.
 - [ ] Confirm the About row in that menu shows the running version, and that it matches what the About box then reports.
-- [ ] Open the wordmark menu and pick Keyboard Shortcuts; confirm it opens the same dialog the top bar's gear does, and that only one dialog appears.
+- [ ] Open the wordmark menu and pick Keyboard Shortcuts; confirm the shortcuts configuration dialog opens and that only one dialog appears.
 - [ ] Open the wordmark menu and pick AI settings; confirm it opens the same provider dialog the AI panel's gear does, and that only one dialog appears.
 - [ ] Repeat that in Media mode, in Rec mode, and in Edit mode with the chat panel collapsed — the three states in which the dialog had no owner before, and the reason the row must not be Edit-only.
 - [ ] Connect or disconnect a provider from the menu's dialog while the chat panel is open behind it, close the dialog, and confirm the composer and the model pill follow without reopening the panel.


### PR DESCRIPTION
## Summary
Cherry-pick of #465 onto `release/v1.10.0` for the next RC.

- Remove the gear/Settings icon button from the editor top bar (between the theme toggle and Export) — it opened the shortcuts configuration dialog, already reachable as "Keyboard Shortcuts" from the OpenScreen wordmark menu.
- Drop the now-unused `topbar.settings` string from all 13 locales.
- Fix two manual e2e checklist lines that tested/referenced the removed control.

## Related issue
No tracked issue — reported directly by screenshot. See #465 for the original change.

## Type of change
- [x] Bug fix

## Release impact
- [x] Patch

## Desktop impact
- [x] Not platform-specific

## Screenshots / video
Not attached — this removes one existing top-bar icon with no other visual change.

## Testing
Cherry-picked commit is identical in content to the one already merged and verified on `main` (#465). Re-ran on top of `release/v1.10.0` (currently `1.10.0-rc.1`, rebased onto the latest tip):
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` over the affected suites (`EditorTopBar`, `localeParity`, `ProviderSettings`) — 35 tests pass
- [x] `npx biome check` on all changed files — clean

Cherry-picked cleanly with one trivial auto-merge in `manual-e2e-checklist.md` (unrelated doc edits landed nearby on the release branch since it was cut), same 15-file diff as #465.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1540680912059240570 -->