### PR TITLE
fix(editor): timeline clip delete icon contrast in light theme

### DIFF
--- a/src/components/ai-edition/v4/EditorShellV4.module.css
+++ b/src/components/ai-edition/v4/EditorShellV4.module.css
@@ -1626,7 +1626,12 @@
 	display: grid;
 	place-items: center;
 	border-radius: 7px;
-	color: var(--muted);
+	/* The chip itself is a fixed dark frosted-glass overlay regardless of
+	   theme (it sits on top of an arbitrary video thumbnail), so its icon
+	   needs the "light text on a dark overlay" token, not --muted — which
+	   is tuned for the app's own light/dark surfaces and reads as
+	   near-invisible against this chip in light theme. */
+	color: var(--overlay-text);
 	background: color-mix(in srgb, #080a0d 55%, transparent);
 	border: 1px solid rgba(255, 255, 255, 0.08);
 	backdrop-filter: blur(8px);


### PR DESCRIPTION
## Summary

Follow-up to #470/#474 — same class of bug, spotted directly against a real clip in the timeline.

- `.tlClipDelete` (the trash icon on a timeline clip's thumbnail) sits on the same fixed dark frosted-glass chip as `.tlClipLabel` right next to it — both deliberately theme-independent since they overlay an arbitrary video thumbnail. But its icon used `color: var(--muted)` (the app's own theme-dependent secondary-text token) instead of the "light text on a dark overlay" token its sibling already uses correctly (`.tlClipName` is a flat `#fff` for the same reason).
- In light theme, `--muted` is a medium slate gray close enough in tone to the chip's blended backdrop to read as nearly invisible.
- Switched to `--overlay-text`, the token `design-tokens.css` defines specifically for this pairing (already used for scene/PiP overlay captions elsewhere).

## Testing
- `npx tsc --noEmit -p .` — clean
- Not independently visually verified in a live browser session (reaching this state needs a loaded project with an actual video clip in the timeline, not available in this session's browser-only preview); the fix mirrors the exact working pattern of the adjacent `.tlClipName` rule one-for-one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1540696864788316292 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the visibility of clip deletion controls across themes, particularly on dark frosted-glass overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->