### PR TITLE
fix(editor): timeline clip delete icon contrast in light theme (cherry-pick for 1.10.0-rc.3)

### DIFF
--- a/src/components/ai-edition/v4/EditorShellV4.module.css
+++ b/src/components/ai-edition/v4/EditorShellV4.module.css
@@ -1626,7 +1626,12 @@
 	display: grid;
 	place-items: center;
 	border-radius: 7px;
-	color: var(--muted);
+	/* The chip itself is a fixed dark frosted-glass overlay regardless of
+	   theme (it sits on top of an arbitrary video thumbnail), so its icon
+	   needs the "light text on a dark overlay" token, not --muted — which
+	   is tuned for the app's own light/dark surfaces and reads as
+	   near-invisible against this chip in light theme. */
+	color: var(--overlay-text);
 	background: color-mix(in srgb, #080a0d 55%, transparent);
 	border: 1px solid rgba(255, 255, 255, 0.08);
 	backdrop-filter: blur(8px);


### PR DESCRIPTION
Cherry-pick of #480 onto \`release/v1.10.0\` (currently at rc.2) for the next RC.

## Summary

\`.tlClipDelete\` (the trash icon on a timeline clip's thumbnail) sits on the same fixed dark frosted-glass chip as \`.tlClipLabel\` right next to it — deliberately theme-independent since they overlay an arbitrary video thumbnail. But its icon used \`color: var(--muted)\` (theme-dependent) instead of the "light text on a dark overlay" token its sibling already uses correctly (\`.tlClipName\` is a flat \`#fff\` for the same reason). In light theme, \`--muted\` is close enough in tone to the chip's blended backdrop to read as nearly invisible — reported directly against a real clip's delete button. Switched to \`--overlay-text\`, the token \`design-tokens.css\` defines for exactly this pairing.

Same commit as #480 (merged to main), cherry-picked verbatim.

## Testing
\`npx tsc --noEmit -p .\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1540697515253309532 -->