### PR TITLE
fix: initialise CoreGraphics before building a window capture filter (cherry-pick for 1.10.0-rc.4)

### DIFF
--- a/electron/native/screencapturekit/Sources/OpenScreenScreenCaptureKitHelper/ScreenCaptureRecorder.swift
+++ b/electron/native/screencapturekit/Sources/OpenScreenScreenCaptureKitHelper/ScreenCaptureRecorder.swift
@@ -802,6 +802,15 @@ final class ScreenCaptureRecorder: NSObject, SCStreamOutput, SCStreamDelegate {
 struct OpenScreenScreenCaptureKitHelper {
 	static func main() async {
 		do {
+			// This helper is a plain command-line executable, so nothing has connected it to
+			// the window server yet. `SCContentFilter(desktopIndependentWindow:)` reaches into
+			// SkyLight (`SLSGetDisplaysWithRect`) to find the display a window sits on, and
+			// SkyLight aborts with `CGS_REQUIRE_INIT` when CoreGraphics was never initialised
+			// in the process — so every window capture crashed before it produced a frame,
+			// while display capture (which never resolves a rect) worked fine. Touching any
+			// CoreGraphics display API first performs that initialisation.
+			_ = CGMainDisplayID()
+
 			guard CommandLine.arguments.count == 2 else {
 				throw HelperError.invalidArguments
 			}


### PR DESCRIPTION
Cherry-pick of #488 onto `release/v1.10.0`, for **rc.4**.

macOS window capture has never worked: picking any window in the source picker aborts the ScreenCaptureKit helper before it produces a frame, with `Assertion failed: (did_initialize), function CGS_REQUIRE_INIT, file CGInitialization.c, line 44`. Fixed by touching a CoreGraphics display API (`CGMainDisplayID()`) at the top of `main()`, which performs the window-server initialisation `SCContentFilter(desktopIndependentWindow:)` otherwise needs SkyLight for and never gets in a plain CLI process.

Per the release contract in `technical-documentation/engineering/release-and-secrets.md`, only the bug-fix commit is cherry-picked here — the follow-up refactor and the manual E2E checklist entry from #488 are docs/refactor changes that stay on `main` and ship in the next cycle, not on the frozen release branch.

Build and all 22 Swift unit tests verified green on this branch before pushing.

<!-- discord-thread-id:1541047620330459268 -->