### PR TITLE
docs: publish minimum and recommended system requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Every platform has a recommended route below. On Windows that is the Microsoft S
 
 ### System requirements
 
-- **Windows**: version 1903+ (build 18362), Intel 8th Gen / AMD Ryzen 2000 series or newer recommended
+- **Windows**: version 1903+ (build 18362) with Intel 8th Gen / AMD Ryzen 2000 series or newer minimum; Windows 11 with Intel 12th Gen / Ryzen 4000 series or newer recommended
 - **macOS**: 12.3 (Monterey) or later — required by ScreenCaptureKit for native capture
-- **Linux**: a desktop with `xdg-desktop-portal` and PipeWire (default on Ubuntu 22.04+, Fedora 34+)
+- **Linux**: `xdg-desktop-portal` and PipeWire for native capture and system audio; recording still works without them through the browser-capture fallback, with fewer capabilities (see [Platform differences](#platform-differences))
 - **RAM**: 8 GB minimum, 16 GB recommended
 
 Full table and notes on older integrated graphics: [system requirements](https://getopenscreen.com/docs/installation#system-requirements).

--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ See [docs/cli.md](./docs/cli.md).
 
 Every platform has a recommended route below. On Windows that is the Microsoft Store; everywhere else it is the installer from the [GitHub Releases](https://github.com/getopenscreen/openscreen/releases) page.
 
+### System requirements
+
+- **Windows**: version 1903+ (build 18362), Intel 8th Gen / AMD Ryzen 2000 series or newer recommended
+- **macOS**: 12.3 (Monterey) or later — required by ScreenCaptureKit for native capture
+- **Linux**: a desktop with `xdg-desktop-portal` and PipeWire (default on Ubuntu 22.04+, Fedora 34+)
+- **RAM**: 8 GB minimum, 16 GB recommended
+
+Full table and notes on older integrated graphics: [system requirements](https://getopenscreen.com/docs/installation#system-requirements).
+
 ### macOS
 
 Download the `.dmg` installer directly from the [Releases page](https://github.com/getopenscreen/openscreen/releases) and drag OpenScreen into your Applications folder. Builds from 1.9.0 onward are signed with a Developer ID certificate and notarized by Apple, so Gatekeeper does not block them and no terminal step is needed.

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -24,7 +24,7 @@ Download the latest installer for your platform from the [download page](/downlo
 |---|---|---|
 | **Windows** | Windows 10 version 1903 (build 18362) or later, Intel 8th Gen / AMD Ryzen 2000 series or newer | Windows 11, Intel 12th Gen / AMD Ryzen 4000 series or newer |
 | **macOS** | macOS 12.3 (Monterey) — required by ScreenCaptureKit for native capture | macOS 14 or later |
-| **Linux** | A desktop with `xdg-desktop-portal` and PipeWire (default on Ubuntu 22.04+, Fedora 34+) | Same, kept up to date |
+| **Linux** | `xdg-desktop-portal` and PipeWire for native capture and system audio (default on Ubuntu 22.04+, Fedora 34+) — recording still works without them through the [browser-capture fallback](#platform-differences), with fewer capabilities | Same, kept up to date |
 | **RAM** | 8 GB | 16 GB |
 
 :::note Older integrated graphics on Windows

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -18,6 +18,19 @@ keywords:
 
 Download the latest installer for your platform from the [download page](/download), or straight from [GitHub Releases](https://github.com/getopenscreen/openscreen/releases).
 
+## System requirements
+
+| | Minimum | Recommended |
+|---|---|---|
+| **Windows** | Windows 10 version 1903 (build 18362) or later, Intel 8th Gen / AMD Ryzen 2000 series or newer | Windows 11, Intel 12th Gen / AMD Ryzen 4000 series or newer |
+| **macOS** | macOS 12.3 (Monterey) — required by ScreenCaptureKit for native capture | macOS 14 or later |
+| **Linux** | A desktop with `xdg-desktop-portal` and PipeWire (default on Ubuntu 22.04+, Fedora 34+) | Same, kept up to date |
+| **RAM** | 8 GB | 16 GB |
+
+:::note Older integrated graphics on Windows
+Machines with integrated graphics older than roughly 8th-generation Intel (or the equivalent AMD Ryzen 2000 series) are not blocked from installing, but some have known driver stability issues that can make a recording fail to stop and save — see [#460](https://github.com/getopenscreen/openscreen/issues/460). If you hit this, open the tray icon or **Help → Save Diagnostics** right after the failure (before starting another recording) and attach the file to a bug report.
+:::
+
 ## macOS
 
 Download the `.dmg` installer from [Releases](https://github.com/getopenscreen/openscreen/releases) and drag OpenScreen into your Applications folder. Builds from 1.9.0 onward are signed with a Developer ID certificate and notarized by Apple, so Gatekeeper does not block them and no terminal step is needed.

--- a/website/src/pages/download.tsx
+++ b/website/src/pages/download.tsx
@@ -56,7 +56,7 @@ const PLATFORMS: PlatformSpec[] = [
 		footnote: (
 			<>
 				System audio is captured without extra drivers. Integrated graphics older than ~8th-gen
-				Intel may hit known recording-stop issues — see{" "}
+				Intel (or the AMD Ryzen 2000 series equivalent) may hit known recording-stop issues — see{" "}
 				<Link to="/docs/installation#system-requirements">system requirements</Link>.
 			</>
 		),

--- a/website/src/pages/download.tsx
+++ b/website/src/pages/download.tsx
@@ -11,6 +11,7 @@ import {
 	ShieldCheck,
 	TerminalSquare,
 } from "lucide-react";
+import type { ReactNode } from "react";
 
 import { type AssetKind, findAsset, formatSize, type LatestRelease } from "../lib/release";
 import { jsonLd, SOFTWARE_ID, softwareApplicationLd, WEBSITE_ID } from "../lib/structured-data";
@@ -33,7 +34,7 @@ type PlatformSpec = {
 	icon: typeof Apple;
 	/** One row per artifact the platform actually ships. */
 	options: { kind: AssetKind; label: string; sublabel: string }[];
-	footnote?: string;
+	footnote?: ReactNode;
 };
 
 const PLATFORMS: PlatformSpec[] = [
@@ -52,7 +53,13 @@ const PLATFORMS: PlatformSpec[] = [
 		name: "Windows",
 		icon: AppWindow,
 		options: [{ kind: "windows", label: "Windows 10 & 11", sublabel: "Installer · .exe" }],
-		footnote: "System audio is captured without extra drivers.",
+		footnote: (
+			<>
+				System audio is captured without extra drivers. Integrated graphics older than ~8th-gen
+				Intel may hit known recording-stop issues — see{" "}
+				<Link to="/docs/installation#system-requirements">system requirements</Link>.
+			</>
+		),
 	},
 	{
 		id: "linux",


### PR DESCRIPTION
## Summary

The download page invited anyone on "Windows 10 & 11" with no hardware qualifier, and nothing — README, install docs — said anything about minimum specs either. That gap is part of why #460 took as long as it did to diagnose: reporters on a decade-old Intel iGPU had no way to know their hardware was the likely cause before hitting a confusing recording-stop failure.

- Added a full **System requirements** section to `website/docs/installation.md` (Windows/macOS/Linux/RAM, minimum + recommended), with a note pointing affected users at Save Diagnostics.
- Added a condensed version to `README.md`, linking out to the docs page.
- Added a short note + link on the **Windows** card of the download page (`website/src/pages/download.tsx`) — the point where a user on old hardware would otherwise download with zero warning.

## How the Windows floor was chosen

Landed on **Intel 8th Gen / AMD Ryzen 2000 series**, matching Camtasia's published minimum (a direct, comparable competitor). Checked against Intel's own driver support tiers first, but that turned out to be a weaker signal than expected — "legacy" status now reaches through 10th and even into 11th-14th Gen, so using it as the line would exclude a large share of hardware still in common, working use. The competitor's real-world floor sits comfortably above both hardware profiles #460 actually reproduced on (Haswell/HD 4600, Skylake/HD 520), so it cleanly excludes known-bad configurations without being unusually restrictive.

**Documented only, not enforced** — no startup detection, no install blocking. Consistent with the read that a hard block isn't worth building without stronger signal on how many users are actually affected; chasing every old-GPU driver bug individually doesn't scale, but a spec line does.

## Verification

- `tsc --noEmit` and `biome check` clean
- `docusaurus build` succeeds
- Rendered both pages locally and confirmed the table, the admonition, and the download-page link to `#system-requirements` all resolve correctly (checked via the app's `read_page` accessibility tree, not just visually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1541396827574763551 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added system requirements for supported Windows, macOS, and Linux configurations.
  * Documented recommended hardware, minimum RAM, and detailed requirements.
  * Added guidance about older integrated Windows graphics and potential recording-save failures.

* **Download Experience**
  * Expanded Windows download notes with system-audio capture information and a link to detailed requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->