### PR TITLE
chore: bump nix package to v1.10.0

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -51,7 +51,7 @@ buildNpmPackage {
       );
     };
 
-  npmDepsHash = "sha256-Vr6Sw/WKmX22eT4a22+Xr3/miMzZr2uAwiYx12toU/E=";
+  npmDepsHash = "sha256-sp1UlXIUZ4z03LRV36+yN0Op8pu/qPROU7sI15LgyTg=";
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 


### PR DESCRIPTION
Automated bump triggered by release `v1.10.0`.

- `version` → `1.10.0`
- `npmDepsHash` → `sha256-sp1UlXIUZ4z03LRV36+yN0Op8pu/qPROU7sI15LgyTg=` (computed via `prefetch-npm-deps package-lock.json`)

Merge this so Nix users (NixOS, Home Manager, `nix run github:getopenscreen/openscreen`) pick up the new release.

<!-- discord-thread-id:1541401512767660073 -->