### PR TITLE
fix(website): match recreation generator's param name to amplitude

### DIFF
--- a/website/scripts/gen-recreation.mjs
+++ b/website/scripts/gen-recreation.mjs
@@ -188,11 +188,11 @@ const waveBarCount = new Function(
 	`return ${lift(/const barCount = ([^;]+);/, "waveform barCount")};`,
 );
 const waveBarHeightPct = new Function(
-	"h",
+	"amplitude",
 	`return ${lift(/height: `\$\{([^}]+)\}%`/, "waveform bar height")};`,
 );
 const waveBarOpacity = new Function(
-	"h",
+	"amplitude",
 	`return ${lift(/opacity: ([^,\n]+),\n/, "waveform bar opacity")};`,
 );
 

--- a/website/src/components/Recreation/generated.ts
+++ b/website/src/components/Recreation/generated.ts
@@ -544,7 +544,7 @@ export const PANELS = {
 		],
 	},
 	effects: {
-		title: "Video Effects",
+		title: "Composition",
 		padding: "Padding",
 		blurBg: "Blur BG",
 		motionBlur: "Motion Blur",
@@ -802,7 +802,7 @@ export const PROVENANCE: ProvenanceEntry[] = [
 	{ shown: "Gradient", source: "src/i18n/locales/en/settings.json → background.gradient" },
 	{ shown: "Upload Custom", source: "src/i18n/locales/en/settings.json → background.uploadCustom" },
 	{ shown: "Background 1", source: "computed: settings.json background.imageLabel over the 18 wallpapers WALLPAPER_COUNT declares in src/lib/wallpaper.ts" },
-	{ shown: "Video Effects", source: "src/i18n/locales/en/settings.json → effects.title" },
+	{ shown: "Composition", source: "src/i18n/locales/en/settings.json → effects.title" },
 	{ shown: "Padding", source: "src/i18n/locales/en/settings.json → effects.padding" },
 	{ shown: "Blur BG", source: "src/i18n/locales/en/settings.json → effects.blurBg" },
 	{ shown: "Motion Blur", source: "src/i18n/locales/en/settings.json → effects.motionBlur" },


### PR DESCRIPTION
## Summary
- The v1.10.0 release build's docs-refresh step failed: \`check:recreation\` crashed with \`ReferenceError: amplitude is not defined\`.
- \`gen-recreation.mjs\` lifts \`ClipWaveform\`'s height/opacity expressions verbatim out of \`V4Timeline.tsx\` and re-evaluates them as a \`new Function(...)\`, but hardcoded the parameter name as \`h\`. The component had renamed that variable to \`amplitude\`, so the lifted body referenced an undeclared name.
- Renamed the \`Function\` parameters to \`amplitude\` and regenerated \`generated.ts\` (also picks up an unrelated locale drift: \`effects.title\` "Video Effects" → "Composition").

## Test plan
- [x] \`node scripts/gen-recreation.mjs --check\` passes locally
- [x] \`node scripts/gen-recreation.mjs\` regenerates cleanly with no further diff

<!-- discord-thread-id:1541404728900980750 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Renamed the **Video Effects** panel to **Composition** for clearer terminology across the recreation interface.
  - Preserved existing waveform behavior while improving consistency in the underlying configuration, with no change to the visible output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->