### PR TITLE
fix(ci): don't let the docs refresh block Microsoft Store publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -988,6 +988,12 @@ jobs:
         # with a tag ref and failed its deploy every time. See docs.yml.
         if: ${{ steps.release.outputs.is_prerelease == 'false' }}
         timeout-minutes: 20
+        # Bookkeeping, not publishing: the release itself is already out by the time
+        # this runs. Letting it fail the job silently skipped publish-msstore on
+        # v1.10.0 (an unrelated Store submission, gated on this job's `needs` success)
+        # even though "Publish release assets" above had already succeeded. Allowed
+        # to fail so a flaky docs deploy never blocks a downstream publish step.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.OPENSCREEN_RELEASE_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
- v1.10.0's Microsoft Store submission was silently skipped: \`publish-msstore\` requires \`publish-release\` to succeed via \`needs\`, and the docs-refresh step inside \`publish-release\` (bookkeeping that runs after the actual release assets are already published) failed with no \`continue-on-error\`, marking the whole job failed even though the release itself published fine.
- Added \`continue-on-error: true\` to the docs-refresh step, matching the same pattern already used for promote.yml's main-sync step: publishing is done by the time it runs, so its own failure shouldn't cascade to unrelated downstream jobs.

## Test plan
- N/A — workflow-only change, exercised on the next release build.

<!-- discord-thread-id:1541406388238946356 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release reliability by allowing documentation deployment issues to avoid blocking Microsoft Store publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->