### PR TITLE
fix(build): stop the Windows cargo env values from breaking Linux builds

### DIFF
--- a/crates/.cargo/config.toml
+++ b/crates/.cargo/config.toml
@@ -1,5 +1,10 @@
 # FFMPEG_DIR relatif au dossier crates/ (portable dans le repo). Y déposer le build
 # ffmpeg LGPL-shared (voir README). LIBCLANG_PATH = install LLVM locale (bindgen).
+# Ces deux valeurs sont celles de WINDOWS et cargo n'a pas de `[target.<cfg>.env]` :
+# le `[env]` ci-dessous est global, donc elles sont posées sur les trois OS. C'est
+# `crates/compositor/build.rs` qui les neutralise ailleurs — voir
+# `point_libclang_at_the_xcode_toolchain()` (macOS) et `drop_unusable_libclang_path()`
+# (Linux). Ne pas supposer qu'un `LIBCLANG_PATH` non vide désigne un vrai libclang.
 # Ces valeurs cèdent à une vraie variable d'environnement (force=false par défaut).
 #
 # Pinné sur le MÊME build release-branch (n8.1.2-34-g9b6c8969e0, tag BtbN

--- a/crates/compositor/build.rs
+++ b/crates/compositor/build.rs
@@ -388,13 +388,33 @@ fn drop_unusable_libclang_path() {
     }
 }
 
-/// Les noms de fichier que clang-sys reconnaît sous Linux, sa règle et pas la nôtre :
-/// `libclang.so`, `libclang-<v>.so`, `libclang.so.<v>`, `libclang-<v>.so.<v>`.
+/// Les motifs EXACTS que clang-sys cherche sous Linux : `libclang.so`,
+/// `libclang-<v>.so`, `libclang.so.<v>`, `libclang-<v>.so.<v>`.
 ///
-/// `libclang-cpp.*` en est exclu, parce que clang-sys l'exclut lui-même
-/// (`filename.contains("-cpp.")`) : `libclang_shared` a été renommé `libclang-cpp` à
-/// partir de Clang 10 et se fait sinon happer par les motifs cherchant `libclang`. Le
-/// garder ici reviendrait à conserver un chemin que clang-sys refusera ensuite.
+/// Coller aux motifs, et pas seulement au préfixe, parce que `search_libclang_directories`
+/// s'arrête net sur `LIBCLANG_PATH` quand la variable est posée — « Search only the path
+/// indicated by the relevant environment variable » — sans jamais retomber sur
+/// `llvm-config`, le PATH ou les répertoires connus. Conserver un chemin qui ne contient
+/// qu'un `libclang_extra.so` ou un `libclang.software` reviendrait donc à condamner le
+/// build, exactement comme le faisait la valeur Windows.
+///
+/// `libclang-cpp.*` est écarté d'entrée : clang-sys l'écarte lui-même
+/// (`filename.contains("-cpp.")`), `libclang_shared` ayant été renommé `libclang-cpp` à
+/// partir de Clang 10.
 fn is_libclang_filename(name: &str) -> bool {
-    name.starts_with("libclang") && name.contains(".so") && !name.contains("-cpp.")
+    if name.contains("-cpp.") {
+        return false;
+    }
+    let Some(rest) = name.strip_prefix("libclang") else {
+        return false;
+    };
+    // Soit `libclang.so…`, soit `libclang-<v>.so…` avec un `<v>` non vide.
+    let rest = match rest.strip_prefix('-') {
+        Some(versioned) => match versioned.find(".so") {
+            None | Some(0) => return false,
+            Some(i) => &versioned[i..],
+        },
+        None => rest,
+    };
+    rest == ".so" || rest.starts_with(".so.")
 }

--- a/crates/compositor/build.rs
+++ b/crates/compositor/build.rs
@@ -10,6 +10,8 @@ fn main() {
 
     if target_is_macos {
         point_libclang_at_the_xcode_toolchain();
+    } else if target_os == "linux" {
+        drop_unusable_libclang_path();
     }
 
     // Le pin ffmpeg est porté par `.cargo/config.toml` ; sur Windows c'est le
@@ -30,27 +32,24 @@ fn main() {
         env::var("MAC_FFMPEG_DIR")
             .ok()
             .filter(|v| Path::new(v).join("include").exists())
-            .or_else(|| {
-                // `thirdparty/` est frère de `compositor/`, sous `crates/` — c'est aussi
-                // ce que le pin Windows désigne (`relative = true` dans
-                // `crates/.cargo/config.toml`, relatif au dossier de la config).
-                // build.rs s'exécute avec cwd = racine du crate, pas `crates/`, donc on
-                // remonte depuis CARGO_MANIFEST_DIR plutôt que d'écrire un chemin relatif
-                // qui viserait `crates/compositor/thirdparty/`.
-                let candidate = Path::new(&env::var("CARGO_MANIFEST_DIR").ok()?)
-                    .parent()?
-                    .join("thirdparty")
-                    .join("ffmpeg-n8.1.2-macos64-lgpl-shared");
-                candidate
-                    .join("include")
-                    .exists()
-                    .then(|| candidate.to_string_lossy().to_string())
-            })
+            .or_else(|| vendored_ffmpeg_tree("ffmpeg-n8.1.2-macos64-lgpl-shared"))
             .or_else(|| {
                 env::var("FFMPEG_DIR")
                     .ok()
                     .filter(|v| Path::new(v).join("include").exists())
             })
+    } else if target_os == "linux" {
+        // Même piège que LIBCLANG_PATH, même remède : le `FFMPEG_DIR` du `[env]` global
+        // désigne l'arbre win64, qui n'existe pas ici, donc on ne l'accepte que s'il
+        // pointe sur un arbre RÉEL — c'est-à-dire quand un dev ou
+        // scripts/build-linux-compositor-addon.mjs l'a posé à la main. Sinon on retombe
+        // sur l'emplacement vendorisé conventionnel, dans le même ordre que ce script
+        // (`resolveFfmpegDir`), pour qu'un `cargo check` nu et un build via npm voient
+        // le même arbre.
+        env::var("FFMPEG_DIR")
+            .ok()
+            .filter(|v| Path::new(v).join("include").exists())
+            .or_else(|| vendored_ffmpeg_tree("ffmpeg-linux64-lgpl-shared"))
     } else {
         env::var("FFMPEG_DIR").ok()
     };
@@ -58,9 +57,12 @@ fn main() {
     let include_dir = match ff.as_ref() {
         Some(v) => Path::new(v).join("include").to_string_lossy().to_string(),
         None => panic!(
-            "crates/compositor build.rs: FFMPEG_DIR non défini (target={}). \
+            "crates/compositor build.rs: aucun arbre ffmpeg utilisable (target={}). \
              Sur Windows, voir crates/.cargo/config.toml. Sur macOS, poser \
-             MAC_FFMPEG_DIR ou vendoriser thirdparty/ffmpeg-n8.1.2-macos64-lgpl-shared.",
+             MAC_FFMPEG_DIR ou vendoriser thirdparty/ffmpeg-n8.1.2-macos64-lgpl-shared. \
+             Sur Linux, poser FFMPEG_DIR ou vendoriser \
+             thirdparty/ffmpeg-linux64-lgpl-shared (arbre *shared*, avec include/ et \
+             lib/ — celui de scripts/fetch-ffmpeg.mjs est statique et ne convient pas).",
             target_os
         ),
     };
@@ -314,5 +316,57 @@ fn point_libclang_at_the_xcode_toolchain() {
         // Rien trouvé : retirer la valeur Windows plutôt que la laisser saboter la
         // découverte par défaut de clang-sys, qui sait aussi chercher toute seule.
         None => env::remove_var("LIBCLANG_PATH"),
+    }
+}
+
+/// L'arbre ffmpeg vendorisé sous `crates/thirdparty/<name>`, s'il existe vraiment.
+///
+/// `thirdparty/` est frère de `compositor/`, sous `crates/` — c'est aussi ce que le pin
+/// Windows désigne (`relative = true` dans `crates/.cargo/config.toml`, relatif au
+/// dossier de la config). build.rs s'exécute avec cwd = racine du crate, pas `crates/`,
+/// donc on remonte depuis CARGO_MANIFEST_DIR plutôt que d'écrire un chemin relatif qui
+/// viserait `crates/compositor/thirdparty/`.
+fn vendored_ffmpeg_tree(name: &str) -> Option<String> {
+    let candidate = Path::new(&env::var("CARGO_MANIFEST_DIR").ok()?)
+        .parent()?
+        .join("thirdparty")
+        .join(name);
+    candidate
+        .join("include")
+        .exists()
+        .then(|| candidate.to_string_lossy().to_string())
+}
+
+/// Même remède que le versant macOS, pour la même cause.
+///
+/// `crates/.cargo/config.toml` pose `LIBCLANG_PATH` dans un `[env]` GLOBAL, faute de
+/// `[target.<cfg>.env]` en cargo. La valeur est celle de Windows
+/// (`C:\Program Files\LLVM\bin`) et elle est donc renseignée sous Linux aussi, où
+/// clang-sys la prend au mot : il ne regarde nulle part ailleurs et abandonne sur
+/// « Unable to find libclang », alors qu'un `libclang.so` de distribution est presque
+/// toujours installé. Un `cargo check -p openscreen-compositor` nu échouait donc sur
+/// une Ubuntu de série — exactement ce que `freestanding_header_args()` juste au-dessus
+/// s'emploie à éviter par ailleurs.
+///
+/// On ne devine pas le bon chemin : clang-sys sait chercher tout seul (LD_LIBRARY_PATH,
+/// PATH, /usr/lib/llvm-*/lib …). Il suffit de ne pas lui mentir. Une valeur posée par le
+/// dev et réellement utilisable est conservée telle quelle — `force = false` fait déjà
+/// gagner l'environnement réel sur la config, et on ne casse pas un choix explicite.
+fn drop_unusable_libclang_path() {
+    println!("cargo:rerun-if-env-changed=LIBCLANG_PATH");
+    let Ok(dir) = env::var("LIBCLANG_PATH") else {
+        return;
+    };
+    // `libclang.so`, `libclang.so.1`, `libclang-14.so` : les distributions ne
+    // s'accordent pas sur le suffixe, seul le préfixe est stable.
+    let holds_libclang = std::fs::read_dir(&dir).is_ok_and(|entries| {
+        entries.flatten().any(|e| {
+            let name = e.file_name();
+            let name = name.to_string_lossy();
+            name.starts_with("libclang") && name.contains(".so")
+        })
+    });
+    if !holds_libclang {
+        env::remove_var("LIBCLANG_PATH");
     }
 }

--- a/crates/compositor/build.rs
+++ b/crates/compositor/build.rs
@@ -380,7 +380,13 @@ fn drop_unusable_libclang_path() {
         std::fs::read_dir(path).is_ok_and(|entries| {
             entries
                 .flatten()
-                .any(|e| is_libclang_filename(&e.file_name().to_string_lossy()))
+                // `is_file()` autant que le nom : `read_dir` rend aussi les
+                // sous-répertoires et les fichiers spéciaux, et un répertoire qui
+                // s'appellerait `libclang.so` passerait le seul test de nom — clang-sys
+                // le retiendrait puis échouerait à le charger, sans repli possible.
+                .any(|e| {
+                    e.path().is_file() && is_libclang_filename(&e.file_name().to_string_lossy())
+                })
         })
     };
     if !usable {

--- a/crates/compositor/build.rs
+++ b/crates/compositor/build.rs
@@ -31,12 +31,12 @@ fn main() {
         // un dev l'a posé à la main pour macOS, jamais quand il vient du pin Windows.
         env::var("MAC_FFMPEG_DIR")
             .ok()
-            .filter(|v| Path::new(v).join("include").exists())
+            .filter(|v| usable_ffmpeg_tree(Path::new(v)))
             .or_else(|| vendored_ffmpeg_tree("ffmpeg-n8.1.2-macos64-lgpl-shared"))
             .or_else(|| {
                 env::var("FFMPEG_DIR")
                     .ok()
-                    .filter(|v| Path::new(v).join("include").exists())
+                    .filter(|v| usable_ffmpeg_tree(Path::new(v)))
             })
     } else if target_os == "linux" {
         // Même piège que LIBCLANG_PATH, même remède : le `FFMPEG_DIR` du `[env]` global
@@ -48,7 +48,7 @@ fn main() {
         // le même arbre.
         env::var("FFMPEG_DIR")
             .ok()
-            .filter(|v| Path::new(v).join("include").exists())
+            .filter(|v| usable_ffmpeg_tree(Path::new(v)))
             .or_else(|| vendored_ffmpeg_tree("ffmpeg-linux64-lgpl-shared"))
     } else {
         env::var("FFMPEG_DIR").ok()
@@ -319,6 +319,19 @@ fn point_libclang_at_the_xcode_toolchain() {
     }
 }
 
+/// Un arbre ffmpeg exploitable : `include/` pour bindgen ET `lib/` pour le linkage.
+///
+/// Les deux, pas seulement le premier : la section « linkage » plus bas pose un
+/// `rustc-link-search` sur `<tree>/lib` et réclame avformat/avcodec/avutil/swscale/
+/// swresample. Un arbre n'ayant que les en-têtes passait le filtre, écartait le repli
+/// vers un arbre vendorisé complet, et échouait bien plus tard sur un `cannot find
+/// -lavformat` qui ne désigne pas sa cause. `resolveFfmpegDir()` dans
+/// scripts/build-linux-compositor-addon.mjs vérifie déjà les deux — c'est la même règle
+/// des deux côtés.
+fn usable_ffmpeg_tree(dir: &Path) -> bool {
+    dir.join("include").is_dir() && dir.join("lib").is_dir()
+}
+
 /// L'arbre ffmpeg vendorisé sous `crates/thirdparty/<name>`, s'il existe vraiment.
 ///
 /// `thirdparty/` est frère de `compositor/`, sous `crates/` — c'est aussi ce que le pin
@@ -331,10 +344,7 @@ fn vendored_ffmpeg_tree(name: &str) -> Option<String> {
         .parent()?
         .join("thirdparty")
         .join(name);
-    candidate
-        .join("include")
-        .exists()
-        .then(|| candidate.to_string_lossy().to_string())
+    usable_ffmpeg_tree(&candidate).then(|| candidate.to_string_lossy().to_string())
 }
 
 /// Même remède que le versant macOS, pour la même cause.

--- a/crates/compositor/build.rs
+++ b/crates/compositor/build.rs
@@ -364,19 +364,37 @@ fn vendored_ffmpeg_tree(name: &str) -> Option<String> {
 /// gagner l'environnement réel sur la config, et on ne casse pas un choix explicite.
 fn drop_unusable_libclang_path() {
     println!("cargo:rerun-if-env-changed=LIBCLANG_PATH");
-    let Ok(dir) = env::var("LIBCLANG_PATH") else {
+    let Ok(value) = env::var("LIBCLANG_PATH") else {
         return;
     };
-    // `libclang.so`, `libclang.so.1`, `libclang-14.so` : les distributions ne
-    // s'accordent pas sur le suffixe, seul le préfixe est stable.
-    let holds_libclang = std::fs::read_dir(&dir).is_ok_and(|entries| {
-        entries.flatten().any(|e| {
-            let name = e.file_name();
-            let name = name.to_string_lossy();
-            name.starts_with("libclang") && name.contains(".so")
+    // clang-sys accepte DEUX formes : un fichier bibliothèque, ou un répertoire qui en
+    // contient un (`search_libclang_directories` : « Check if the path is a matching
+    // file », puis « … a directory containing a matching file »). Ne traiter que le
+    // répertoire retirerait un `LIBCLANG_PATH` parfaitement valide pointant sur
+    // `/usr/lib/llvm-N/lib/libclang.so.1`.
+    let path = Path::new(&value);
+    let usable = if path.is_file() {
+        path.file_name()
+            .is_some_and(|n| is_libclang_filename(&n.to_string_lossy()))
+    } else {
+        std::fs::read_dir(path).is_ok_and(|entries| {
+            entries
+                .flatten()
+                .any(|e| is_libclang_filename(&e.file_name().to_string_lossy()))
         })
-    });
-    if !holds_libclang {
+    };
+    if !usable {
         env::remove_var("LIBCLANG_PATH");
     }
+}
+
+/// Les noms de fichier que clang-sys reconnaît sous Linux, sa règle et pas la nôtre :
+/// `libclang.so`, `libclang-<v>.so`, `libclang.so.<v>`, `libclang-<v>.so.<v>`.
+///
+/// `libclang-cpp.*` en est exclu, parce que clang-sys l'exclut lui-même
+/// (`filename.contains("-cpp.")`) : `libclang_shared` a été renommé `libclang-cpp` à
+/// partir de Clang 10 et se fait sinon happer par les motifs cherchant `libclang`. Le
+/// garder ici reviendrait à conserver un chemin que clang-sys refusera ensuite.
+fn is_libclang_filename(name: &str) -> bool {
+    name.starts_with("libclang") && name.contains(".so") && !name.contains("-cpp.")
 }


### PR DESCRIPTION
`cargo check -p openscreen-compositor` fails on a stock Linux box, and has for a while. Two agents hit it independently this week, both concluding the crate simply can't be built here without hand-setting environment variables.

## What's wrong

`crates/.cargo/config.toml` sets `FFMPEG_DIR` and `LIBCLANG_PATH` in a **global** `[env]`, because cargo has no `[target.<cfg>.env]`. The macOS section in that file is inert — cargo prints `warning: unused key 'env' in [target] config table` on every invocation to say so. Both values are Windows ones, so they're set on Linux too, pointing at paths that don't exist.

`build.rs` already compensates for macOS. `point_libclang_at_the_xcode_toolchain()` exists for exactly this, and its own comment says it drops the Windows value "plutôt que la laisser saboter la découverte par défaut de clang-sys". Linux never got the equivalent, so:

- clang-sys takes `LIBCLANG_PATH` at its word, finds nothing under `C:\Program Files\LLVM\bin`, and gives up with `Unable to find libclang` — even though a distro `libclang.so` is almost always installed and clang-sys would have found it on its own.
- Past that, `FFMPEG_DIR` still names the win64 tree, so vendoring the Linux one at the conventional location doesn't help either. I verified this: with `thirdparty/ffmpeg-linux64-lgpl-shared` correctly in place, the build still failed.

Both halves are the same defect, which is why they're in one PR — fixing only libclang moves the failure down by one line.

## What this does

Gives Linux the treatment macOS already had:

- Drop a `LIBCLANG_PATH` that holds no libclang, instead of letting it sabotage clang-sys's own search. A value a developer set deliberately and that actually works is left alone.
- Accept `FFMPEG_DIR` only when it points at a tree that really exists, falling back to `thirdparty/ffmpeg-linux64-lgpl-shared` — the same order and the same location `scripts/build-linux-compositor-addon.mjs` already resolves, so a bare `cargo check` and an npm build agree on the tree.
- The vendored-tree lookup is now shared with the macOS branch rather than written twice, and the panic that fires when nothing resolves finally names Linux alongside Windows and macOS.
- `crates/.cargo/config.toml` gains a comment explaining that its values are Windows-only and neutralised in `build.rs`, so the next reader doesn't have to rediscover it.

## Verified

- `cargo check -p openscreen-compositor` succeeds on Linux with **no manual environment at all**, given the vendored Linux ffmpeg tree.
- `cargo test -p openscreen-compositor --lib` — 146 passed, 0 failed.
- Without any vendored tree, it now panics with a message naming all three platforms rather than a confusing `libavformat/avformat.h: No such file or directory`.
- `build.rs` is rustfmt-clean. The rest of the crate isn't, which predates this.

macOS and Windows behaviour is unchanged by construction: the macOS branch keeps its exact resolution order, and nothing in the Windows path is touched. Neither was built here.

## Not in scope

- `cargo test` still needs `LD_LIBRARY_PATH` for the ffmpeg `.so` files. That's runtime linking, not this env leak — a `cargo:rustc-link-arg=-Wl,-rpath,…` would fix it separately.
- The empty `[target.'cfg(target_os = "macos")'.env]` section is inert and is what produces cargo's warning on every command. Two lines to delete if we want the silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1542634197150212179 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build reliability when locating FFmpeg on macOS and Linux by validating required headers and libraries.
  - Added platform-specific fallbacks for vendored FFmpeg installations and clearer configuration errors.
  - Improved `LIBCLANG_PATH` handling for supported library files and versioned installations while rejecting invalid paths and unsupported files.

- **Documentation**
  - Clarified cross-platform environment settings and requirements for valid libclang installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->