### PR TITLE
fix(macos): warn when recording the default microphone

### DIFF
--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -2723,6 +2723,14 @@ export function registerIpcHandlers(
 
 			await waitForNativeMacCaptureStart(proc);
 			const captureStartedAtMs = Date.now();
+			const microphoneDefaulted =
+				request.audio.microphone.enabled && readMicrophoneDefaulted(nativeMacCaptureOutput);
+			if (microphoneDefaulted) {
+				console.warn("[native-sck] recording the default input; microphone was not resolved", {
+					deviceId: request.audio.microphone.deviceId,
+					deviceName: request.audio.microphone.deviceName,
+				});
+			}
 			nativeMacCursorOffsetMs =
 				cursorCaptureMode === "editable-overlay"
 					? Math.max(0, captureStartedAtMs - cursorStartTimeMs)
@@ -2738,6 +2746,7 @@ export function registerIpcHandlers(
 				recordingId,
 				path: outputPath,
 				helperPath,
+				microphoneDefaulted,
 			};
 		} catch (error) {
 			console.error("Failed to start native macOS recording:", error);

--- a/electron/native/screencapturekit/Sources/OpenScreenScreenCaptureKitHelper/ScreenCaptureRecorder.swift
+++ b/electron/native/screencapturekit/Sources/OpenScreenScreenCaptureKitHelper/ScreenCaptureRecorder.swift
@@ -465,6 +465,12 @@ final class ScreenCaptureRecorder: NSObject, SCStreamOutput, SCStreamDelegate {
 			configuration.setValue(true, forKey: "captureMicrophone")
 			if let deviceId = resolveMicrophoneCaptureDeviceID() {
 				configuration.setValue(deviceId, forKey: "microphoneCaptureDeviceID")
+			} else {
+				emit([
+					"event": "warning",
+					"code": "microphone-defaulted",
+					"message": "The requested microphone could not be resolved; capturing the default input.",
+				])
 			}
 		} else {
 			nativeMicrophoneEnabled = false

--- a/electron/native/screencapturekit/Sources/OpenScreenScreenCaptureKitHelper/ScreenCaptureRecorder.swift
+++ b/electron/native/screencapturekit/Sources/OpenScreenScreenCaptureKitHelper/ScreenCaptureRecorder.swift
@@ -465,7 +465,7 @@ final class ScreenCaptureRecorder: NSObject, SCStreamOutput, SCStreamDelegate {
 			configuration.setValue(true, forKey: "captureMicrophone")
 			if let deviceId = resolveMicrophoneCaptureDeviceID() {
 				configuration.setValue(deviceId, forKey: "microphoneCaptureDeviceID")
-			} else {
+			} else if requestedASpecificMicrophone {
 				emit([
 					"event": "warning",
 					"code": "microphone-defaulted",
@@ -784,6 +784,25 @@ final class ScreenCaptureRecorder: NSObject, SCStreamOutput, SCStreamDelegate {
 		streamConfig.responds(to: Selector(("setCaptureMicrophone:"))) &&
 			streamConfig.responds(to: Selector(("setMicrophoneCaptureDeviceID:"))) &&
 			SCStreamOutputType(rawValue: microphoneOutputTypeRawValue) != nil
+	}
+
+	/// Did the user actually ask for a particular microphone?
+	///
+	/// The same test the Windows helper makes before emitting this warning
+	/// (`wantedAParticularMicrophone` in wgc-capture/src/wasapi_loopback_capture.cpp),
+	/// and it has to be made here too because `resolveMicrophoneCaptureDeviceID()`
+	/// returns nil for two very different situations. One is a chosen microphone that
+	/// nothing here could find, which is worth saying out loud. The other is no choice
+	/// at all, which is the common case and has to stay silent: the HUD leaves both
+	/// fields unset until its picker moves off "default", and persists the literal id
+	/// "default" when the user picks Chromium's own Default entry — so both shapes
+	/// arrive here meaning "the system default is fine", not "your microphone is gone".
+	private var requestedASpecificMicrophone: Bool {
+		let deviceId =
+			request.audio.microphone.deviceId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+		let deviceName =
+			request.audio.microphone.deviceName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+		return (!deviceId.isEmpty && deviceId != "default") || !deviceName.isEmpty
 	}
 
 	private func resolveMicrophoneCaptureDeviceID() -> String? {

--- a/electron/native/screencapturekit/Sources/OpenScreenScreenCaptureKitHelper/ScreenCaptureRecorder.swift
+++ b/electron/native/screencapturekit/Sources/OpenScreenScreenCaptureKitHelper/ScreenCaptureRecorder.swift
@@ -802,7 +802,13 @@ final class ScreenCaptureRecorder: NSObject, SCStreamOutput, SCStreamDelegate {
 			request.audio.microphone.deviceId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 		let deviceName =
 			request.audio.microphone.deviceName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-		return (!deviceId.isEmpty && deviceId != "default") || !deviceName.isEmpty
+		// "default" has to veto the name, not sit beside it. Chromium's picker
+		// persists BOTH fields from whichever entry was clicked, and its Default
+		// entry is labelled "Default - Microphone (…)" — a string no AVCaptureDevice
+		// localizedName ever matches. Reading the name here meant that picking
+		// "Default" warned about a microphone the user never chose.
+		if deviceId == "default" { return false }
+		return !deviceId.isEmpty || !deviceName.isEmpty
 	}
 
 	private func resolveMicrophoneCaptureDeviceID() -> String? {

--- a/src/hooks/useScreenRecorder.nativeMacStartWarning.test.tsx
+++ b/src/hooks/useScreenRecorder.nativeMacStartWarning.test.tsx
@@ -55,6 +55,7 @@ async function settle(ms = 0) {
 beforeEach(() => {
 	vi.useFakeTimers();
 	stubElectronAPI();
+	vi.mocked(toast.error).mockClear();
 });
 
 afterEach(() => {
@@ -86,5 +87,34 @@ describe("useScreenRecorder native macOS start warnings", () => {
 		);
 		expect(view.result.current.recording).toBe(true);
 		expect(toast.error).toHaveBeenCalledWith("recording.microphoneDefaulted");
+	});
+
+	it("does not warn after the recording start is cancelled", async () => {
+		let resolveStart:
+			| ((result: Awaited<ReturnType<ElectronAPI["startNativeMacRecording"]>>) => void)
+			| null = null;
+		api.startNativeMacRecording.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolveStart = resolve;
+				}),
+		);
+		const view = renderHook(() => useScreenRecorder());
+		await settle();
+
+		await act(async () => {
+			view.result.current.toggleRecording();
+		});
+		await settle(3_500);
+		expect(api.startNativeMacRecording).toHaveBeenCalledOnce();
+
+		view.unmount();
+		await act(async () => {
+			resolveStart?.({ success: true, recordingId: 8, microphoneDefaulted: true });
+			await Promise.resolve();
+		});
+
+		expect(api.stopNativeMacRecording).toHaveBeenCalledWith(true);
+		expect(toast.error).not.toHaveBeenCalled();
 	});
 });

--- a/src/hooks/useScreenRecorder.nativeMacStartWarning.test.tsx
+++ b/src/hooks/useScreenRecorder.nativeMacStartWarning.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/contexts/I18nContext", () => ({
+	useScopedT: () => (key: string) => key,
+}));
+
+vi.mock("sonner", () => ({
+	toast: { error: vi.fn(), success: vi.fn(), info: vi.fn(), warning: vi.fn() },
+}));
+
+import { toast } from "sonner";
+import { useScreenRecorder } from "./useScreenRecorder";
+
+type ElectronAPI = Window["electronAPI"];
+
+const SOURCE = { id: "screen:0:0", name: "Screen 1", display_id: "1", thumbnail: "" };
+
+let api: Record<string, ReturnType<typeof vi.fn>>;
+
+function stubElectronAPI() {
+	api = {
+		getRecordingPrefs: vi.fn(async () => ({
+			micEnabled: true,
+			micDeviceId: "chromium-device-id",
+			micDeviceName: "USB Microphone",
+			camEnabled: false,
+			camDeviceId: null,
+			systemAudioEnabled: false,
+			cursorCaptureMode: "system",
+		})),
+		getPlatform: vi.fn(() => "darwin"),
+		getSelectedSource: vi.fn(async () => SOURCE),
+		isNativeMacCaptureAvailable: vi.fn(async () => ({ success: true, available: true })),
+		startNativeMacRecording: vi.fn(async () => ({
+			success: true,
+			recordingId: 7,
+			microphoneDefaulted: true,
+		})),
+		stopNativeMacRecording: vi.fn(async () => ({ success: true, discarded: true })),
+		showCountdownOverlay: vi.fn(async () => true),
+		setCountdownOverlayValue: vi.fn(async () => true),
+		hideCountdownOverlay: vi.fn(async () => true),
+	};
+	window.electronAPI = api as unknown as ElectronAPI;
+}
+
+async function settle(ms = 0) {
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(ms);
+	});
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	stubElectronAPI();
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+describe("useScreenRecorder native macOS start warnings", () => {
+	it("warns but keeps recording when the selected microphone defaults", async () => {
+		const view = renderHook(() => useScreenRecorder());
+		await settle();
+
+		await act(async () => {
+			view.result.current.toggleRecording();
+		});
+		await settle(3_500);
+
+		expect(api.startNativeMacRecording).toHaveBeenCalledWith(
+			expect.objectContaining({
+				audio: {
+					system: { enabled: false },
+					microphone: expect.objectContaining({
+						enabled: true,
+						deviceId: "chromium-device-id",
+						deviceName: "USB Microphone",
+					}),
+				},
+			}),
+		);
+		expect(view.result.current.recording).toBe(true);
+		expect(toast.error).toHaveBeenCalledWith("recording.microphoneDefaulted");
+	});
+});

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -1327,12 +1327,12 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			if (!result.success || !result.recordingId) {
 				throw new Error(result.error ?? "Native macOS capture failed.");
 			}
-			if (result.microphoneDefaulted) {
-				toast.error(t("recording.microphoneDefaulted"));
-			}
 			if (!isCountdownRunActive(countdownRunToken)) {
 				await window.electronAPI.stopNativeMacRecording(true);
 				return true;
+			}
+			if (result.microphoneDefaulted) {
+				toast.error(t("recording.microphoneDefaulted"));
 			}
 
 			// The IPC call above only resolves once the helper's stdout confirms its

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -1327,6 +1327,9 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			if (!result.success || !result.recordingId) {
 				throw new Error(result.error ?? "Native macOS capture failed.");
 			}
+			if (result.microphoneDefaulted) {
+				toast.error(t("recording.microphoneDefaulted"));
+			}
 			if (!isCountdownRunActive(countdownRunToken)) {
 				await window.electronAPI.stopNativeMacRecording(true);
 				return true;

--- a/src/lib/nativeMacRecording.ts
+++ b/src/lib/nativeMacRecording.ts
@@ -88,6 +88,8 @@ export type NativeMacRecordingStartResult = {
 	recordingId?: number;
 	path?: string;
 	helperPath?: string;
+	/** The helper could not resolve the selected device and is using the system default. */
+	microphoneDefaulted?: boolean;
 	error?: string;
 };
 


### PR DESCRIPTION
## Summary

- make the macOS ScreenCaptureKit helper report when it cannot resolve the selected microphone
- preserve the existing safe fallback to the system-default input
- propagate that warning through Electron's native recording result
- show the existing localized `recording.microphoneDefaulted` toast while recording continues
- add a hook regression test covering the complete warning path visible to the user

## Root cause

The native macOS helper already fell back to ScreenCaptureKit's default input when the saved Chromium device identity could not be matched to an AVFoundation device. Unlike the Windows helper, however, it did not report that fallback, so users could unknowingly record the wrong microphone.

The helper now emits the same structured `microphone-defaulted` warning used by the Windows capture path. The main process includes it in the successful start result, and the renderer warns the user without interrupting the recording.

## Related issue

Fixes #402

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact

- [x] Patch
- [ ] Minor
- [ ] Major / breaking change
- [ ] No release note needed

## Desktop impact

- [ ] Windows
- [x] macOS
- [ ] Linux
- [ ] Installer / packaging
- [ ] Not platform-specific

## Screenshots / video

No new UI. The existing localized microphone-fallback toast is now shown on the macOS native recording path.

## Testing

- TDD red phase: native recording started successfully, but the expected `recording.microphoneDefaulted` toast had zero calls
- `npx vitest --run src/hooks/useScreenRecorder.nativeMacStartWarning.test.tsx electron/recording/nativeWindowsCaptureStop.test.ts` — 36 passed
- `swift test --package-path electron/native/screencapturekit` — 22 passed
- `swift build -c release --package-path electron/native/screencapturekit`
- `npm run build:native:mac` — packaged the darwin-arm64 helpers
- `npx tsc --noEmit`
- `npx tsc -p tsconfig.node.json --noEmit`
- `npm run lint` — no errors (14 pre-existing warnings)
- `npm run test` — 182 files, 2,164 passed, 2 skipped
- `git diff --check`

<!-- discord-thread-id:1542723288801873991 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * macOS recording now detects when the selected microphone cannot be found and the system default microphone is used.
  * A clear notification is shown when recording proceeds with the default microphone.
  * Notifications are no longer shown when a recording is cancelled before it begins or the recording does not proceed.
  * Default-microphone warnings are limited to cases where a specific microphone was requested.

* **Tests**
  * Added coverage for microphone fallback detection, user notifications, and cancelled recording starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->