### PR TITLE
fix(stt): distinguish initializing from transcribing on every spinner

### DIFF
--- a/src/i18n/locales/ar/editor.json
+++ b/src/i18n/locales/ar/editor.json
@@ -146,7 +146,6 @@
 		"transcribing": "جارٍ النسخ",
 		"downloadingModel": "جارٍ تنزيل نموذج الكلام",
 		"initializingModel": "جارٍ تهيئة نموذج الكلام",
-		"transcribingEllipsis": "جارٍ النسخ…",
 		"pendingTranscription": "بانتظار النسخ",
 		"transcriptionFailed": "فشل النسخ",
 		"cpuBackendHint": "يعمل على المعالج — أبطأ بنحو 2× من معالج الرسوميات",

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -141,7 +141,6 @@
 		"transcribing": "Transcribing",
 		"downloadingModel": "Downloading speech model",
 		"initializingModel": "Starting speech model",
-		"transcribingEllipsis": "Transcribing…",
 		"pendingTranscription": "Pending transcription",
 		"transcriptionFailed": "Transcription failed",
 		"cpuBackendHint": "Running on CPU — about 2× slower than on the GPU",

--- a/src/i18n/locales/es/editor.json
+++ b/src/i18n/locales/es/editor.json
@@ -146,7 +146,6 @@
 		"transcribing": "Transcribiendo",
 		"downloadingModel": "Descargando modelo de voz",
 		"initializingModel": "Iniciando el modelo de voz",
-		"transcribingEllipsis": "Transcribiendo…",
 		"pendingTranscription": "Transcripción pendiente",
 		"transcriptionFailed": "Error de transcripción",
 		"cpuBackendHint": "Ejecutándose en la CPU — unas 2× más lento que en la GPU",

--- a/src/i18n/locales/fr/editor.json
+++ b/src/i18n/locales/fr/editor.json
@@ -146,7 +146,6 @@
 		"transcribing": "Transcription en cours",
 		"downloadingModel": "Téléchargement du modèle vocal",
 		"initializingModel": "Démarrage du modèle vocal",
-		"transcribingEllipsis": "Transcription en cours…",
 		"pendingTranscription": "Transcription en attente",
 		"transcriptionFailed": "Échec de la transcription",
 		"cpuBackendHint": "Exécution sur le processeur — environ 2× plus lent que sur le GPU",

--- a/src/i18n/locales/it/editor.json
+++ b/src/i18n/locales/it/editor.json
@@ -146,7 +146,6 @@
 		"transcribing": "Trascrizione in corso",
 		"downloadingModel": "Download del modello vocale",
 		"initializingModel": "Avvio del modello vocale",
-		"transcribingEllipsis": "Trascrizione in corso…",
 		"pendingTranscription": "Trascrizione in attesa",
 		"transcriptionFailed": "Trascrizione non riuscita",
 		"cpuBackendHint": "In esecuzione su CPU — circa 2× più lento che su GPU",

--- a/src/i18n/locales/ja-JP/editor.json
+++ b/src/i18n/locales/ja-JP/editor.json
@@ -146,7 +146,6 @@
 		"transcribing": "文字起こし中",
 		"downloadingModel": "音声モデルをダウンロード中",
 		"initializingModel": "音声モデルを起動しています",
-		"transcribingEllipsis": "文字起こし中…",
 		"pendingTranscription": "文字起こし待機中",
 		"transcriptionFailed": "文字起こしに失敗しました",
 		"cpuBackendHint": "CPU で実行中 — GPU より約 2 倍低速です",

--- a/src/i18n/locales/ko-KR/editor.json
+++ b/src/i18n/locales/ko-KR/editor.json
@@ -146,7 +146,6 @@
 		"transcribing": "받아쓰는 중",
 		"downloadingModel": "음성 모델 다운로드 중",
 		"initializingModel": "음성 모델 시작 중",
-		"transcribingEllipsis": "받아쓰는 중…",
 		"pendingTranscription": "받아쓰기 대기 중",
 		"transcriptionFailed": "받아쓰기 실패",
 		"cpuBackendHint": "CPU에서 실행 중 — GPU보다 약 2배 느립니다",

--- a/src/i18n/locales/pt-BR/editor.json
+++ b/src/i18n/locales/pt-BR/editor.json
@@ -146,7 +146,6 @@
 		"transcribing": "Transcrevendo",
 		"downloadingModel": "Baixando modelo de voz",
 		"initializingModel": "Iniciando modelo de voz",
-		"transcribingEllipsis": "Transcrevendo…",
 		"pendingTranscription": "Transcrição pendente",
 		"transcriptionFailed": "Falha na transcrição",
 		"cpuBackendHint": "Executando na CPU — cerca de 2× mais lento do que na GPU",

--- a/src/i18n/locales/ru/editor.json
+++ b/src/i18n/locales/ru/editor.json
@@ -146,7 +146,6 @@
 		"transcribing": "Расшифровка",
 		"downloadingModel": "Загрузка речевой модели",
 		"initializingModel": "Запуск речевой модели",
-		"transcribingEllipsis": "Расшифровка…",
 		"pendingTranscription": "Ожидает расшифровки",
 		"transcriptionFailed": "Ошибка расшифровки",
 		"cpuBackendHint": "Выполняется на процессоре — примерно в 2× медленнее, чем на GPU",

--- a/src/i18n/locales/tr/editor.json
+++ b/src/i18n/locales/tr/editor.json
@@ -146,7 +146,6 @@
 		"transcribing": "Metne dökülüyor",
 		"downloadingModel": "Konuşma modeli indiriliyor",
 		"initializingModel": "Konuşma modeli başlatılıyor",
-		"transcribingEllipsis": "Metne dökülüyor…",
 		"pendingTranscription": "Metne dökme bekliyor",
 		"transcriptionFailed": "Metne dökme başarısız oldu",
 		"cpuBackendHint": "CPU üzerinde çalışıyor — GPU'ya göre yaklaşık 2× daha yavaş",

--- a/src/i18n/locales/vi/editor.json
+++ b/src/i18n/locales/vi/editor.json
@@ -146,7 +146,6 @@
 		"transcribing": "Đang phiên âm",
 		"downloadingModel": "Đang tải mô hình giọng nói",
 		"initializingModel": "Đang khởi động mô hình giọng nói",
-		"transcribingEllipsis": "Đang phiên âm…",
 		"pendingTranscription": "Đang chờ phiên âm",
 		"transcriptionFailed": "Phiên âm thất bại",
 		"cpuBackendHint": "Đang chạy trên CPU — chậm hơn khoảng 2× so với GPU",

--- a/src/i18n/locales/zh-CN/editor.json
+++ b/src/i18n/locales/zh-CN/editor.json
@@ -146,7 +146,6 @@
 		"transcribing": "正在转录",
 		"downloadingModel": "正在下载语音模型",
 		"initializingModel": "正在启动语音模型",
-		"transcribingEllipsis": "正在转录…",
 		"pendingTranscription": "等待转录",
 		"transcriptionFailed": "转录失败",
 		"cpuBackendHint": "正在使用 CPU 运行 — 比 GPU 慢约 2 倍",

--- a/src/i18n/locales/zh-TW/editor.json
+++ b/src/i18n/locales/zh-TW/editor.json
@@ -146,7 +146,6 @@
 		"transcribing": "轉錄中",
 		"downloadingModel": "正在下載語音模型",
 		"initializingModel": "正在啟動語音模型",
-		"transcribingEllipsis": "轉錄中…",
 		"pendingTranscription": "等待轉錄",
 		"transcriptionFailed": "轉錄失敗",
 		"cpuBackendHint": "正在使用 CPU 執行 — 比 GPU 慢約 2 倍",


### PR DESCRIPTION
## Summary

On the first transcription after app launch, whisper-stt-server does one-time work (fetching the model on first run, then loading it and warming the backend) that can take minutes. The boolean spinners in the editor — the Captions button, the Transcript pane header, and the Source-transcript modal — label that whole wait as transcribing, and the media stage calls all of it downloading even once the file is on disk; either way the first-run wait reads as a hang.

The transcription state already carries a `phase` (`loading-model` vs `transcribing`), and the phase-to-copy mapping lives in one shared hook — but only the media stage and the left panel's status dot consumed it. This change:

- routes the three boolean spinner surfaces (Captions pane, Transcript pane, Source-transcript modal) through a small `transcriptionBusyLabel` helper on top of that shared mapping, so their busy copy comes from the phase instead of a flat "Transcribing" — the shape the issue asks for ("the state itself should carry the phase, not just `pending`");
- splits the `loading-model` copy in the shared mapping: while model bytes are still arriving it stays "Downloading speech model", and once the file is on disk but the engine is still initializing it shows the new "Starting speech model" string (`editor.initializingModel`, added to every locale) — every consumer of the mapping benefits;
- passes the live transcription view into the Source-transcript modal so its status chip, spinner, and hint text use the same phase-aware label;
- removes the `captions.transcribing` locale key, which is unused after this change, and updates the two gating tests that asserted the old flat labels.

## Related issue

Fixes #334

## Type of change
- [x] Bug fix

## Release impact
- [x] Patch

## Desktop impact
- [x] Not platform-specific

## Screenshots / video

Text description in place of screenshots: on a cold start, the Captions button, the Transcript pane header, and the Source-transcript modal all show "Starting speech model" for the duration of the model load, then flip to the transcribing label once the engine reports actual transcription. On a warm engine the spinner goes straight to transcribing.

## Testing

- `npx vitest run` over the touched component suites (`transcriptionBusyLabel`, `TranscriptionStatus`, `CaptionsPane.gating`, `TranscriptPane.gating`) at this branch's head: 4 files, 18 passed; the touched store/status suites (`document/transcribe`, `transcription/status`): 2 files, 48 passed.
- `npx tsc --noEmit` and `npx tsc -p tsconfig.test.json --noEmit` at this branch's head: clean.

Manual verification on Windows 11, on an earlier revision of this series carrying this change: with a fresh user-data directory (real model download and cold engine load), every visible spinner surface showed the download phase, then the initializing phase, then transcribing; a second transcription in the same session showed transcribing immediately. The spinner surfaces outside the Edit dialog are byte-identical between that revision and this branch; the Source-transcript modal differs there by the sibling crop-preview change and by dropping a synthesized fallback view that revision still carried.

Scope note: pane-level busy labels are timeline-scoped — resolved over the same asset set the enablement gates read (with the whole-bin fallback while the timeline is empty) — so a job on a bin-only asset cannot relabel a control the gate keeps enabled. An earlier revision of this description claimed a label/gate scope mismatch predates this branch; that was incorrect, and the mismatch this branch briefly introduced is fixed in the follow-up commit.

<!-- discord-thread-id:1542762588784295967 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer transcription progress statuses, including speech-model initialization and download progress.
  - Transcription labels now update dynamically across captions, transcript panes, buttons, and empty states.
  - Added localized “Starting speech model” messaging across supported languages.

- **Bug Fixes**
  - Transcription activity now reflects only assets on the timeline, preventing unrelated jobs from disabling or relabeling retry controls.
  - Retry buttons remain available for timeline assets when another asset is processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->