### PR TITLE
feat(editor): persist and restore the editor window bounds

### DIFF
--- a/electron/editorWindowState.test.ts
+++ b/electron/editorWindowState.test.ts
@@ -77,4 +77,32 @@ describe("editor window state", () => {
 		);
 		expect(loadEditorWindowState(dir)).toBeNull();
 	});
+
+	it("rejects zero or negative dimensions instead of clamping them up", () => {
+		// A width:0 record is garbage the app never writes; letting it through
+		// would restore a min-size non-maximized window instead of the default.
+		for (const dims of [
+			{ width: 0, height: 720 },
+			{ width: 1280, height: 0 },
+			{ width: -1280, height: 720 },
+		]) {
+			const dir = tmp();
+			writeFileSync(
+				path.join(dir, "editor-window.json"),
+				JSON.stringify({ x: 10, y: 20, ...dims, maximized: false }),
+			);
+			expect(loadEditorWindowState(dir)).toBeNull();
+		}
+	});
+
+	it("rejects a non-boolean maximized rather than coercing it", () => {
+		for (const maximized of ["true", 1, null, undefined]) {
+			const dir = tmp();
+			writeFileSync(
+				path.join(dir, "editor-window.json"),
+				JSON.stringify({ x: 10, y: 20, width: 1280, height: 720, maximized }),
+			);
+			expect(loadEditorWindowState(dir)).toBeNull();
+		}
+	});
 });

--- a/electron/editorWindowState.test.ts
+++ b/electron/editorWindowState.test.ts
@@ -1,0 +1,80 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	clampRectToWorkArea,
+	loadEditorWindowState,
+	resolveEditorCreation,
+	saveEditorWindowState,
+	shouldTrackEditorWindow,
+} from "./editorWindowState";
+
+const temps: string[] = [];
+
+afterEach(() => {
+	for (const dir of temps) rmSync(dir, { recursive: true, force: true });
+	temps.length = 0;
+});
+
+function tmp(): string {
+	const dir = mkdtempSync(path.join(os.tmpdir(), "os-editor-win-"));
+	temps.push(dir);
+	return dir;
+}
+
+describe("editor window state", () => {
+	it("returns null when the file is missing", () => {
+		expect(loadEditorWindowState(tmp())).toBeNull();
+	});
+
+	it("clamps an off-screen rect onto the display workArea", () => {
+		const clamped = clampRectToWorkArea(
+			{ x: -4000, y: 50, width: 1200, height: 800 },
+			{ x: 0, y: 0, width: 1920, height: 1080 },
+		);
+		expect(clamped.x).toBe(0);
+		expect(clamped.y).toBe(50);
+		expect(clamped.width).toBe(1200);
+		expect(clamped.height).toBe(800);
+	});
+
+	it("still maximizes when nothing is saved, and never loads or saves the bench", () => {
+		const missing = resolveEditorCreation({ isBench: false, saved: null });
+		expect(missing.maximize).toBe(true);
+		expect(missing.persist).toBe(true);
+		expect(missing.bounds).toEqual({ width: 1200, height: 800 });
+
+		expect(shouldTrackEditorWindow({ windowType: "bench" })).toBe(false);
+		const bench = resolveEditorCreation({ isBench: true, saved: null });
+		expect(bench.persist).toBe(false);
+		expect(bench.maximize).toBe(true);
+
+		const dir = tmp();
+		saveEditorWindowState(dir, { x: 10, y: 20, width: 1280, height: 720, maximized: false });
+		expect(shouldTrackEditorWindow({ windowType: "bench" })).toBe(false);
+		expect(shouldTrackEditorWindow({})).toBe(true);
+	});
+
+	it("round-trips a save through load", () => {
+		const dir = tmp();
+		const state = { x: 10, y: 20, width: 1280, height: 720, maximized: true };
+		saveEditorWindowState(dir, state);
+		expect(loadEditorWindowState(dir)).toEqual(state);
+	});
+
+	it("returns null on a corrupted file instead of throwing", () => {
+		const dir = tmp();
+		writeFileSync(path.join(dir, "editor-window.json"), "{ not json");
+		expect(loadEditorWindowState(dir)).toBeNull();
+	});
+
+	it("rejects garbage fields rather than restoring a broken rect", () => {
+		const dir = tmp();
+		writeFileSync(
+			path.join(dir, "editor-window.json"),
+			JSON.stringify({ x: Number.NaN, y: 20, width: "1280", height: 720, maximized: false }),
+		);
+		expect(loadEditorWindowState(dir)).toBeNull();
+	});
+});

--- a/electron/editorWindowState.ts
+++ b/electron/editorWindowState.ts
@@ -1,0 +1,120 @@
+// Persist/restore the editor window's normal bounds and maximized flag.
+// The export bench must never load or save this file — it measures a 1200×800
+// maximized window on purpose.
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export const DEFAULT_EDITOR_SIZE = { width: 1200, height: 800 };
+export const EDITOR_WINDOW_MIN = { width: 800, height: 600 };
+
+export interface EditorWindowRect {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+export interface EditorWindowState extends EditorWindowRect {
+	maximized: boolean;
+}
+
+export interface DisplayWorkArea {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+export function editorWindowStatePath(userData: string): string {
+	return path.join(userData, "editor-window.json");
+}
+
+function isFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
+export function parseEditorWindowState(raw: unknown): EditorWindowState | null {
+	if (!raw || typeof raw !== "object") return null;
+	const rec = raw as Record<string, unknown>;
+	if (
+		!isFiniteNumber(rec.x) ||
+		!isFiniteNumber(rec.y) ||
+		!isFiniteNumber(rec.width) ||
+		!isFiniteNumber(rec.height)
+	) {
+		return null;
+	}
+	return {
+		x: rec.x,
+		y: rec.y,
+		width: rec.width,
+		height: rec.height,
+		maximized: rec.maximized === true,
+	};
+}
+
+export function loadEditorWindowState(userData: string): EditorWindowState | null {
+	const file = editorWindowStatePath(userData);
+	if (!existsSync(file)) return null;
+	try {
+		return parseEditorWindowState(JSON.parse(readFileSync(file, "utf8")));
+	} catch {
+		return null;
+	}
+}
+
+export function saveEditorWindowState(userData: string, state: EditorWindowState): void {
+	try {
+		writeFileSync(editorWindowStatePath(userData), `${JSON.stringify(state)}\n`, "utf8");
+	} catch {
+		// Best-effort; a failed write must not block close.
+	}
+}
+
+export function clampRectToWorkArea(
+	rect: EditorWindowRect,
+	workArea: DisplayWorkArea,
+	min = EDITOR_WINDOW_MIN,
+): EditorWindowRect {
+	const width = Math.min(Math.max(rect.width, min.width), Math.max(min.width, workArea.width));
+	const height = Math.min(Math.max(rect.height, min.height), Math.max(min.height, workArea.height));
+	const maxX = workArea.x + Math.max(0, workArea.width - width);
+	const maxY = workArea.y + Math.max(0, workArea.height - height);
+	return {
+		x: Math.min(Math.max(rect.x, workArea.x), maxX),
+		y: Math.min(Math.max(rect.y, workArea.y), maxY),
+		width,
+		height,
+	};
+}
+
+export function shouldTrackEditorWindow(query: Record<string, string>): boolean {
+	return query.windowType !== "bench";
+}
+
+export function resolveEditorCreation(input: {
+	isBench: boolean;
+	saved: EditorWindowState | null;
+}): {
+	bounds: { x?: number; y?: number; width: number; height: number };
+	maximize: boolean;
+	persist: boolean;
+} {
+	if (input.isBench) {
+		return { bounds: { ...DEFAULT_EDITOR_SIZE }, maximize: true, persist: false };
+	}
+	if (!input.saved) {
+		return { bounds: { ...DEFAULT_EDITOR_SIZE }, maximize: true, persist: true };
+	}
+	return {
+		bounds: {
+			x: input.saved.x,
+			y: input.saved.y,
+			width: input.saved.width,
+			height: input.saved.height,
+		},
+		maximize: input.saved.maximized,
+		persist: true,
+	};
+}

--- a/electron/editorWindowState.ts
+++ b/electron/editorWindowState.ts
@@ -37,11 +37,17 @@ function isFiniteNumber(value: unknown): value is number {
 export function parseEditorWindowState(raw: unknown): EditorWindowState | null {
 	if (!raw || typeof raw !== "object") return null;
 	const rec = raw as Record<string, unknown>;
+	// Zero/negative dimensions and a non-boolean `maximized` are garbage the
+	// app never writes; restoring them would clamp into a small non-maximized
+	// window instead of the documented default. Reject the record whole.
 	if (
 		!isFiniteNumber(rec.x) ||
 		!isFiniteNumber(rec.y) ||
 		!isFiniteNumber(rec.width) ||
-		!isFiniteNumber(rec.height)
+		!isFiniteNumber(rec.height) ||
+		rec.width <= 0 ||
+		rec.height <= 0 ||
+		typeof rec.maximized !== "boolean"
 	) {
 		return null;
 	}
@@ -50,7 +56,7 @@ export function parseEditorWindowState(raw: unknown): EditorWindowState | null {
 		y: rec.y,
 		width: rec.width,
 		height: rec.height,
-		maximized: rec.maximized === true,
+		maximized: rec.maximized,
 	};
 }
 

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -1,6 +1,13 @@
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { BrowserWindow, ipcMain, screen } from "electron";
+import { app, BrowserWindow, ipcMain, screen } from "electron";
+import {
+	clampRectToWorkArea,
+	loadEditorWindowState,
+	resolveEditorCreation,
+	saveEditorWindowState,
+	shouldTrackEditorWindow,
+} from "./editorWindowState";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -392,10 +399,18 @@ export function createHudOverlayWindow(): BrowserWindow {
  */
 export function createEditorWindow(query: Record<string, string> = {}): BrowserWindow {
 	const isMac = process.platform === "darwin";
+	const persist = shouldTrackEditorWindow(query);
+	const loaded = persist ? loadEditorWindowState(app.getPath("userData")) : null;
+	const saved = loaded
+		? {
+				...clampRectToWorkArea(loaded, screen.getDisplayMatching(loaded).workArea),
+				maximized: loaded.maximized,
+			}
+		: null;
+	const creation = resolveEditorCreation({ isBench: query.windowType === "bench", saved });
 
 	const win = new BrowserWindow({
-		width: 1200,
-		height: 800,
+		...creation.bounds,
 		minWidth: 800,
 		minHeight: 600,
 		// Seamless titlebar on every platform: the app's own topbar IS the titlebar
@@ -425,7 +440,23 @@ export function createEditorWindow(query: Record<string, string> = {}): BrowserW
 		},
 	});
 
-	win.maximize();
+	if (creation.maximize) win.maximize();
+	if (creation.persist) {
+		const persistState = () => {
+			if (win.isDestroyed()) return;
+			const bounds = win.getNormalBounds();
+			saveEditorWindowState(app.getPath("userData"), {
+				x: bounds.x,
+				y: bounds.y,
+				width: bounds.width,
+				height: bounds.height,
+				maximized: win.isMaximized(),
+			});
+		};
+		win.on("moved", persistState);
+		win.on("resized", persistState);
+		win.on("close", persistState);
+	}
 
 	// The editor renders its own File/Edit/View menu bar in the custom titlebar,
 	// so hide the native OS menu bar on Windows/Linux (it stays reachable via Alt).


### PR DESCRIPTION
## Summary

The editor always opened maximized at a default size, forgetting any resize/reposition from the previous session.

- The editor window now persists its normal bounds and maximized flag (to `editor-window.json` in the user-data directory) on move, resize, and close, and restores them on the next open.
- Restored bounds are clamped to the work area of the display they were saved on (via `screen.getDisplayMatching`), so a window saved on a since-disconnected or rearranged monitor cannot come back off-screen.
- A corrupt or hand-edited state file falls back to the default maximized 1200x800 window instead of throwing.
- The export bench window is deliberately excluded — it measures a fixed-size maximized window on purpose and must not load or save this state.

## Related issue

Part of #362 — this covers remembering the window size, position, and maximized state. Full-screen mode (which the issue also asks to remember) is intentionally not persisted here: restoring straight into full-screen has platform-specific behavior (notably macOS Spaces) that deserves its own change rather than riding along in this one.

## Type of change
- [x] Feature

## Release impact
- [x] Minor

## Desktop impact
- [x] Not platform-specific

## Screenshots / video

Not a visual change beyond the window opening where it was left; no screenshots.

## Testing

- `npx vitest run electron/editorWindowState.test.ts` at this branch's head: 6 passed — save/load round-trip, missing file, corrupted file, garbage fields, off-screen clamping onto the work area, and the default/bench creation path (bench never loads or saves).
- `npx tsc --noEmit` and `npx tsc -p tsconfig.test.json --noEmit` at this branch's head: clean.

Manual verification on Windows 11: resize and move the editor, close it, finish another recording — the editor reopens with the same bounds; maximize before closing and it reopens maximized. Verified on a build whose `electron/windows.ts` and `electron/editorWindowState.ts` are byte-identical to this branch.

Notes:
- On Linux, window managers that do not deliver move/resize events reliably are still covered by the close-time save.
- The 800x600 minimum exists both as the `BrowserWindow` min options and as a clamp floor in the state module; deduplicating those constants is left as-is to keep this change small.

<!-- discord-thread-id:1542762860231524476 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editor windows now restore their previous size, position, and maximized state when reopened.
  * Restored windows are automatically kept within the available display area.
  * Standard editor window changes are saved for future sessions.

* **Bug Fixes**
  * Prevented temporary bench windows from affecting or restoring saved editor window settings.
  * Added safeguards for invalid or corrupted saved window data, including unusable dimensions and invalid maximized states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->