### PR TITLE
perf(linux): convert to YUV on the GPU, halving the export readback

### DIFF
--- a/crates/compositor/src/compositor_linux.rs
+++ b/crates/compositor/src/compositor_linux.rs
@@ -133,6 +133,40 @@ struct ReadbackRing {
     pending: std::collections::VecDeque<PendingCopy>,
 }
 
+/// Cibles et pipelines de la conversion RGBA -> YUV420P sur le GPU.
+///
+/// Trois cibles R8Unorm plutot qu'une seule : Y est en pleine resolution et U/V
+/// en demie (4:2:0), et wgpu ne sait pas ecrire des attachements de tailles
+/// differentes dans une meme passe.
+struct YuvTargets {
+    /// Gardees en vie pour leurs vues ; seules les vues servent au rendu.
+    _y: wgpu::Texture,
+    _u: wgpu::Texture,
+    _v: wgpu::Texture,
+    y_view: wgpu::TextureView,
+    u_view: wgpu::TextureView,
+    v_view: wgpu::TextureView,
+    bind: wgpu::BindGroup,
+    pipe_y: wgpu::RenderPipeline,
+    pipe_u: wgpu::RenderPipeline,
+    pipe_v: wgpu::RenderPipeline,
+    /// Dimensions pour lesquelles tout ceci a ete construit : un resize doit
+    /// tout refaire, et comparer ici est moins fragile que de s'en souvenir.
+    w: u32,
+    h: u32,
+    /// `bytes_per_row` alignes a 256. En 1080p, Y passe de 1920 a 2048 et U/V de
+    /// 960 a 1024 : contrairement au RGBA (7680 = 30*256, deja aligne), les plans
+    /// PORTENT du padding, et le lecteur doit le retirer ligne a ligne.
+    bpr_y: u32,
+    bpr_uv: u32,
+    /// Offsets des trois plans dans le buffer de staging unique. Alignes a 256
+    /// (exigence de `copy_texture_to_buffer`), ce que la taille du plan Y
+    /// garantit deja puisque `bpr_y` l'est.
+    off_u: u64,
+    off_v: u64,
+    total: u64,
+}
+
 // ---------------------------------------------------------------------------
 // Segmentation du sujet webcam
 // ---------------------------------------------------------------------------
@@ -219,6 +253,18 @@ pub struct Compositor {
     /// Ring de buffers de staging (cf. `ReadbackRing`). `RefCell` : les methodes
     /// publiques du compositeur sont `&self`, comme tout le reste de l'etat.
     readback: RefCell<ReadbackRing>,
+
+    /// Conversion RGBA -> Y/U/V sur le GPU, construite a la premiere demande.
+    ///
+    /// Paresseuse et non dans `new` pour une raison de contrat : la preview
+    /// n'en veut pas (elle rend du RGBA a un `<canvas>`) et la payer a chaque
+    /// construction de compositeur couterait trois textures et trois pipelines
+    /// a tout le monde pour le seul benefice de l'export.
+    yuv: RefCell<Option<YuvTargets>>,
+    /// Ring de staging DEDIEE aux plans YUV : ses buffers font 3,1 Mo la ou
+    /// ceux de `readback` en font 8,3, et melanger les deux tailles dans une
+    /// seule ring rendrait la reutilisation dependante de l'ordre des appels.
+    readback_yuv: RefCell<ReadbackRing>,
 
     // Etat pilote par live.rs (interior mutability : les methodes sont `&self`).
     live_params: RefCell<LiveParams>,
@@ -557,6 +603,13 @@ impl Compositor {
             free: vec![Self::make_staging(&gpu, readback_bpr, h)],
             pending: std::collections::VecDeque::new(),
         });
+        // Vide : les buffers YUV sont dimensionnes par `YuvTargets` (qui connait
+        // les trois `bytes_per_row` alignes) et alloues a la premiere relecture.
+        let readback_yuv = RefCell::new(ReadbackRing {
+            depth: 1,
+            free: Vec::new(),
+            pending: std::collections::VecDeque::new(),
+        });
 
         Ok(Compositor {
             gpu,
@@ -579,6 +632,8 @@ impl Compositor {
             accum_view,
             readback_bpr,
             readback,
+            yuv: RefCell::new(None),
+            readback_yuv,
             live_params: RefCell::new(LiveParams::default()),
             scene: RefCell::new(None),
             cursor: RefCell::new(None),
@@ -2873,6 +2928,281 @@ impl Compositor {
         while ring.free.len() < depth {
             let buf = Self::make_staging(&self.gpu, self.readback_bpr, self.render_h);
             ring.free.push(buf);
+        }
+        Ok(())
+    }
+
+    /// Construit (ou reconstruit apres resize) les cibles et pipelines YUV.
+    fn ensure_yuv(&self) -> Result<()> {
+        let (w, h) = (self.render_w, self.render_h);
+        if let Some(t) = self.yuv.borrow().as_ref() {
+            if t.w == w && t.h == h {
+                return Ok(());
+            }
+        }
+        // 4:2:0 : les plans de chrominance font la moitie, arrondie au superieur
+        // pour ne jamais perdre la derniere colonne/ligne d'une dimension impaire.
+        let (cw, ch) = (w.div_ceil(2), h.div_ceil(2));
+        let gpu = &self.gpu;
+
+        let mk = |label: &str, tw: u32, th: u32| {
+            gpu.device.create_texture(&wgpu::TextureDescriptor {
+                label: Some(label),
+                size: wgpu::Extent3d { width: tw, height: th, depth_or_array_layers: 1 },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::R8Unorm,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+                view_formats: &[],
+            })
+        };
+        let y = mk("yuv-y", w, h);
+        let u = mk("yuv-u", cw, ch);
+        let v = mk("yuv-v", cw, ch);
+        let y_view = y.create_view(&wgpu::TextureViewDescriptor::default());
+        let u_view = u.create_view(&wgpu::TextureViewDescriptor::default());
+        let v_view = v.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let module = gpu.device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("yuv"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("vk_shaders/yuv.wgsl").into()),
+        });
+        let bgl = gpu.device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("yuv-bgl"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+        // Sampler LINEAIRE : c'est lui qui fait le sous-echantillonnage 2x2 des
+        // plans de chrominance. Avec un `Nearest` on prendrait un pixel sur
+        // quatre au lieu de leur moyenne, ce qui aliase visiblement les bords.
+        let samp = gpu.device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("yuv-samp"),
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+        let bind = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("yuv-bg"),
+            layout: &bgl,
+            entries: &[
+                wgpu::BindGroupEntry { binding: 0, resource: wgpu::BindingResource::TextureView(&self.rt_view) },
+                wgpu::BindGroupEntry { binding: 1, resource: wgpu::BindingResource::Sampler(&samp) },
+            ],
+        });
+        let layout = gpu.device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("yuv-pl"),
+            bind_group_layouts: &[&bgl],
+            push_constant_ranges: &[],
+        });
+        let mk_pipe = |entry: &str, label: &str| {
+            gpu.device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some(label),
+                layout: Some(&layout),
+                vertex: wgpu::VertexState {
+                    module: &module,
+                    entry_point: Some("vs_fullscreen"),
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                    buffers: &[],
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &module,
+                    entry_point: Some(entry),
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: wgpu::TextureFormat::R8Unorm,
+                        blend: None,
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    ..Default::default()
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            })
+        };
+
+        let bpr_y = w.div_ceil(256) * 256;
+        let bpr_uv = cw.div_ceil(256) * 256;
+        let size_y = u64::from(bpr_y) * u64::from(h);
+        let size_uv = u64::from(bpr_uv) * u64::from(ch);
+        let targets = YuvTargets {
+            _y: y,
+            _u: u,
+            _v: v,
+            y_view,
+            u_view,
+            v_view,
+            bind,
+            pipe_y: mk_pipe("fs_y", "yuv-y"),
+            pipe_u: mk_pipe("fs_u", "yuv-u"),
+            pipe_v: mk_pipe("fs_v", "yuv-v"),
+            w,
+            h,
+            bpr_y,
+            bpr_uv,
+            off_u: size_y,
+            off_v: size_y + size_uv,
+            total: size_y + 2 * size_uv,
+        };
+        // Les buffers de l'ancienne taille ne conviennent plus.
+        self.readback_yuv.borrow_mut().free.clear();
+        *self.yuv.borrow_mut() = Some(targets);
+        Ok(())
+    }
+
+    /// Pendant YUV de `readback_submit` : convertit le RT en Y/U/V sur le GPU,
+    /// copie les trois plans dans UN buffer de staging, et recolte la frame
+    /// precedente. Meme contrat de ring et de profondeur que la version RGBA.
+    ///
+    /// Rend les plans avec leur padding : `(w, h, buf)` ou `buf` contient Y a
+    /// l'offset 0 (stride `align256(w)`), puis U et V (stride `align256(w/2)`).
+    /// L'appelant recalcule ces strides depuis `w`/`h` — les depadder ici
+    /// couterait une recopie de plus pour rien, l'encodeur sachant lire un
+    /// `linesize`.
+    pub unsafe fn readback_submit_yuv(&self) -> Result<Option<(u32, u32, Vec<u8>)>> {
+        self.ensure_yuv()?;
+        let (w, h, cw, ch, bpr_y, bpr_uv, off_u, off_v, total) = {
+            let g = self.yuv.borrow();
+            let t = g.as_ref().expect("ensure_yuv");
+            (t.w, t.h, t.w.div_ceil(2), t.h.div_ceil(2), t.bpr_y, t.bpr_uv, t.off_u, t.off_v, t.total)
+        };
+
+        let buf = {
+            let mut ring = self.readback_yuv.borrow_mut();
+            match ring.free.pop() {
+                Some(b) => b,
+                None => self.gpu.device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("readback-yuv"),
+                    size: total,
+                    usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+                    mapped_at_creation: false,
+                }),
+            }
+        };
+
+        let mut encoder = self
+            .gpu
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some("yuv-convert") });
+        {
+            let g = self.yuv.borrow();
+            let t = g.as_ref().expect("ensure_yuv");
+            for (view, pipe) in [
+                (&t.y_view, &t.pipe_y),
+                (&t.u_view, &t.pipe_u),
+                (&t.v_view, &t.pipe_v),
+            ] {
+                let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("yuv-plane"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            // Chaque passe reecrit chaque texel : `Load` ferait lire
+                            // une cible dont on va ecraser le contenu.
+                            load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                });
+                pass.set_pipeline(pipe);
+                pass.set_bind_group(0, &t.bind, &[]);
+                pass.draw(0..3, 0..1);
+            }
+            for (tex, off, bpr, pw, ph) in [
+                (&t._y, 0u64, bpr_y, w, h),
+                (&t._u, off_u, bpr_uv, cw, ch),
+                (&t._v, off_v, bpr_uv, cw, ch),
+            ] {
+                encoder.copy_texture_to_buffer(
+                    wgpu::TexelCopyTextureInfo {
+                        texture: tex,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    wgpu::TexelCopyBufferInfo {
+                        buffer: &buf,
+                        layout: wgpu::TexelCopyBufferLayout {
+                            offset: off,
+                            bytes_per_row: Some(bpr),
+                            rows_per_image: Some(ph),
+                        },
+                    },
+                    wgpu::Extent3d { width: pw, height: ph, depth_or_array_layers: 1 },
+                );
+            }
+        }
+
+        let idx = self.gpu.context.submit(std::iter::once(encoder.finish()));
+        let (tx, rx) = std::sync::mpsc::channel();
+        buf.slice(..).map_async(wgpu::MapMode::Read, move |r| {
+            let _ = tx.send(r);
+        });
+        {
+            let mut ring = self.readback_yuv.borrow_mut();
+            ring.pending.push_back(PendingCopy { buf, idx, rx, w, h, bpr: bpr_y });
+            if ring.pending.len() < ring.depth {
+                return Ok(None); // amorcage, comme la ring RGBA
+            }
+        }
+        self.readback_take_yuv()
+    }
+
+    /// Recolte la plus ancienne conversion en vol. Pendant de `readback_take`.
+    pub unsafe fn readback_take_yuv(&self) -> Result<Option<(u32, u32, Vec<u8>)>> {
+        let Some(p) = self.readback_yuv.borrow_mut().pending.pop_front() else {
+            return Ok(None);
+        };
+        self.gpu.device.poll(wgpu::Maintain::WaitForSubmissionIndex(p.idx));
+        p.rx
+            .recv()
+            .map_err(|_| anyhow::anyhow!("map_async channel (yuv)"))?
+            .map_err(|e| anyhow::anyhow!("map_async yuv: {e:?}"))?;
+        let slice = p.buf.slice(..);
+        let mapped = slice.get_mapped_range();
+        let out = mapped.to_vec();
+        drop(mapped);
+        p.buf.unmap();
+        self.readback_yuv.borrow_mut().free.push(p.buf);
+        Ok(Some((p.w, p.h, out)))
+    }
+
+    /// Profondeur de la ring YUV. Meme role et memes raisons que
+    /// `set_readback_depth` pour la ring RGBA.
+    pub fn set_readback_yuv_depth(&self, depth: usize) -> Result<()> {
+        let depth = depth.max(1);
+        // SAFETY : meme contrat que `set_readback_depth` — le drain ne touche que
+        // des buffers dont la soumission est terminee.
+        while unsafe { self.readback_take_yuv()? }.is_some() {}
+        let mut ring = self.readback_yuv.borrow_mut();
+        ring.depth = depth;
+        while ring.free.len() > depth {
+            ring.free.pop();
         }
         Ok(())
     }

--- a/crates/compositor/src/pipeline_linux.rs
+++ b/crates/compositor/src/pipeline_linux.rs
@@ -322,6 +322,50 @@ impl VideoEncoder {
         averr(avcodec_send_frame(self.ctx, self.sw), "send_frame")
     }
 
+    /// Envoie une frame deja en YUV420P, convertie par le GPU.
+    ///
+    /// Remplace `send_rgba` sur le chemin d'export : plus de `sws_scale`, et le
+    /// buffer relu fait 3,1 Mo au lieu de 8,3 en 1080p. Le seul travail CPU qui
+    /// reste est de retirer le padding des trois plans — `copy_texture_to_buffer`
+    /// aligne chaque `bytes_per_row` sur 256, donc en 1080p Y arrive en 2048 pour
+    /// 1920 utiles et U/V en 1024 pour 960.
+    pub unsafe fn send_yuv420p(&mut self, planes: &[u8], rw: i32, rh: i32, pts: i64) -> Result<()> {
+        use crate::ffi::*;
+        if rw != self.w || rh != self.h {
+            bail!("send_yuv420p {rw}x{rh} != encodeur {}x{}", self.w, self.h);
+        }
+        let (w, h) = (rw as usize, rh as usize);
+        let (cw, ch) = (w.div_ceil(2), h.div_ceil(2));
+        let bpr_y = w.div_ceil(256) * 256;
+        let bpr_uv = cw.div_ceil(256) * 256;
+        let off_u = bpr_y * h;
+        let off_v = off_u + bpr_uv * ch;
+        if planes.len() < off_v + bpr_uv * ch {
+            bail!("plans YUV tronques : {} octets", planes.len());
+        }
+
+        averr(av_frame_make_writable(self.sw), "make_writable")?;
+        // Ligne a ligne parce que les deux strides different : celui du GPU est
+        // aligne a 256, celui de l'AVFrame a ce que ffmpeg a choisi.
+        for (plane, src_off, src_stride, pw, ph) in [
+            (0usize, 0usize, bpr_y, w, h),
+            (1, off_u, bpr_uv, cw, ch),
+            (2, off_v, bpr_uv, cw, ch),
+        ] {
+            let dst = (*self.sw).data[plane];
+            let dst_stride = (*self.sw).linesize[plane] as usize;
+            for y in 0..ph {
+                std::ptr::copy_nonoverlapping(
+                    planes.as_ptr().add(src_off + y * src_stride),
+                    dst.add(y * dst_stride),
+                    pw,
+                );
+            }
+        }
+        (*self.sw).pts = pts;
+        averr(avcodec_send_frame(self.ctx, self.sw), "send_frame")
+    }
+
     /// Flush : une frame nulle finalise le bitstream de l'encodeur.
     pub unsafe fn flush(&mut self) -> Result<()> {
         crate::ffi::averr(
@@ -461,7 +505,7 @@ pub fn run_composited_multi(
     // Ring de staging a 2 : l'export ne veut que du debit, une frame de latence
     // ne se voit pas dans un fichier. Voir `Compositor::set_readback_depth` pour
     // la raison pour laquelle la preview, elle, reste a 1.
-    comp.set_readback_depth(2)?;
+    comp.set_readback_yuv_depth(2)?;
     // pts d'encodage : DECOUPLE de l'index de marche `n`, puisque la frame
     // recoltee a l'iteration n est celle composee a n-1. Il reste contigu (les
     // frames sortent de la ring dans l'ordre de composition), donc le fichier
@@ -480,10 +524,10 @@ pub fn run_composited_multi(
             &mut |n| {
                 // Soumet la copie de la frame n SANS l'attendre et recolte la
                 // precedente : c'est tout le pipelining. Pendant que le CPU
-                // passe ses ~12,6 ms dans sws_scale + avcodec_send_frame sur la
-                // frame n-1, le GPU finit la composition et la copie de n.
-                if let Some((rw, rh, rgba)) = comp.readback_submit()? {
-                    enc.send_rgba(&rgba, rw as i32, rh as i32, encoded_pts)?;
+                // passe son temps dans `avcodec_send_frame` sur la frame n-1,
+                // le GPU finit la composition, la conversion YUV et la copie de n.
+                if let Some((rw, rh, planes)) = comp.readback_submit_yuv()? {
+                    enc.send_yuv420p(&planes, rw as i32, rh as i32, encoded_pts)?;
                     encoded_pts += 1;
                     drain_encoder(ectx, octx, ostream, opkt)?;
                 }
@@ -519,15 +563,15 @@ pub fn run_composited_multi(
         // Drain de la ring AVANT le flush de l'encodeur : les `depth - 1`
         // dernieres copies sont encore en vol, et sans ce drain la derniere
         // frame composee ne serait jamais encodee (video amputee d'une frame).
-        while let Some((rw, rh, rgba)) = comp.readback_take()? {
-            enc.send_rgba(&rgba, rw as i32, rh as i32, encoded_pts)?;
+        while let Some((rw, rh, planes)) = comp.readback_take_yuv()? {
+            enc.send_yuv420p(&planes, rw as i32, rh as i32, encoded_pts)?;
             encoded_pts += 1;
             drain_encoder(ectx, octx, ostream, opkt)?;
         }
         // Le compositeur peut survivre a l'export (l'appelant le possede) : on
         // lui rend sa profondeur par defaut plutot que de lui laisser une ring
         // a 2 et le buffer de 8 Mo qui va avec.
-        comp.set_readback_depth(1)?;
+        comp.set_readback_yuv_depth(1)?;
         enc.flush()?;
         drain_encoder(ectx, octx, ostream, opkt)?;
         // Audio : le plan part des frames REELLEMENT produites par clip (un clip

--- a/crates/compositor/src/vk_shaders/yuv.wgsl
+++ b/crates/compositor/src/vk_shaders/yuv.wgsl
@@ -1,0 +1,66 @@
+// RGBA composee -> plans Y / U / V, sur le GPU.
+//
+// POURQUOI. Le chemin Linux relisait le RT en RGBA (8,3 Mo par frame en 1080p)
+// puis convertissait en YUV420P sur le CPU avec `sws_scale`, mono-thread.
+// Mesure sur un export S4 de 3600 frames : relecture 22,4 s, sws_scale 12,2 s.
+// Convertir avant la relecture divise le volume relu par 2,67 (8,3 Mo -> 3,1 Mo)
+// et fait disparaitre sws_scale.
+//
+// COEFFICIENTS. BT.601, plage limitee (Y 16-235, C 16-240) : c'est EXACTEMENT ce
+// que `sws_getContext(..., SWS_POINT, ...)` produit par defaut pour une sortie
+// YUV420P, et le but ici est d'accelerer la conversion, pas d'en changer le
+// resultat. Toute autre matrice deplacerait les couleurs du fichier exporte.
+
+@group(0) @binding(0) var tex:  texture_2d<f32>;
+@group(0) @binding(1) var samp: sampler;
+
+struct VsOut {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+// Meme triangle plein ecran que `blur.wgsl::vs_fullscreen`, meme orientation :
+// une passe unique ne pardonne pas une erreur de sens (cf. la note la-bas).
+@vertex
+fn vs_fullscreen(@builtin(vertex_index) vid: u32) -> VsOut {
+    let pos = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>( 3.0, -1.0),
+        vec2<f32>(-1.0,  3.0),
+    );
+    let p = pos[vid];
+    var o: VsOut;
+    o.pos = vec4<f32>(p, 0.0, 1.0);
+    o.uv = vec2<f32>(p.x * 0.5 + 0.5, 0.5 - p.y * 0.5);
+    return o;
+}
+
+fn luma601(c: vec3<f32>) -> f32 {
+    return dot(c, vec3<f32>(0.299, 0.587, 0.114));
+}
+
+// Y pleine resolution. 16 + 219*Y', normalise sur 255 pour un R8Unorm.
+@fragment
+fn fs_y(i: VsOut) -> @location(0) vec4<f32> {
+    let c = textureSample(tex, samp, i.uv).rgb;
+    let y = (16.0 + 219.0 * luma601(c)) / 255.0;
+    return vec4<f32>(y, 0.0, 0.0, 1.0);
+}
+
+// U et V en demi-resolution. Le sampler est LINEAIRE et la cible fait la moitie
+// de la source, donc echantillonner au centre du texel de sortie moyenne
+// exactement le bloc 2x2 correspondant — le meme sous-echantillonnage que fait
+// sws pour du 4:2:0, sans boucle de taps.
+@fragment
+fn fs_u(i: VsOut) -> @location(0) vec4<f32> {
+    let c = textureSample(tex, samp, i.uv).rgb;
+    let u = (128.0 + 224.0 * (-0.168736 * c.r - 0.331264 * c.g + 0.5 * c.b)) / 255.0;
+    return vec4<f32>(u, 0.0, 0.0, 1.0);
+}
+
+@fragment
+fn fs_v(i: VsOut) -> @location(0) vec4<f32> {
+    let c = textureSample(tex, samp, i.uv).rgb;
+    let v = (128.0 + 224.0 * (0.5 * c.r - 0.418688 * c.g - 0.081312 * c.b)) / 255.0;
+    return vec4<f32>(v, 0.0, 0.0, 1.0);
+}


### PR DESCRIPTION
Follow-up to the measurement work in #544. The Linux export spent roughly half its
time moving pixels around rather than encoding them, and a large part of that was
an artefact of *where* the RGBA→YUV420P conversion happened.

## The problem

The export loop read the render target back as RGBA and handed it to `sws_scale`
to make the YUV420P the encoder wanted. Instrumenting a 3600-frame 1080p60 export
with every effect on:

| stage | time |
|---|---|
| readback (RT → CPU) | 22.4 s |
| RGBA → YUV420P in front of the encoder | 12.2 s |
| `avcodec_send_frame` | 24.9 s |
| drain + mux | 0.07 s |
| *(uninstrumented: decode, compose, upload)* | *12.4 s* |
| **total** | **72.0 s** |

Compositing itself is not the cost — an export with all effects disabled took
73.4 s against 74.9 s with all four on, so the whole effect stack is ~1.5 s. The
34.6 s above it is format plumbing.

And the readback is expensive *because* of the format. RGBA at 1080p is 8.3 MB
per frame; the encoder wanted 3.1 MB of planes. We were moving 2.67× more data
across the bus than the consumer needed, then paying a second time on the CPU to
throw the excess away.

## The change

Do the conversion on the GPU, before the readback instead of after it.

`vk_shaders/yuv.wgsl` renders the composed texture into three `R8Unorm` targets —
Y at full resolution, U and V at half — and the export path reads *those* back.

Two details worth calling out:

- **The 4:2:0 subsampling is free.** U and V render into targets half the size of
  the source, so sampling at the centre of each output texel with a linear sampler
  averages exactly the corresponding 2×2 source block. The filter unit does the
  subsampling; there is no tap loop to write and no edge case to get wrong.
- **BT.601 limited range is not a choice.** It is what `sws_getContext(...)` already
  produced by default for a YUV420P output. The point is to make the conversion
  cheaper, not to move the colours in exported files.

## Result

| stage | before | after |
|---|---|---|
| readback | 22.4 s | **9.75 s** |
| RGBA → YUV420P in front of the encoder | 12.2 s | **0 s** |
| `avcodec_send_frame` | 24.9 s | 29.5 s |

End to end:

| | before | after | |
|---|---|---|---|
| export, standalone | 71.97 s | 53.76 s | −25.3% |
| export, measured in a harness | 76.42 s | 56.66 s | −25.9% |

Output verified equivalent each time: 60.000 s, 3600 frames, 1920×1080 @ 60,
h264 + aac, audio at −49.8 dBFS either way, all pixel checks passing.

## Two things I want a reviewer to push on

**The encode stage moved the wrong way**, 24.9 s → 29.5 s, and I cannot account
for it. The encoder gets the same pixel format and the same dimensions; the only
thing that changed is that frames now arrive faster. My best guess is that
libopenh264 was previously blocked on a slower producer and some of its cost was
being attributed to the stage in front of it — but that is a guess, and I would
rather flag it than dress it up. The end-to-end number is what was measured.

**The conversion is not bit-exact** against `sws_scale`: 46.4 dB PSNR average
(Y 45.7, U 48.0, V 48.7), from chroma siting and rounding. Above 40 dB is
visually transparent on this content, and it is a resampling difference rather
than a systematic shift — but it does change the rendered bytes, so it should be
a deliberate decision rather than something noticed later.

`send_rgba` and its `SwsContext` are left in place: `run_composited_multi` still
uses them, and this touches the export path only. The YUV targets and their
staging ring are built lazily, so the preview — which renders RGBA to a canvas —
pays nothing.

## What this does not fix

**This does not make the export `sws_scale`-free.** `linux_frames::present` still
converts every decoded source frame to NV12 on the CPU, twice per output frame
(screen and webcam). That conversion is untouched here and has never been
instrumented; it sits inside the 12.4 s residual above. Uploading the decoder's
three planes directly instead of converting to NV12 would remove it, and is a
separate change.

The encode is now the largest remaining stage by a wide margin, and it is still
**software** (`libopenh264`). The readback is also still a full GPU→CPU copy, just
a smaller one — and it still blocks the calling thread on
`Maintain::WaitForSubmissionIndex`. The whole export runs on one thread while the
other cores idle.

Both of the big ones point at the same answer — keep the frame on the GPU and hand
it to a hardware encoder — and #552 covers what stands in the way of that on
Ubuntu 24.04, which is the current LTS. For reference, `h264_vaapi` encodes these
same 3600 frames in 11.2 s on this machine, against 29.5 s for libopenh264.

## Measured on

AMD Ryzen 5 7520U / Radeon 610M (Mendocino), Ubuntu 24.04, Wayland, Mesa RADV.
One machine, one scenario — the stage breakdown should generalise, the exact
percentages will not. The before/after legs were run in a single session so both
are divided by floors measured minutes apart; on this box the VAAPI block has two
sustained clocks and a comparison assembled from two separate runs would be
measuring the clock rather than the change.

The stage numbers above came from temporary counters around each stage, which are
not part of this PR. The end-to-end figures come from the build without them:
re-measured after the counters were removed, this lands at 57.28 s median with a
±0.03 s MAD over three scoring runs, and a cost of 2.42× the machine's hardware
floor against 2.405× for the instrumented build — so the counters were not paying
for themselves in either direction.

<!-- discord-thread-id:1544239307768733697 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved Linux video export performance by moving RGBA-to-YUV conversion to the GPU.
  * Reduced CPU processing during frame export.
* **Video Export**
  * Added efficient YUV420P frame readback and encoding support.
  * Preserved expected color ranges and chroma subsampling for exported video.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->