### PR TITLE
feat(cursor): editable cursor choreography — the editor layer, on the model and compositor halves

### DIFF
--- a/crates/compositor/src/cursor.rs
+++ b/crates/compositor/src/cursor.rs
@@ -50,6 +50,34 @@ fn sample_at(samples: &[(f32, f32, f32)], t: f32) -> Option<(f32, f32)> {
     Some((a.1 + (b.1 - a.1) * f, a.2 + (b.2 - a.2) * f))
 }
 
+/// Sous-intervalles de `[lo, hi]` une fois retranchée l'union de `blockers` : ce qui reste
+/// du span d'une région après que les régions postérieures — qui gagnent le recouvrement —
+/// y ont masqué leurs portions. Un `blockers` vide rend `[(lo, hi)]` ; une région entièrement
+/// recouverte rend une liste vide et ne pose aucun point.
+fn visible_spans(lo: f32, hi: f32, blockers: &[(f32, f32)]) -> Vec<(f32, f32)> {
+    let mut sorted: Vec<(f32, f32)> =
+        blockers.iter().copied().filter(|(b_lo, b_hi)| *b_lo < hi && *b_hi > lo).collect();
+    sorted.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    let mut spans = Vec::new();
+    let mut cursor = lo;
+    for (b_lo, b_hi) in sorted {
+        if b_hi <= cursor {
+            continue; // déjà masqué par un bloqueur précédent
+        }
+        if b_lo > cursor {
+            spans.push((cursor, b_lo));
+        }
+        cursor = b_hi;
+        if cursor >= hi {
+            return spans;
+        }
+    }
+    if cursor < hi {
+        spans.push((cursor, hi));
+    }
+    spans
+}
+
 /// Port de `advanceFollowFocus` (`cursorFollowUtils.ts`) : lissage exponentiel dont le facteur
 /// croît avec la distance à la cible (loin = rattrape vite, près = décélère), corrigé en temps
 /// pour être indépendant de la cadence.
@@ -255,16 +283,27 @@ impl CursorTrack {
         let mut samples: Vec<(f32, f32, f32)> =
             self.samples.iter().filter(|(t, _, _)| covering(*t).is_none()).copied().collect();
 
-        for region in &active {
-            let span = region.end_s - region.start_s;
-            let steps = ((span / STEP_S).round() as usize).max(1);
-            for i in 0..=steps {
-                // Le dernier point est posé sur `end_s` exact plutôt que sur la grille : la
-                // couture avec l'échantillon brut suivant doit être franche, sinon
-                // l'interpolation de `sample_at` traverse un trou et coupe le raccord.
-                let t = if i == steps { region.end_s } else { region.start_s + i as f32 * STEP_S };
-                let (x, y) = sample_region(region, t);
-                samples.push((t, x, y));
+        for (i, region) in active.iter().enumerate() {
+            // La dernière région doit gagner sur TOUT son recouvrement, pas seulement aux
+            // instants échantillonnés : chaque région ne pose donc des points que sur ses
+            // sous-intervalles visibles (son span moins ceux des régions qui la suivent
+            // dans la liste). Ré-échantillonner un span recouvert entier entrelacerait les
+            // grilles des deux régions, et `sample_at` interpolerait d'une courbe à l'autre
+            // entre les points.
+            let blockers: Vec<(f32, f32)> =
+                active[i + 1..].iter().map(|r| (r.start_s, r.end_s)).collect();
+            for (lo, hi) in visible_spans(region.start_s, region.end_s, &blockers) {
+                let span = hi - lo;
+                let steps = ((span / STEP_S).round() as usize).max(1);
+                for k in 0..=steps {
+                    // Le dernier point est posé sur la borne exacte du sous-intervalle plutôt
+                    // que sur la grille : la couture avec ce qui suit (télémétrie brute ou la
+                    // région masquante elle-même) doit être franche, sinon l'interpolation de
+                    // `sample_at` traverse un trou et coupe le raccord.
+                    let t = if k == steps { hi } else { lo + k as f32 * STEP_S };
+                    let (x, y) = sample_region(region, t);
+                    samples.push((t, x, y));
+                }
             }
         }
 
@@ -561,6 +600,39 @@ mod tests {
             detour_track().with_motion(&[region(CursorMotionPreset::Arc), second]);
         let (_, y) = edited.at(2.0).unwrap();
         assert!((y - 0.8).abs() < 1e-3, "la seconde région devrait l'emporter, obtenu {y}");
+    }
+
+    /// …et pas seulement AUX instants échantillonnés : ré-échantillonner chaque région sur
+    /// son span entier entrelace les grilles, et `sample_at` interpolerait d'une courbe à
+    /// l'autre entre deux points. Un temps hors grille des deux côtés doit donc rendre la
+    /// courbe de la région postérieure, au point près.
+    #[test]
+    fn overlap_keeps_the_last_region_between_sample_times() {
+        let mut second = region(CursorMotionPreset::Straight);
+        second.start_s = 1.25;
+        second.end_s = 2.0;
+        second.end = (1.0, 0.8);
+        let edited =
+            detour_track().with_motion(&[region(CursorMotionPreset::Arc), second.clone()]);
+
+        // 1.401 n'est multiple de la grille 240 Hz d'aucune des deux régions (ancrées à
+        // 1.0 et 1.25) : toute coincidence de points est exclue du chemin de `sample_at`.
+        let t = 1.401;
+        let (x, y) = edited.at(t).expect("dans le recouvrement");
+        let (want_x, want_y) = sample_region(&second, t);
+        assert!(
+            (x - want_x).abs() < 1e-3 && (y - want_y).abs() < 1e-3,
+            "la seconde région doit régner sur tout le recouvrement, obtenu ({x}, {y}), sa courbe dit ({want_x}, {want_y})"
+        );
+
+        // Avant le recouvrement, la première région reste seule maîtresse de son tracé.
+        let t = 1.1234;
+        let (x, y) = edited.at(t).expect("avant le recouvrement");
+        let (want_x, want_y) = sample_region(&region(CursorMotionPreset::Arc), t);
+        assert!(
+            (x - want_x).abs() < 1e-3 && (y - want_y).abs() < 1e-3,
+            "la première région doit rester seule avant le recouvrement, obtenu ({x}, {y}), sa courbe dit ({want_x}, {want_y})"
+        );
     }
 
     /// L'édition déplace la trajectoire, pas la chronologie : clics et états gardent leurs

--- a/crates/compositor/src/cursor.rs
+++ b/crates/compositor/src/cursor.rs
@@ -219,6 +219,204 @@ impl CursorTrack {
         // déplace la trajectoire, pas la chronologie de ce que faisait l'utilisateur.
         CursorTrack::new(samples, self.clicks.clone(), self.types.clone())
     }
+
+    /// Piste dont les portions couvertes par une région éditée suivent la géométrie du preset
+    /// au lieu de la télémétrie.
+    ///
+    /// Appliqué UNE fois aux échantillons, comme `smoothed` et pour la même raison : la piste
+    /// reste une pure fonction de `t`, donc la preview et l'export rendent le même tracé, et un
+    /// seek retombe sur l'image de la lecture linéaire.
+    ///
+    /// La courbe est ré-échantillonnée à 240 Hz à l'intérieur des régions, indépendamment de la
+    /// densité de la télémétrie : le tracé est analytique, alors qu'une capture peut n'avoir que
+    /// quelques points sur la durée d'une région — les reprendre tels quels rendrait un arc en
+    /// ligne brisée. Hors régions, les échantillons bruts passent intacts.
+    ///
+    /// Les clics et les états gardent leurs instants (même principe que `smoothed`) : rien ici
+    /// ne retime ce que faisait l'utilisateur, seule la position change.
+    pub fn with_motion(&self, regions: &[CursorMotionRegion]) -> CursorTrack {
+        // `Recorded` est inerte : une région qui ne change rien ne doit pas déclencher le
+        // ré-échantillonnage, sinon elle remplacerait la télémétrie par sa propre relecture.
+        let active: Vec<&CursorMotionRegion> = regions
+            .iter()
+            .filter(|r| r.preset != CursorMotionPreset::Recorded && r.end_s > r.start_s)
+            .collect();
+        if active.is_empty() {
+            return CursorTrack::new(self.samples.clone(), self.clicks.clone(), self.types.clone());
+        }
+
+        // Recouvrement : la DERNIÈRE région gagne, parité `findCursorMotionRegionAtTime` (TS)
+        // qui parcourt la liste à l'envers.
+        let covering = |t: f32| -> Option<&CursorMotionRegion> {
+            active.iter().rev().find(|r| t >= r.start_s && t <= r.end_s).copied()
+        };
+
+        const STEP_S: f32 = 1.0 / 240.0;
+        let mut samples: Vec<(f32, f32, f32)> =
+            self.samples.iter().filter(|(t, _, _)| covering(*t).is_none()).copied().collect();
+
+        for region in &active {
+            let span = region.end_s - region.start_s;
+            let steps = ((span / STEP_S).round() as usize).max(1);
+            for i in 0..=steps {
+                // Le dernier point est posé sur `end_s` exact plutôt que sur la grille : la
+                // couture avec l'échantillon brut suivant doit être franche, sinon
+                // l'interpolation de `sample_at` traverse un trou et coupe le raccord.
+                let t = if i == steps { region.end_s } else { region.start_s + i as f32 * STEP_S };
+                let (x, y) = sample_region(region, t);
+                samples.push((t, x, y));
+            }
+        }
+
+        samples.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+        CursorTrack::new(samples, self.clicks.clone(), self.types.clone())
+    }
+}
+
+/// Forme dessinée entre les deux ancres d'une région. `Recorded` est inerte : la région
+/// existe pour porter une sélection dans l'éditeur sans toucher au tracé.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CursorMotionPreset {
+    Recorded,
+    Straight,
+    Arc,
+    Wave,
+    Loop,
+    Overshoot,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CursorMotionEasing {
+    Linear,
+    EaseInOut,
+    EaseIn,
+    EaseOut,
+}
+
+/// Une portion de trajectoire éditée, qui remplace la télémétrie entre `start_s` et `end_s`.
+///
+/// Les ancres arrivent RÉSOLUES (l'éditeur possède la détection des rests, clics et coupes
+/// manuelles) : ce module ne fait que de la géométrie, donc la même liste redonne toujours
+/// le même tracé. `control` est un point absolu, pas un décalage — le sampler en prend
+/// l'écart au milieu de [start, end], si bien qu'un point de contrôle laissé au milieu est
+/// neutre pour tous les presets.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CursorMotionRegion {
+    pub start_s: f32,
+    pub end_s: f32,
+    pub start: (f32, f32),
+    pub end: (f32, f32),
+    pub control: (f32, f32),
+    pub preset: CursorMotionPreset,
+    pub cycles: u32,
+    pub speed: f32,
+    pub easing: CursorMotionEasing,
+}
+
+fn lerp(a: f32, b: f32, p: f32) -> f32 {
+    a + (b - a) * p
+}
+
+/// Parité `clampCursorMotionCycles` (TS) : entier, borné 1..6.
+fn clamp_cycles(cycles: u32) -> f32 {
+    cycles.clamp(1, 6) as f32
+}
+
+/// Parité `clampCursorMotionSpeed` (TS) : borné 1..4 PUIS arrondi au dixième. L'arrondi
+/// n'est pas cosmétique — il entre dans l'exposant ci-dessous, donc l'omettre ferait
+/// diverger le tracé de ce que l'éditeur a affiché.
+fn clamp_speed(speed: f32) -> f32 {
+    let v = if speed.is_finite() { speed } else { 1.0 };
+    (v.clamp(1.0, 4.0) * 10.0).round() / 10.0
+}
+
+/// Parité `applyCursorMotionSpeed` (TS) : `1 - (1-t)^vitesse`. Reprofile la progression,
+/// ne retime pas la région — et démarre au premier instant, sans palier gelé en tête (un
+/// palier avait rendu invisibles la plupart des courts déplacements à 2x).
+fn apply_speed(progress: f32, speed: f32) -> f32 {
+    let t = progress.clamp(0.0, 1.0);
+    (1.0 - (1.0 - t).powf(clamp_speed(speed))).clamp(0.0, 1.0)
+}
+
+/// Parité `easeProgress` (TS).
+fn ease_progress(progress: f32, easing: CursorMotionEasing) -> f32 {
+    let t = progress.clamp(0.0, 1.0);
+    match easing {
+        CursorMotionEasing::EaseIn => t * t * t,
+        CursorMotionEasing::EaseOut => 1.0 - (1.0 - t).powi(3),
+        CursorMotionEasing::EaseInOut => {
+            if t < 0.5 {
+                4.0 * t * t * t
+            } else {
+                1.0 - (-2.0 * t + 2.0).powi(3) / 2.0
+            }
+        }
+        CursorMotionEasing::Linear => t,
+    }
+}
+
+/// Parité `easeOutBack` (TS) : dépasse la cible puis revient.
+fn ease_out_back(progress: f32) -> f32 {
+    const C1: f32 = 1.70158;
+    const C3: f32 = C1 + 1.0;
+    let t = progress.clamp(0.0, 1.0) - 1.0;
+    1.0 + C3 * t.powi(3) + C1 * t.powi(2)
+}
+
+/// Position dans une région à l'instant `t` — port direct de `sampleCursorMotionRegion`
+/// (TS). Fonction pure de `t` : c'est ce qui autorise à l'appliquer une fois aux
+/// échantillons plutôt que par frame, donc à faire coïncider preview et export.
+fn sample_region(region: &CursorMotionRegion, t: f32) -> (f32, f32) {
+    let duration = (region.end_s - region.start_s).max(0.001);
+    let raw = ((t - region.start_s) / duration).clamp(0.0, 1.0);
+    if raw <= 0.0 {
+        return region.start;
+    }
+    if raw >= 1.0 {
+        return region.end;
+    }
+    let motion = apply_speed(raw, region.speed);
+    if motion == 0.0 {
+        return region.start;
+    }
+    let progress = ease_progress(motion, region.easing);
+
+    let mid = ((region.start.0 + region.end.0) / 2.0, (region.start.1 + region.end.1) / 2.0);
+    let offset = (region.control.0 - mid.0, region.control.1 - mid.1);
+    let envelope = (std::f32::consts::PI * motion).sin();
+
+    if region.preset == CursorMotionPreset::Overshoot {
+        let p = ease_out_back(progress);
+        return (
+            lerp(region.start.0, region.end.0, p) + offset.0 * envelope * 0.35,
+            lerp(region.start.1, region.end.1, p) + offset.1 * envelope * 0.35,
+        );
+    }
+
+    let base = (
+        lerp(region.start.0, region.end.0, progress),
+        lerp(region.start.1, region.end.1, progress),
+    );
+    let cycles = clamp_cycles(region.cycles);
+
+    match region.preset {
+        CursorMotionPreset::Arc => (base.0 + offset.0 * envelope, base.1 + offset.1 * envelope),
+        CursorMotionPreset::Wave => {
+            let wave = (std::f32::consts::PI * 2.0 * cycles * motion).sin() * envelope;
+            (base.0 + offset.0 * wave, base.1 + offset.1 * wave)
+        }
+        CursorMotionPreset::Loop => {
+            let phase = std::f32::consts::PI * 2.0 * cycles * motion;
+            let tangent = phase.sin() * envelope;
+            let normal = (1.0 - phase.cos()) * 0.5 * envelope;
+            (
+                base.0 + offset.0 * tangent - offset.1 * normal,
+                base.1 + offset.1 * tangent + offset.0 * normal,
+            )
+        }
+        // `Straight` suit la droite ; `Recorded` n'arrive jamais ici (filtré en amont).
+        _ => base,
+    }
 }
 
 /// Ressort-amortisseur, intégration semi-implicite (symplectique) d'Euler — stable pour ces
@@ -275,6 +473,105 @@ mod tests {
         assert_eq!(track.type_at(0.9), Some("arrow"), "tient jusqu'à la suivante");
         assert_eq!(track.type_at(1.2), Some("text"));
         assert_eq!(track.type_at(99.0), Some("pointer"), "la dernière tient jusqu'à la fin");
+    }
+
+    fn region(preset: CursorMotionPreset) -> CursorMotionRegion {
+        CursorMotionRegion {
+            start_s: 1.0,
+            end_s: 2.0,
+            start: (0.0, 0.0),
+            end: (1.0, 0.0),
+            // Écarté du milieu (0.5, 0.0) : de quoi rendre les presets courbes visibles.
+            control: (0.5, 0.4),
+            preset,
+            cycles: 1,
+            speed: 1.0,
+            easing: CursorMotionEasing::Linear,
+        }
+    }
+
+    /// Une piste qui fait un détour par le haut entre t=1 et t=2.
+    fn detour_track() -> CursorTrack {
+        CursorTrack::new(
+            vec![
+                (0.0, 0.0, 0.0),
+                (1.0, 0.0, 0.0),
+                (1.5, 0.5, -0.9), // le détour que l'édition doit effacer
+                (2.0, 1.0, 0.0),
+                (3.0, 1.0, 0.0),
+            ],
+            vec![1.5],
+            vec![(0.0, "arrow".into())],
+        )
+    }
+
+    /// `Straight` remplace la trajectoire enregistrée par la droite entre les deux ancres :
+    /// au milieu de la région on doit être sur la corde, pas sur le détour capturé.
+    #[test]
+    fn straight_region_replaces_the_recorded_detour() {
+        let edited = detour_track().with_motion(&[region(CursorMotionPreset::Straight)]);
+        let (x, y) = edited.at(1.5).expect("position au milieu de la région");
+        assert!((x - 0.5).abs() < 0.01, "x devrait être à mi-corde, obtenu {x}");
+        assert!(y.abs() < 0.01, "le détour vertical devrait avoir disparu, obtenu {y}");
+    }
+
+    /// `Recorded` est inerte — c'est le préréglage par défaut, et il ne doit surtout pas
+    /// ré-échantillonner la piste : le tracé capturé passe intact.
+    #[test]
+    fn recorded_region_leaves_the_track_untouched() {
+        let raw = detour_track();
+        let edited = raw.with_motion(&[region(CursorMotionPreset::Recorded)]);
+        assert_eq!(edited.sample_count(), raw.sample_count());
+        assert_eq!(edited.at(1.5), raw.at(1.5), "le détour doit survivre");
+    }
+
+    /// Les bornes sont exactes : une région ne doit pas décaler la position aux instants où
+    /// elle se raccorde au reste de la piste, sinon la couture saute à l'image près.
+    #[test]
+    fn region_endpoints_land_exactly_on_their_anchors() {
+        let edited = detour_track().with_motion(&[region(CursorMotionPreset::Arc)]);
+        let (sx, sy) = edited.at(1.0).unwrap();
+        let (ex, ey) = edited.at(2.0).unwrap();
+        assert!(sx.abs() < 1e-4 && sy.abs() < 1e-4, "début ({sx}, {sy})");
+        assert!((ex - 1.0).abs() < 1e-4 && ey.abs() < 1e-4, "fin ({ex}, {ey})");
+    }
+
+    /// Hors région, la télémétrie brute n'est pas touchée.
+    #[test]
+    fn samples_outside_the_region_survive() {
+        let edited = detour_track().with_motion(&[region(CursorMotionPreset::Straight)]);
+        assert_eq!(edited.at(0.0), Some((0.0, 0.0)));
+        assert_eq!(edited.at(3.0), Some((1.0, 0.0)));
+    }
+
+    /// `Arc` s'écarte de la corde du côté du point de contrôle, au maximum en milieu de course.
+    #[test]
+    fn arc_bends_toward_its_control_point() {
+        let edited = detour_track().with_motion(&[region(CursorMotionPreset::Arc)]);
+        let (_, y) = edited.at(1.5).unwrap();
+        assert!(y > 0.3, "l'arc devrait culminer vers le point de contrôle, obtenu {y}");
+    }
+
+    /// Recouvrement : la dernière région gagne, comme `findCursorMotionRegionAtTime` en TS.
+    #[test]
+    fn overlapping_regions_resolve_to_the_last_one() {
+        let mut second = region(CursorMotionPreset::Straight);
+        second.end = (1.0, 0.8); // destination distincte, pour trancher sans ambiguïté
+        let edited =
+            detour_track().with_motion(&[region(CursorMotionPreset::Arc), second]);
+        let (_, y) = edited.at(2.0).unwrap();
+        assert!((y - 0.8).abs() < 1e-3, "la seconde région devrait l'emporter, obtenu {y}");
+    }
+
+    /// L'édition déplace la trajectoire, pas la chronologie : clics et états gardent leurs
+    /// instants, exactement comme sous `smoothed`.
+    #[test]
+    fn motion_preserves_clicks_and_types() {
+        let edited = detour_track().with_motion(&[region(CursorMotionPreset::Loop)]);
+        assert_eq!(edited.type_at(1.5), Some("arrow"));
+        // Échantillonné DANS la fenêtre d'animation, pas sur son bord : à l'instant même du
+        // clic la pression commence tout juste et vaut encore 1.0.
+        assert!(edited.bounce(1.55) < 1.0, "le clic à 1.5 s doit toujours produire son bounce");
     }
 
     /// Le lissage déplace la trajectoire, pas la chronologie : les états doivent survivre

--- a/crates/compositor/src/live.rs
+++ b/crates/compositor/src/live.rs
@@ -1532,9 +1532,22 @@ unsafe fn render_thread(
         // les lire au-dessus les prendrait à l'état du tour précédent — une trajectoire
         // éditée n'apparaîtrait qu'à la frame suivante, ou jamais si rien d'autre ne bouge.
         if let Some(raw) = &raw_cursor {
+            // Régions du clip ACTIF seulement : chacune appartient au clip dont le temps
+            // source la porte (`clipIndex`), et la piste rechargée est celle de ce clip.
+            // Sans propriétaire (`clipIndex` absent, scènes d'avant le champ) une région
+            // s'applique à toutes les pistes — le comportement historique. Le filtre lit
+            // `active_clip_index`, rafraîchi par les blocs set_active_clip et scène
+            // ci-dessus : placé avant, il prendrait le clip du tour précédent.
             let motion: Vec<crate::cursor::CursorMotionRegion> = full_scene
                 .as_ref()
-                .map(|s| s.cursor.motion.iter().map(Into::into).collect())
+                .map(|s| {
+                    s.cursor
+                        .motion
+                        .iter()
+                        .filter(|r| r.clip_index.map(|i| i == active_clip_index).unwrap_or(true))
+                        .map(Into::into)
+                        .collect()
+                })
                 .unwrap_or_default();
             if ip.cursor_smoothing != last_smoothing || motion != last_motion {
                 comp.set_cursor(raw.with_motion(&motion).smoothed(ip.cursor_smoothing));

--- a/crates/compositor/src/live.rs
+++ b/crates/compositor/src/live.rs
@@ -1228,6 +1228,9 @@ unsafe fn render_thread(
     let mut last_preview_size: (u32, u32) = (0, 0);
     let mut last_ip: Option<InspectorParams> = None;
     let mut last_smoothing: f32 = -1.0; // force la 1re application (0.0 est une valeur valide)
+    // Dernières régions appliquées. La liste vide est l'état de repos ET une valeur valide :
+    // c'est `last_smoothing = -1.0` qui garantit la première application, pas ce champ.
+    let mut last_motion: Vec<crate::cursor::CursorMotionRegion> = Vec::new();
     // La vue live est TOUJOURS pilotée par la scène de l'app. Tant qu'aucune scène n'a été
     // appliquée, on refuse de jouer le layout fixture (POC) : un fallback fixture ne ferait que
     // MASQUER un scene-push cassé. On attend la scène avant de produire le 1er frame.
@@ -1364,14 +1367,6 @@ unsafe fn render_thread(
             cursor_motion_blur: ip.cursor_motion_blur,
             has_webcam: has_real_webcam,
         });
-        // Lissage ressort-amortisseur : re-génère la piste (240 Hz) uniquement quand la valeur
-        // change (pas à chaque frame — le resample+ressort parcourt tout l'enregistrement).
-        if let Some(raw) = &raw_cursor {
-            if ip.cursor_smoothing != last_smoothing {
-                comp.set_cursor(raw.smoothed(ip.cursor_smoothing));
-                last_smoothing = ip.cursor_smoothing;
-            }
-        }
         // un changement de param doit se voir même en pause (édition live des sliders) :
         // on recompose la frame courante dans la branche pause ci-dessous.
         let ip_changed = last_ip != Some(ip);
@@ -1399,6 +1394,25 @@ unsafe fn render_thread(
                 scene_for_clip(&base_scene, active_clip_index)
             });
             comp.set_scene(scene);
+        }
+
+        // Piste curseur : trajectoire éditée puis lissage ressort-amortisseur. Re-générée
+        // uniquement quand l'un des deux change — le resample 240 Hz parcourt tout
+        // l'enregistrement, c'est trop cher par frame.
+        //
+        // Placé APRÈS le bloc de scène, pas avant : les régions viennent de `full_scene`, et
+        // les lire au-dessus les prendrait à l'état du tour précédent — une trajectoire
+        // éditée n'apparaîtrait qu'à la frame suivante, ou jamais si rien d'autre ne bouge.
+        if let Some(raw) = &raw_cursor {
+            let motion: Vec<crate::cursor::CursorMotionRegion> = full_scene
+                .as_ref()
+                .map(|s| s.cursor.motion.iter().map(Into::into).collect())
+                .unwrap_or_default();
+            if ip.cursor_smoothing != last_smoothing || motion != last_motion {
+                comp.set_cursor(raw.with_motion(&motion).smoothed(ip.cursor_smoothing));
+                last_smoothing = ip.cursor_smoothing;
+                last_motion = motion;
+            }
         }
 
         // résolution cible du preview (le canvas Electron) → force le recadrage des

--- a/crates/compositor/src/scene.rs
+++ b/crates/compositor/src/scene.rs
@@ -405,6 +405,11 @@ pub struct ScenePoint {
 pub struct SceneCursorMotionRegion {
     #[allow(dead_code)]
     pub id: String,
+    /// Index du clip dont le temps SOURCE porte cette région (voir `SceneZoomRegion`).
+    /// Absent pour les scènes d'avant le champ — la région s'applique alors à toutes les
+    /// pistes curseur, le comportement historique.
+    #[serde(default)]
+    pub clip_index: Option<usize>,
     pub start_sec: f32,
     pub end_sec: f32,
     pub start_point: ScenePoint,
@@ -886,6 +891,7 @@ mod annotation_tests {
             "clickBounce": 1.0, "clipToBounds": false, "theme": "system",
             "motion": [{
                 "id": "r1",
+                "clipIndex": 2,
                 "startSec": 1.0, "endSec": 2.5,
                 "startPoint": { "cx": 0.1, "cy": 0.2 },
                 "endPoint": { "cx": 0.8, "cy": 0.4 },
@@ -902,6 +908,7 @@ mod annotation_tests {
         assert_eq!(r.start_sec, 1.0);
         assert_eq!(r.control_point.cy, 0.9);
         assert_eq!(r.cycles, 3);
+        assert_eq!(r.clip_index, Some(2), "le propriétaire de la région doit traverser le pont");
     }
 
     /// Une scène d'avant ce champ doit rester lisible : `motion` absent → aucune région,
@@ -914,5 +921,23 @@ mod annotation_tests {
         }"#;
         let cursor: SceneCursor = serde_json::from_str(json).expect("scène héritée");
         assert!(cursor.motion.is_empty());
+    }
+
+    /// Une région d'avant `clipIndex` reste lisible et sans propriétaire : elle s'applique
+    /// à toutes les pistes, le comportement historique — pas un échec de parse.
+    #[test]
+    fn a_cursor_motion_region_without_clip_index_parses_unowned() {
+        let json = r#"{
+            "show": true, "size": 1.0, "smoothing": 0.0, "motionBlur": 0.0,
+            "clickBounce": 1.0, "clipToBounds": false, "theme": "system",
+            "motion": [{
+                "id": "legacy", "startSec": 0.0, "endSec": 1.0,
+                "startPoint": { "cx": 0.0, "cy": 0.0 }, "endPoint": { "cx": 1.0, "cy": 1.0 },
+                "controlPoint": { "cx": 0.5, "cy": 0.5 },
+                "preset": "straight", "cycles": 1, "speed": 1.0, "easing": "linear"
+            }]
+        }"#;
+        let cursor: SceneCursor = serde_json::from_str(json).expect("région héritée");
+        assert_eq!(cursor.motion[0].clip_index, None);
     }
 }

--- a/crates/compositor/src/scene.rs
+++ b/crates/compositor/src/scene.rs
@@ -336,6 +336,87 @@ pub struct SceneCursor {
     /// `#[serde(default)]` : champ ajouté après coup, absent des JSON de test existants.
     #[serde(default)]
     pub cursor_sprites: std::collections::HashMap<String, SceneCursorSprite>,
+    /// Portions de trajectoire éditées, dans l'ordre de la timeline. Absent ou vide → la
+    /// télémétrie enregistrée joue telle quelle, ce que produit tout projet sans l'éditeur
+    /// de choréographie. `#[serde(default)]` pour cette raison : les scènes existantes ne
+    /// portent pas ce champ et doivent rester lisibles.
+    #[serde(default)]
+    pub motion: Vec<SceneCursorMotionRegion>,
+}
+
+/// Point normalisé dans le cadre screen.
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub struct ScenePoint {
+    pub cx: f32,
+    pub cy: f32,
+}
+
+/// Une région de trajectoire éditée. Miroir de `SceneCursorMotionRegion` (TS,
+/// `src/native/sceneDescription.ts`) — les ancres arrivent résolues, ce module ne fait que
+/// de la géométrie.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SceneCursorMotionRegion {
+    #[allow(dead_code)]
+    pub id: String,
+    pub start_sec: f32,
+    pub end_sec: f32,
+    pub start_point: ScenePoint,
+    pub end_point: ScenePoint,
+    pub control_point: ScenePoint,
+    pub preset: SceneCursorMotionPreset,
+    pub cycles: u32,
+    pub speed: f32,
+    pub easing: SceneCursorMotionEasing,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SceneCursorMotionPreset {
+    Recorded,
+    Straight,
+    Arc,
+    Wave,
+    Loop,
+    Overshoot,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SceneCursorMotionEasing {
+    Linear,
+    EaseInOut,
+    EaseIn,
+    EaseOut,
+}
+
+impl From<&SceneCursorMotionRegion> for crate::cursor::CursorMotionRegion {
+    fn from(r: &SceneCursorMotionRegion) -> Self {
+        use crate::cursor::{CursorMotionEasing as E, CursorMotionPreset as P};
+        crate::cursor::CursorMotionRegion {
+            start_s: r.start_sec,
+            end_s: r.end_sec,
+            start: (r.start_point.cx, r.start_point.cy),
+            end: (r.end_point.cx, r.end_point.cy),
+            control: (r.control_point.cx, r.control_point.cy),
+            preset: match r.preset {
+                SceneCursorMotionPreset::Recorded => P::Recorded,
+                SceneCursorMotionPreset::Straight => P::Straight,
+                SceneCursorMotionPreset::Arc => P::Arc,
+                SceneCursorMotionPreset::Wave => P::Wave,
+                SceneCursorMotionPreset::Loop => P::Loop,
+                SceneCursorMotionPreset::Overshoot => P::Overshoot,
+            },
+            cycles: r.cycles,
+            speed: r.speed,
+            easing: match r.easing {
+                SceneCursorMotionEasing::Linear => E::Linear,
+                SceneCursorMotionEasing::EaseInOut => E::EaseInOut,
+                SceneCursorMotionEasing::EaseIn => E::EaseIn,
+                SceneCursorMotionEasing::EaseOut => E::EaseOut,
+            },
+        }
+    }
 }
 
 /// Un sprite de curseur : image + point de pivot.
@@ -610,5 +691,46 @@ mod annotation_tests {
             filtered.annotations.iter().map(|a| a.id.as_str()).collect::<Vec<_>>(),
             vec!["keep"]
         );
+    }
+
+    /// Le contrat JS→Rust, dans les deux sens où il dérive en silence : le camelCase des
+    /// champs et l'orthographe des variantes. `easing` est en kebab-case (`ease-in-out`)
+    /// alors que `preset` est en minuscules collées — deux conventions dans le même objet,
+    /// donc exactement le genre de détail qu'un test doit tenir.
+    #[test]
+    fn a_cursor_motion_region_parses_from_the_typescript_shape() {
+        let json = r#"{
+            "show": true, "size": 1.0, "smoothing": 0.5, "motionBlur": 0.0,
+            "clickBounce": 1.0, "clipToBounds": false, "theme": "system",
+            "motion": [{
+                "id": "r1",
+                "startSec": 1.0, "endSec": 2.5,
+                "startPoint": { "cx": 0.1, "cy": 0.2 },
+                "endPoint": { "cx": 0.8, "cy": 0.4 },
+                "controlPoint": { "cx": 0.5, "cy": 0.9 },
+                "preset": "overshoot", "cycles": 3, "speed": 2.5,
+                "easing": "ease-in-out"
+            }]
+        }"#;
+        let cursor: SceneCursor = serde_json::from_str(json).expect("SceneCursor doit parser");
+        assert_eq!(cursor.motion.len(), 1);
+        let r = &cursor.motion[0];
+        assert_eq!(r.preset, SceneCursorMotionPreset::Overshoot);
+        assert_eq!(r.easing, SceneCursorMotionEasing::EaseInOut);
+        assert_eq!(r.start_sec, 1.0);
+        assert_eq!(r.control_point.cy, 0.9);
+        assert_eq!(r.cycles, 3);
+    }
+
+    /// Une scène d'avant ce champ doit rester lisible : `motion` absent → aucune région,
+    /// pas une erreur de parse. C'est le cas de tout projet existant.
+    #[test]
+    fn a_cursor_without_motion_still_parses() {
+        let json = r#"{
+            "show": true, "size": 1.0, "smoothing": 0.0, "motionBlur": 0.0,
+            "clickBounce": 1.0, "clipToBounds": false, "theme": "system"
+        }"#;
+        let cursor: SceneCursor = serde_json::from_str(json).expect("scène héritée");
+        assert!(cursor.motion.is_empty());
     }
 }

--- a/crates/compositor/src/timeline_walk.rs
+++ b/crates/compositor/src/timeline_walk.rs
@@ -159,12 +159,14 @@ pub(crate) unsafe fn walk_composited_timeline(
 ) -> Result<u64> {
     let cursor_enabled = scene.as_ref().map(|s| s.cursor.show).unwrap_or(false);
     let cursor_smoothing = scene.as_ref().map(|s| s.cursor.smoothing).unwrap_or(0.0);
-    // Régions éditées converties une fois : elles sont les mêmes pour tous les clips, et la
-    // conversion n'a pas à être refaite à chaque piste chargée.
-    let cursor_motion: Vec<crate::cursor::CursorMotionRegion> =
-        scene.as_ref().map(|s| s.cursor.motion.iter().map(Into::into).collect()).unwrap_or_default();
-    let mut cursor_tracks: HashMap<String, CursorTrack> = HashMap::new();
-    let mut cursor_active_path: Option<String> = None;
+    // Régions éditées gardées dans leur forme de scène : chacune appartient au clip dont le
+    // temps source la porte (`clipIndex`), donc la conversion vers la géométrie du sampler
+    // se fait PAR CLIP dans la boucle — une même recording coupée en deux clips ne partage
+    // pas ses régions, et la piste éditée qui en découle non plus.
+    let scene_cursor_motion: Vec<crate::scene::SceneCursorMotionRegion> =
+        scene.as_ref().map(|s| s.cursor.motion.clone()).unwrap_or_default();
+    let mut cursor_tracks: HashMap<(usize, String), CursorTrack> = HashMap::new();
+    let mut cursor_active: Option<(usize, String)> = None;
 
     let mut frames: u64 = 0;
 
@@ -284,7 +286,18 @@ pub(crate) unsafe fn walk_composited_timeline(
         }
 
         if cursor_enabled {
-            if !cursor_tracks.contains_key(&clip.screen) {
+            // La clé du cache est (clip, fichier), pas le fichier seul : deux coupes d'une
+            // même recording peuvent porter des régions différentes, et leur piste éditée
+            // respective ne doit pas se confondre.
+            let cursor_key = (clip_index, clip.screen.clone());
+            if !cursor_tracks.contains_key(&cursor_key) {
+                let cursor_motion: Vec<crate::cursor::CursorMotionRegion> = scene_cursor_motion
+                    .iter()
+                    // Sans propriétaire (`clipIndex` absent, scènes d'avant le champ) la
+                    // région s'applique à toutes les pistes — le comportement historique.
+                    .filter(|r| r.clip_index.map(|i| i == clip_index).unwrap_or(true))
+                    .map(Into::into)
+                    .collect();
                 let path = format!("{}.cursor.json", clip.screen);
                 if let Ok(raw) = CursorTrack::load(&path, 0.0, 24.0 * 3600.0) {
                     // Trajectoire éditée d'ABORD, lissage ensuite : le preset définit le tracé,
@@ -292,19 +305,19 @@ pub(crate) unsafe fn walk_composited_timeline(
                     // l'autre ordre les portions éditées resteraient nettes au milieu d'une
                     // piste amortie, et le slider n'aurait plus d'effet sur elles.
                     let edited = raw.with_motion(&cursor_motion);
-                    cursor_tracks.insert(clip.screen.clone(), edited.smoothed(cursor_smoothing));
+                    cursor_tracks.insert((clip_index, clip.screen.clone()), edited.smoothed(cursor_smoothing));
                 }
                 // absente/illisible → pas d'entrée : ce clip s'exporte sans curseur (visible,
                 // pas masqué en un curseur fantôme d'un autre clip).
             }
-            if cursor_active_path.as_deref() != Some(clip.screen.as_str()) {
-                if let Some(track) = cursor_tracks.get(&clip.screen) {
+            if cursor_active.as_ref() != Some(&cursor_key) {
+                if let Some(track) = cursor_tracks.get(&cursor_key) {
                     comp.set_cursor(track.clone());
-                    cursor_active_path = Some(clip.screen.clone());
+                    cursor_active = Some(cursor_key);
                 } else {
                     comp.clear_cursor();
                     comp.set_cursor_time(None);
-                    cursor_active_path = None;
+                    cursor_active = None;
                 }
             }
         }
@@ -327,7 +340,7 @@ pub(crate) unsafe fn walk_composited_timeline(
                 }
 
                 comp.set_timeline_time(Some(target_source_time as f32));
-                if cursor_enabled && cursor_active_path.is_some() {
+                if cursor_enabled && cursor_active.is_some() {
                     comp.set_cursor_time(Some(target_source_time as f32));
                 }
                 comp.compose_frame(sf, wf, frames as f32, cfg)?;

--- a/crates/compositor/src/timeline_walk.rs
+++ b/crates/compositor/src/timeline_walk.rs
@@ -73,6 +73,10 @@ pub(crate) unsafe fn walk_composited_timeline(
 ) -> Result<u64> {
     let cursor_enabled = scene.as_ref().map(|s| s.cursor.show).unwrap_or(false);
     let cursor_smoothing = scene.as_ref().map(|s| s.cursor.smoothing).unwrap_or(0.0);
+    // Régions éditées converties une fois : elles sont les mêmes pour tous les clips, et la
+    // conversion n'a pas à être refaite à chaque piste chargée.
+    let cursor_motion: Vec<crate::cursor::CursorMotionRegion> =
+        scene.as_ref().map(|s| s.cursor.motion.iter().map(Into::into).collect()).unwrap_or_default();
     let mut cursor_tracks: HashMap<String, CursorTrack> = HashMap::new();
     let mut cursor_active_path: Option<String> = None;
 
@@ -161,7 +165,12 @@ pub(crate) unsafe fn walk_composited_timeline(
             if !cursor_tracks.contains_key(&clip.screen) {
                 let path = format!("{}.cursor.json", clip.screen);
                 if let Ok(raw) = CursorTrack::load(&path, 0.0, 24.0 * 3600.0) {
-                    cursor_tracks.insert(clip.screen.clone(), raw.smoothed(cursor_smoothing));
+                    // Trajectoire éditée d'ABORD, lissage ensuite : le preset définit le tracé,
+                    // le lissage est un filtre de rendu qui s'applique à celui qu'on a. Dans
+                    // l'autre ordre les portions éditées resteraient nettes au milieu d'une
+                    // piste amortie, et le slider n'aurait plus d'effet sur elles.
+                    let edited = raw.with_motion(&cursor_motion);
+                    cursor_tracks.insert(clip.screen.clone(), edited.smoothed(cursor_smoothing));
                 }
                 // absente/illisible → pas d'entrée : ce clip s'exporte sans curseur (visible,
                 // pas masqué en un curseur fantôme d'un autre clip).

--- a/src/components/ai-edition/CursorMotionPathOverlay.tsx
+++ b/src/components/ai-edition/CursorMotionPathOverlay.tsx
@@ -14,7 +14,7 @@
 // overlay stretches with the stage, and every stroke carries
 // `vector-effect="non-scaling-stroke"` so that stretch never thickens a line.
 
-import type { PointerEvent as ReactPointerEvent } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
 import { useCallback, useMemo, useRef } from "react";
 import type { AxcutCursorMotionRegion } from "@/lib/ai-edition/schema";
 import { toModelCursorMotionRegion } from "@/lib/ai-edition/timeline/cursorMotionRegions";
@@ -159,6 +159,46 @@ export function CursorMotionPathOverlay({
 		onControlPointCommit?.();
 	}, [onControlPointCommit]);
 
+	// The handle is focusable, so it must also be movable from the keyboard: arrows
+	// nudge both coordinates (Shift = coarse step), each press landing as one committed
+	// edit — the drag commits once on release, a keypress is its own release.
+	const onKeyDown = useCallback(
+		(e: ReactKeyboardEvent) => {
+			const step = e.shiftKey ? 0.1 : 0.01;
+			let dx = 0;
+			let dy = 0;
+			switch (e.key) {
+				case "ArrowLeft":
+					dx = -step;
+					break;
+				case "ArrowRight":
+					dx = step;
+					break;
+				case "ArrowUp":
+					dy = -step;
+					break;
+				case "ArrowDown":
+					dy = step;
+					break;
+				default:
+					return;
+			}
+			e.preventDefault();
+			onControlPointChange(region.id, {
+				cx: clamp01(region.controlPoint.cx + dx),
+				cy: clamp01(region.controlPoint.cy + dy),
+			});
+			onControlPointCommit?.();
+		},
+		[
+			onControlPointChange,
+			onControlPointCommit,
+			region.controlPoint.cx,
+			region.controlPoint.cy,
+			region.id,
+		],
+	);
+
 	const controlX = region.controlPoint.cx * 100;
 	const controlY = region.controlPoint.cy * 100;
 	const shapeable = region.segmentKind === "move" && region.preset !== "recorded";
@@ -245,8 +285,12 @@ export function CursorMotionPathOverlay({
 					tabIndex={0}
 					aria-label="Cursor path control point"
 					aria-valuenow={Math.round(region.controlPoint.cx * 100)}
+					// The value is two-dimensional; `aria-valuenow` alone would announce
+					// only the horizontal half of where the handle sits.
+					aria-valuetext={`x ${Math.round(region.controlPoint.cx * 100)}%, y ${Math.round(region.controlPoint.cy * 100)}%`}
 					aria-valuemin={0}
 					aria-valuemax={100}
+					onKeyDown={onKeyDown}
 					onPointerDown={onPointerDown}
 					onPointerMove={onPointerMove}
 					onPointerUp={endDrag}

--- a/src/components/ai-edition/CursorMotionPathOverlay.tsx
+++ b/src/components/ai-edition/CursorMotionPathOverlay.tsx
@@ -1,0 +1,274 @@
+// The edited cursor path drawn over the preview, with the one handle that shapes
+// it. Sibling of `ZoomFocusOverlay` and built the same way — a plain CSS/SVG layer
+// over the screen stage, not a Pixi one; #116's version was built on Pixi, which
+// `main` dropped when the preview moved to the native compositor.
+//
+// Two paths are drawn, and the pair is the point: the recorded trajectory says
+// where the cursor actually went, the edited one says where it will go. A single
+// path would leave "is this better than what I recorded" unanswerable without
+// scrubbing back and forth.
+//
+// Coordinates are normalised (0..1) against the SCREEN RECT, which is what the
+// motion model stores and what the compositor samples, so nothing here converts
+// between spaces. The viewBox is 0..100 with `preserveAspectRatio="none"`: the
+// overlay stretches with the stage, and every stroke carries
+// `vector-effect="non-scaling-stroke"` so that stretch never thickens a line.
+
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { useCallback, useMemo, useRef } from "react";
+import type { AxcutCursorMotionRegion } from "@/lib/ai-edition/schema";
+import { toModelCursorMotionRegion } from "@/lib/ai-edition/timeline/cursorMotionRegions";
+import type { CursorMotionPoint } from "@/lib/cursor/cursorMotion";
+import { sampleCursorMotionRegion } from "@/lib/cursor/cursorMotion";
+import { clamp01 } from "@/utils/math";
+
+/** Enough segments that an arc reads as a curve at any stage size, few enough that
+ *  re-sampling on every drag frame stays free. The compositor re-samples the same
+ *  curve at 240 Hz; this is only what the eye needs. */
+const PATH_STEPS = 64;
+
+interface CursorMotionPathOverlayProps {
+	region: AxcutCursorMotionRegion;
+	/** Recorded cursor positions for the owning asset, in SOURCE ms. Only the ones
+	 *  inside the region's span are drawn. Absent when the recording carries no
+	 *  telemetry, which just means the comparison line is absent.
+	 *
+	 *  Nullable, not just optional: `useCursorTelemetry` declares an array but hands
+	 *  through whatever the bridge returns, and a bridge with no cursor endpoint —
+	 *  the browser-mode shim, a platform without the sampler helper — returns null.
+	 *  It reached here as a crash on `.filter`, so the null is handled where it
+	 *  arrives rather than assumed away. */
+	telemetry?: readonly { timeMs: number; cx: number; cy: number }[] | null;
+	onControlPointChange: (id: string, point: CursorMotionPoint) => void;
+	onControlPointCommit?: () => void;
+}
+
+function toPolyline(points: readonly CursorMotionPoint[]): string {
+	return points.map((p) => `${(p.cx * 100).toFixed(3)},${(p.cy * 100).toFixed(3)}`).join(" ");
+}
+
+function AnchorMarker({
+	point,
+	kind,
+}: {
+	point: CursorMotionPoint;
+	kind: AxcutCursorMotionRegion["startAnchor"];
+}) {
+	const x = point.cx * 100;
+	const y = point.cy * 100;
+	// A rest is a square, a click is a ringed dot, a manual cut is a plain dot.
+	// Three shapes rather than three colours: the anchors sit on footage, and a
+	// colour-only distinction disappears over the wrong frame.
+	if (kind === "rest") {
+		return (
+			<rect
+				x={x}
+				y={y}
+				width={10}
+				height={10}
+				rx={2}
+				transform={`translate(-5,-5)`}
+				fill="#f59e0b"
+				stroke="#ffffff"
+				strokeWidth={2}
+				vectorEffect="non-scaling-stroke"
+			/>
+		);
+	}
+	return (
+		<>
+			<circle
+				cx={x}
+				cy={y}
+				r={kind === "click" ? 6 : 4}
+				fill={kind === "click" ? "#22d3ee" : "#0f172a"}
+				stroke="#ffffff"
+				strokeWidth={2}
+				vectorEffect="non-scaling-stroke"
+			/>
+			{kind === "click" ? <circle cx={x} cy={y} r={2} fill="#0f172a" /> : null}
+		</>
+	);
+}
+
+export function CursorMotionPathOverlay({
+	region,
+	telemetry,
+	onControlPointChange,
+	onControlPointCommit,
+}: CursorMotionPathOverlayProps) {
+	const hostRef = useRef<HTMLDivElement | null>(null);
+	const draggingRef = useRef(false);
+
+	const model = useMemo(() => toModelCursorMotionRegion(region), [region]);
+
+	const editedPath = useMemo(() => {
+		// A hold has no path — its two anchors are the same point, and drawing a
+		// zero-length line there would put a stray dot on the frame.
+		if (region.segmentKind === "hold") return [];
+		const span = model.sourceEndMs - model.sourceStartMs;
+		return Array.from({ length: PATH_STEPS + 1 }, (_, i) =>
+			sampleCursorMotionRegion(model, model.sourceStartMs + (span * i) / PATH_STEPS),
+		);
+	}, [model, region.segmentKind]);
+
+	const recordedPath = useMemo(
+		() =>
+			(telemetry ?? [])
+				.filter((s) => s.timeMs >= model.sourceStartMs && s.timeMs <= model.sourceEndMs)
+				.map((s) => ({ cx: s.cx, cy: s.cy })),
+		[telemetry, model.sourceStartMs, model.sourceEndMs],
+	);
+
+	const updateFromClientPoint = useCallback(
+		(clientX: number, clientY: number) => {
+			const el = hostRef.current;
+			if (!el) return;
+			const rect = el.getBoundingClientRect();
+			if (!rect.width || !rect.height) return;
+			onControlPointChange(region.id, {
+				cx: clamp01((clientX - rect.left) / rect.width),
+				cy: clamp01((clientY - rect.top) / rect.height),
+			});
+		},
+		[onControlPointChange, region.id],
+	);
+
+	const onPointerDown = useCallback(
+		(e: ReactPointerEvent) => {
+			e.preventDefault();
+			e.stopPropagation();
+			draggingRef.current = true;
+			(e.target as Element).setPointerCapture?.(e.pointerId);
+			updateFromClientPoint(e.clientX, e.clientY);
+		},
+		[updateFromClientPoint],
+	);
+
+	const onPointerMove = useCallback(
+		(e: ReactPointerEvent) => {
+			if (!draggingRef.current) return;
+			updateFromClientPoint(e.clientX, e.clientY);
+		},
+		[updateFromClientPoint],
+	);
+
+	const endDrag = useCallback(() => {
+		if (!draggingRef.current) return;
+		draggingRef.current = false;
+		onControlPointCommit?.();
+	}, [onControlPointCommit]);
+
+	const controlX = region.controlPoint.cx * 100;
+	const controlY = region.controlPoint.cy * 100;
+	const shapeable = region.segmentKind === "move" && region.preset !== "recorded";
+
+	return (
+		<div
+			ref={hostRef}
+			style={{
+				position: "absolute",
+				inset: 0,
+				// The layer is a readout except for the handle itself, which takes its
+				// own pointer events back. Swallowing them all would make the preview
+				// unclickable behind any selected section.
+				pointerEvents: "none",
+				zIndex: 4,
+			}}
+		>
+			<svg
+				viewBox="0 0 100 100"
+				preserveAspectRatio="none"
+				style={{ width: "100%", height: "100%", overflow: "visible" }}
+				aria-hidden="true"
+			>
+				{recordedPath.length > 1 ? (
+					<polyline
+						points={toPolyline(recordedPath)}
+						fill="none"
+						stroke="#ffffff"
+						strokeOpacity={0.45}
+						strokeWidth={2}
+						strokeDasharray="5 4"
+						strokeLinecap="round"
+						vectorEffect="non-scaling-stroke"
+					/>
+				) : null}
+				{editedPath.length > 1 ? (
+					<>
+						{/* Drawn twice: a dark casing under the bright line, so the path stays
+						    readable over pale footage as well as dark. */}
+						<polyline
+							points={toPolyline(editedPath)}
+							fill="none"
+							stroke="#0f172a"
+							strokeOpacity={0.55}
+							strokeWidth={5}
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							vectorEffect="non-scaling-stroke"
+						/>
+						<polyline
+							points={toPolyline(editedPath)}
+							fill="none"
+							stroke="#22d3ee"
+							strokeWidth={2.5}
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							vectorEffect="non-scaling-stroke"
+						/>
+					</>
+				) : null}
+				{shapeable ? (
+					<line
+						x1={((region.startPoint.cx + region.endPoint.cx) / 2) * 100}
+						y1={((region.startPoint.cy + region.endPoint.cy) / 2) * 100}
+						x2={controlX}
+						y2={controlY}
+						stroke="#22d3ee"
+						strokeOpacity={0.5}
+						strokeWidth={1.5}
+						strokeDasharray="3 3"
+						vectorEffect="non-scaling-stroke"
+					/>
+				) : null}
+				<AnchorMarker point={region.startPoint} kind={region.startAnchor} />
+				<AnchorMarker point={region.endPoint} kind={region.endAnchor} />
+			</svg>
+			{shapeable ? (
+				// The handle is a DOM node, not an SVG circle: the overlay stretches with
+				// `preserveAspectRatio="none"`, which would squash a circle into an
+				// ellipse on any non-square stage, and a grab target should not change
+				// shape with the aspect ratio of the footage.
+				<div
+					role="slider"
+					tabIndex={0}
+					aria-label="Cursor path control point"
+					aria-valuenow={Math.round(region.controlPoint.cx * 100)}
+					aria-valuemin={0}
+					aria-valuemax={100}
+					onPointerDown={onPointerDown}
+					onPointerMove={onPointerMove}
+					onPointerUp={endDrag}
+					onPointerCancel={endDrag}
+					style={{
+						position: "absolute",
+						left: `${controlX}%`,
+						top: `${controlY}%`,
+						width: 18,
+						height: 18,
+						marginLeft: -9,
+						marginTop: -9,
+						borderRadius: "50%",
+						background: "#22d3ee",
+						border: "3px solid #ffffff",
+						boxShadow: "0 1px 6px rgba(0,0,0,0.45)",
+						cursor: "grab",
+						pointerEvents: "auto",
+						touchAction: "none",
+					}}
+				/>
+			) : null}
+		</div>
+	);
+}

--- a/src/components/ai-edition/EditorEmptyState.test.tsx
+++ b/src/components/ai-edition/EditorEmptyState.test.tsx
@@ -53,6 +53,7 @@ const sampleDoc = vi.hoisted(
 		},
 		annotations: [],
 		zoomRanges: [],
+		cursorMotionRegions: [],
 		legacyEditor: null,
 	}),
 );

--- a/src/components/ai-edition/ExportDialog.showInFolder.test.tsx
+++ b/src/components/ai-edition/ExportDialog.showInFolder.test.tsx
@@ -75,6 +75,7 @@ const DOC: AxcutDocument = {
 	},
 	annotations: [],
 	zoomRanges: [],
+	cursorMotionRegions: [],
 	legacyEditor: null,
 };
 

--- a/src/components/ai-edition/ExportDialog.test.ts
+++ b/src/components/ai-edition/ExportDialog.test.ts
@@ -57,6 +57,7 @@ function doc(assets: AxcutAsset[], clips: AxcutClip[]): AxcutDocument {
 		},
 		annotations: [],
 		zoomRanges: [],
+		cursorMotionRegions: [],
 		legacyEditor: null,
 	};
 }

--- a/src/components/ai-edition/NewEditorShell.tsx
+++ b/src/components/ai-edition/NewEditorShell.tsx
@@ -870,6 +870,16 @@ export function NewEditorShell() {
 			return;
 		}
 
+		// A cursor motion region is a path between two RESOLVED points — the cursor's
+		// actual position at a rest or a recorded click. Pasting it at the playhead
+		// would draw that path between two places the cursor never was. The inspector's
+		// "apply to all move sections" is the operation that means what copy would mean
+		// here, and it copies the styling without the anchors.
+		if (sel.kind === "cursorMotion") {
+			toast.info("Cursor motion is tied to its anchors — use Apply to all moves instead");
+			return;
+		}
+
 		const source =
 			sel.kind === "zoom"
 				? tl.zoomRegions
@@ -1243,6 +1253,12 @@ export function NewEditorShell() {
 									selectedZoomRegionId={tl.selection?.kind === "zoom" ? tl.selection.id : null}
 									onZoomFocusChange={tl.updateZoomFocusLive}
 									onZoomFocusCommit={() => void tl.commitZoomFocus()}
+									cursorMotionRegions={tl.cursorMotionRegions}
+									selectedCursorMotionId={
+										tl.selection?.kind === "cursorMotion" ? tl.selection.id : null
+									}
+									onCursorMotionControlPointChange={tl.updateCursorMotionControlPointLive}
+									onCursorMotionControlPointCommit={() => void tl.commitCursorMotionControlPoint()}
 									annotationRegions={tl.annotationRegions}
 									selectedAnnotationId={
 										tl.selection?.kind === "annotation" ? tl.selection.id : null

--- a/src/components/ai-edition/NewEditorShell.tsx
+++ b/src/components/ai-edition/NewEditorShell.tsx
@@ -848,9 +848,11 @@ export function NewEditorShell() {
 	// copied is what the user is looking at — the old version dug into the raw
 	// document with a ternary chain that mapped a trim to "zoom" and sent
 	// cameraFullscreen down the speed branch, where neither could ever be found.
-	const handleCopyRegion = useCallback(async () => {
+	// Resolves to whether anything actually landed on the clipboard: Ctrl+X must
+	// not delete a selection whose copy was refused or failed.
+	const handleCopyRegion = useCallback(async (): Promise<boolean> => {
 		const sel = tl.selection;
-		if (!sel) return;
+		if (!sel) return false;
 		const { copyRegion } = await import("@/lib/ai-edition/store/regionClipboard");
 
 		// A trim is stored in SOURCE time against a clip anchor, so there is no
@@ -863,21 +865,22 @@ export function NewEditorShell() {
 			const group = coalescedTrimGroups(tl.trimRanges, tl.clips).find((g) =>
 				g.ids.includes(sel.id),
 			);
-			if (!group) return;
+			if (!group) return false;
 			copyRegion({ kind: "trim", region: { durationSec: group.end - group.start } });
 			setCopiedClipId(null);
 			toast.success("Region copied");
-			return;
+			return true;
 		}
 
 		// A cursor motion region is a path between two RESOLVED points — the cursor's
 		// actual position at a rest or a recorded click. Pasting it at the playhead
 		// would draw that path between two places the cursor never was. The inspector's
 		// "apply to all move sections" is the operation that means what copy would mean
-		// here, and it copies the styling without the anchors.
+		// here, and it copies the styling without the anchors. Cut is refused with it:
+		// there is no clipboard entry to justify deleting the section.
 		if (sel.kind === "cursorMotion") {
 			toast.info("Cursor motion is tied to its anchors — use Apply to all moves instead");
-			return;
+			return false;
 		}
 
 		const source =
@@ -889,11 +892,12 @@ export function NewEditorShell() {
 						? tl.speedRegions
 						: tl.cameraFullscreenRegions;
 		const region = (source as Array<{ id: string }>).find((r) => r.id === sel.id);
-		if (!region) return;
+		if (!region) return false;
 		copyRegion({ kind: sel.kind, region: region as unknown as Record<string, unknown> });
 		// One clipboard wins at a time: a copied pill retires the copied clip.
 		setCopiedClipId(null);
 		toast.success("Region copied");
+		return true;
 	}, [tl]);
 
 	useEffect(() => {
@@ -985,11 +989,15 @@ export function NewEditorShell() {
 			}
 			if (ctrl && e.key.toLowerCase() === "x") {
 				// F2.8 — cut: remember the region in the clipboard, then remove it.
-				// Trims included now that copying one means copying its length.
+				// Trims included now that copying one means copying its length. The
+				// removal only happens on a confirmed copy — cursor-motion selections
+				// refuse theirs, and deleting uncopied would make Ctrl+X a delete.
 				if (tl.selection) {
 					e.preventDefault();
 					const cut = tl.selection;
-					void handleCopyRegion().then(() => tl.removeRegion(cut.kind, cut.id));
+					void handleCopyRegion().then((copied) => {
+						if (copied) tl.removeRegion(cut.kind, cut.id);
+					});
 					return;
 				}
 			}

--- a/src/components/ai-edition/Preview.tsx
+++ b/src/components/ai-edition/Preview.tsx
@@ -4,6 +4,7 @@ import { useScopedT } from "@/contexts/I18nContext";
 import type {
 	AxcutAnnotationRegion,
 	AxcutClip,
+	AxcutCursorMotionRegion,
 	AxcutTrimRange,
 	AxcutZoomRegion,
 } from "@/lib/ai-edition/schema";
@@ -29,6 +30,10 @@ interface PreviewProps {
 	selectedZoomRegionId?: string | null;
 	onZoomFocusChange?: (id: string, focus: ZoomFocus) => void;
 	onZoomFocusCommit?: () => void;
+	cursorMotionRegions?: AxcutCursorMotionRegion[];
+	selectedCursorMotionId?: string | null;
+	onCursorMotionControlPointChange?: (id: string, point: { cx: number; cy: number }) => void;
+	onCursorMotionControlPointCommit?: () => void;
 	annotationRegions?: AxcutAnnotationRegion[];
 	selectedAnnotationId?: string | null;
 	onSelectAnnotation?: (id: string) => void;
@@ -59,6 +64,10 @@ export function Preview({
 	trimRanges,
 	selectedZoomRegionId,
 	onZoomFocusChange,
+	cursorMotionRegions,
+	selectedCursorMotionId,
+	onCursorMotionControlPointChange,
+	onCursorMotionControlPointCommit,
 	onZoomFocusCommit,
 	annotationRegions,
 	selectedAnnotationId,
@@ -185,6 +194,10 @@ export function Preview({
 						trimRanges={trimRanges}
 						selectedZoomRegionId={selectedZoomRegionId}
 						onZoomFocusChange={onZoomFocusChange}
+						cursorMotionRegions={cursorMotionRegions}
+						selectedCursorMotionId={selectedCursorMotionId}
+						onCursorMotionControlPointChange={onCursorMotionControlPointChange}
+						onCursorMotionControlPointCommit={onCursorMotionControlPointCommit}
 						onZoomFocusCommit={onZoomFocusCommit}
 						annotationRegions={annotationRegions}
 						selectedAnnotationId={selectedAnnotationId}

--- a/src/components/ai-edition/PreviewCanvas.tsx
+++ b/src/components/ai-edition/PreviewCanvas.tsx
@@ -22,6 +22,7 @@
 
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { fromFileUrl } from "@/components/video-editor/projectPersistence";
 import {
 	type CameraFullscreenRegion,
 	type CropRegion,
@@ -35,6 +36,7 @@ import { resolveAspectRatioValue } from "@/lib/ai-edition/document/outputFormat"
 import type {
 	AxcutAnnotationRegion,
 	AxcutClip,
+	AxcutCursorMotionRegion,
 	AxcutTrimRange,
 	AxcutZoomRegion,
 } from "@/lib/ai-edition/schema";
@@ -53,8 +55,10 @@ import {
 import { classifyWallpaper, resolveImageWallpaperUrl } from "@/lib/wallpaper";
 import { getCssClipPath } from "@/lib/webcamMaskShapes";
 import { computeCameraFullscreenProgress } from "@/lib/zoomMath/cameraFullscreenUtils";
+import { useCursorTelemetry } from "@/native/hooks/useCursorTelemetry";
 import { clamp, clamp01 } from "@/utils/math";
 import { AnnotationLayer } from "./AnnotationLayer";
+import { CursorMotionPathOverlay } from "./CursorMotionPathOverlay";
 import { NativeCompositorOverlay } from "./NativeCompositorOverlay";
 import styles from "./NewEditorShell.module.css";
 import { type VideoSource, VirtualPreview } from "./VirtualPreview";
@@ -73,6 +77,10 @@ interface PreviewCanvasProps {
 	selectedZoomRegionId?: string | null;
 	onZoomFocusChange?: (id: string, focus: ZoomFocus) => void;
 	onZoomFocusCommit?: () => void;
+	cursorMotionRegions?: AxcutCursorMotionRegion[];
+	selectedCursorMotionId?: string | null;
+	onCursorMotionControlPointChange?: (id: string, point: { cx: number; cy: number }) => void;
+	onCursorMotionControlPointCommit?: () => void;
 	annotationRegions?: AxcutAnnotationRegion[];
 	selectedAnnotationId?: string | null;
 	onSelectAnnotation?: (id: string) => void;
@@ -387,6 +395,23 @@ export function PreviewCanvas(props: PreviewCanvasProps) {
 
 	const isPipGrab = settings.webcamLayoutPreset === "picture-in-picture";
 
+	// Telemetry for the recorded-trace comparison line. Loaded from the SELECTED
+	// section's own asset, not the primary one: in a multi-clip project those differ,
+	// and comparing an edited path against another recording's trace would be worse
+	// than showing no comparison at all.
+	const selectedCursorMotion = props.selectedCursorMotionId
+		? (props.cursorMotionRegions?.find((r) => r.id === props.selectedCursorMotionId) ?? null)
+		: null;
+	// The recorded trace is loaded through the same hook the cursor preview layer
+	// uses, keyed by the SELECTED section's asset. `useCursorTelemetry` takes null
+	// as "nothing to load" and returns an empty list, so nothing is fetched while no
+	// section is selected — which is the common case.
+	const cursorMotionSource = selectedCursorMotion?.assetId
+		? (props.videoSources.find((v) => v.id === selectedCursorMotion.assetId) ?? null)
+		: null;
+	const { samples: cursorMotionTelemetry } = useCursorTelemetry(
+		cursorMotionSource ? fromFileUrl(cursorMotionSource.src) : null,
+	);
 	const selectedZoomRegion = props.selectedZoomRegionId
 		? (props.zoomRegions?.find((z) => z.id === props.selectedZoomRegionId) ?? null)
 		: null;
@@ -429,6 +454,14 @@ export function PreviewCanvas(props: PreviewCanvasProps) {
 							/>
 						);
 					})()}
+					{selectedCursorMotion && props.onCursorMotionControlPointChange ? (
+						<CursorMotionPathOverlay
+							region={selectedCursorMotion}
+							telemetry={cursorMotionTelemetry}
+							onControlPointChange={props.onCursorMotionControlPointChange}
+							onControlPointCommit={props.onCursorMotionControlPointCommit}
+						/>
+					) : null}
 					{selectedZoomRegion && props.onZoomFocusChange ? (
 						<ZoomFocusOverlay
 							region={selectedZoomRegion}

--- a/src/components/ai-edition/WebcamOverlay.test.tsx
+++ b/src/components/ai-edition/WebcamOverlay.test.tsx
@@ -74,6 +74,7 @@ function makeDocument(): AxcutDocument {
 		},
 		annotations: [],
 		zoomRanges: [],
+		cursorMotionRegions: [],
 		legacyEditor: null,
 	};
 }

--- a/src/components/ai-edition/v4/EditorShellV4.module.css
+++ b/src/components/ai-edition/v4/EditorShellV4.module.css
@@ -1496,6 +1496,20 @@
 	border-color: #a855f7;
 	background: rgba(168, 85, 247, 0.14);
 }
+/* Cursor motion sits on its own hue rather than borrowing the zoom accent: the two
+   lanes are adjacent and both describe where the frame is looking, so sharing a
+   colour would make them one band at a glance. */
+.laneCursorMotion {
+	border-color: #22d3ee;
+	background: rgba(34, 211, 238, 0.16);
+}
+/* A hold has no path to direct. It is drawn as the same colour turned down rather
+   than a neutral grey, so a run of sections still reads as one lane. */
+.laneCursorHold {
+	border-color: rgba(34, 211, 238, 0.4);
+	background: rgba(34, 211, 238, 0.06);
+	color: color-mix(in oklch, currentColor 65%, transparent);
+}
 .tlClips {
 	position: relative;
 	/* NOT a flex row. Clips are absolutely positioned by percentage of the

--- a/src/components/ai-edition/v4/FloatingInspector.tsx
+++ b/src/components/ai-edition/v4/FloatingInspector.tsx
@@ -1,7 +1,9 @@
 import {
 	AudioLines,
 	Captions as CaptionsIcon,
+	ChevronLeft,
 	ChevronRight,
+	Copy,
 	FileText,
 	Layout as LayoutIcon,
 	Maximize2,
@@ -9,6 +11,7 @@ import {
 	Pencil,
 	Scissors,
 	SlidersHorizontal,
+	Spline,
 	Trash2,
 	X,
 	ZoomIn,
@@ -39,6 +42,16 @@ import { useEditorSettings } from "@/lib/ai-edition/store/useEditorSettings";
 import type { useTimeline } from "@/lib/ai-edition/store/useTimeline";
 import { formatSeconds } from "@/lib/ai-edition/timeline/format";
 import { coalescedTrimGroups } from "@/lib/ai-edition/timeline/trim-mapping";
+import {
+	CURSOR_MOTION_CYCLES_MAX,
+	CURSOR_MOTION_CYCLES_MIN,
+	CURSOR_MOTION_EASINGS,
+	CURSOR_MOTION_PRESETS,
+	CURSOR_MOTION_SPEED_MAX,
+	CURSOR_MOTION_SPEED_MIN,
+	type CursorMotionEasing,
+	type CursorMotionPreset,
+} from "@/lib/cursor/cursorMotion";
 import { CaptionsPane } from "../CaptionsPane";
 import { ColorField } from "../ColorField";
 import {
@@ -299,6 +312,53 @@ function paneRow(label: string, control: React.ReactNode) {
 			<span style={{ fontSize: 12.5, color: "var(--fg-2)", fontWeight: 500 }}>{label}</span>
 			{control}
 		</div>
+	);
+}
+
+// The preset glyphs, path data unchanged from #113 where the shapes were drawn.
+// A preset is a SHAPE, and a row of words asks the reader to imagine six of them;
+// the picture is the control. `recorded` draws a wobble on purpose — it is the
+// captured trace, the one shape the editor did not choose.
+const CURSOR_MOTION_PREVIEW_PATHS: Record<CursorMotionPreset, string> = {
+	recorded: "M4 18 C12 8 18 21 27 11 S38 4 44 9",
+	straight: "M4 18 L44 6",
+	arc: "M4 18 Q24 1 44 18",
+	wave: "M4 13 C10 2 16 2 22 13 S34 24 44 13",
+	loop: "M4 16 C14 2 34 2 32 15 C30 25 14 23 18 13 C22 5 36 8 44 16",
+	overshoot: "M4 18 C24 18 37 5 46 8 C42 8 40 10 44 14",
+};
+const CURSOR_MOTION_PREVIEW_END_Y: Record<CursorMotionPreset, number> = {
+	recorded: 9,
+	straight: 6,
+	arc: 18,
+	wave: 13,
+	loop: 16,
+	overshoot: 14,
+};
+// The speeds worth one click. The slider covers everything between them; these are
+// the values an editor actually reaches for, and hunting for "2.0" on a 0.1-step
+// slider is a worse way to get there.
+const CURSOR_MOTION_SPEED_PRESETS = [1, 1.5, 2, 3, 4] as const;
+
+function CursorMotionPresetGlyph({ preset }: { preset: CursorMotionPreset }) {
+	return (
+		<svg viewBox="0 0 48 26" style={{ width: "100%", height: 26 }} aria-hidden="true">
+			<path
+				d={CURSOR_MOTION_PREVIEW_PATHS[preset]}
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2.4"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+			<circle
+				cx="4"
+				cy={preset === "wave" ? 13 : preset === "loop" ? 16 : 18}
+				r="2.4"
+				fill="currentColor"
+			/>
+			<circle cx="44" cy={CURSOR_MOTION_PREVIEW_END_Y[preset]} r="2.4" fill="currentColor" />
+		</svg>
 	);
 }
 
@@ -604,6 +664,291 @@ function SelectionPane({ tl, onClose }: { tl: TimelineApi; onClose: () => void }
 					<button type="button" onClick={deleteAndClose} style={deleteBtnStyle}>
 						<Trash2 size={14} />
 						{ts("zoom.deleteZoom")}
+					</button>
+				</div>
+			</div>
+		);
+	}
+
+	if (selection.kind === "cursorMotion") {
+		const regions = tl.cursorMotionRegions ?? [];
+		const region = regions.find((r) => r.id === selection.id);
+		if (!region) return null;
+		// Sections in timeline order, so "previous / next" walks the recording rather
+		// than the order they happen to sit in the document.
+		const ordered = [...regions].sort((a, b) => a.startMs - b.startMs);
+		const index = ordered.findIndex((r) => r.id === region.id);
+		const step = (delta: number) => {
+			const target = ordered[index + delta];
+			if (target) tl.selectRegion("cursorMotion", target.id);
+		};
+		const isHold = region.segmentKind === "hold";
+		return (
+			<div style={{ display: "flex", flexDirection: "column", minHeight: 0 }}>
+				{paneHeader(<Spline size={15} />, ts("cursorMotion.title"), onClose, tc("actions.close"))}
+				<div style={bodyStyle}>
+					<div
+						style={{
+							display: "grid",
+							gridTemplateColumns: "32px 1fr 32px",
+							alignItems: "center",
+							gap: 6,
+						}}
+					>
+						<button
+							type="button"
+							onClick={() => step(-1)}
+							disabled={index <= 0}
+							title={ts("cursorMotion.previousSection")}
+							aria-label={ts("cursorMotion.previousSection")}
+							style={{
+								...secondaryBtnStyle,
+								padding: 0,
+								height: 30,
+								opacity: index <= 0 ? 0.35 : 1,
+							}}
+						>
+							<ChevronLeft size={14} />
+						</button>
+						<span
+							style={{
+								textAlign: "center",
+								fontSize: 12,
+								fontWeight: 600,
+								color: "var(--fg-2)",
+								fontVariantNumeric: "tabular-nums",
+							}}
+						>
+							{ts("cursorMotion.sectionCounter", {
+								current: index + 1,
+								total: ordered.length,
+							})}
+						</span>
+						<button
+							type="button"
+							onClick={() => step(1)}
+							disabled={index < 0 || index >= ordered.length - 1}
+							title={ts("cursorMotion.nextSection")}
+							aria-label={ts("cursorMotion.nextSection")}
+							style={{
+								...secondaryBtnStyle,
+								padding: 0,
+								height: 30,
+								opacity: index >= ordered.length - 1 ? 0.35 : 1,
+							}}
+						>
+							<ChevronRight size={14} />
+						</button>
+					</div>
+
+					{isHold ? (
+						// A hold has no path, so every control below would be inert on it. Say
+						// what the section IS instead of showing six shapes that cannot apply —
+						// this is the section that keeps the cursor still, and that is the whole
+						// reason the rests were split out in the first place.
+						<p style={{ margin: 0, font: "400 11.5px/1.5 var(--font-sans)", color: "var(--fg-2)" }}>
+							{ts("cursorMotion.holdDescription")}
+						</p>
+					) : (
+						<>
+							<div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+								<span style={{ fontSize: 12.5, color: "var(--fg-2)", fontWeight: 500 }}>
+									{ts("cursorMotion.preset")}
+								</span>
+								<div
+									style={{
+										display: "grid",
+										gridTemplateColumns: "repeat(3, 1fr)",
+										gap: 6,
+									}}
+								>
+									{CURSOR_MOTION_PRESETS.map((preset) => {
+										const active = region.preset === preset;
+										return (
+											<button
+												key={preset}
+												type="button"
+												aria-pressed={active}
+												onClick={() => void tl.updateCursorMotionSettings(region.id, { preset })}
+												title={ts(`cursorMotion.presets.${preset}`)}
+												style={{
+													display: "flex",
+													flexDirection: "column",
+													alignItems: "center",
+													gap: 2,
+													padding: "6px 4px",
+													borderRadius: 9,
+													border: `1px solid ${active ? "var(--accent)" : "var(--border)"}`,
+													background: active ? "var(--accent-soft)" : "transparent",
+													color: active ? "var(--accent)" : "var(--fg-2)",
+													cursor: "pointer",
+												}}
+											>
+												<CursorMotionPresetGlyph preset={preset} />
+												<span style={{ fontSize: 10, fontWeight: 600 }}>
+													{ts(`cursorMotion.presets.${preset}`)}
+												</span>
+											</button>
+										);
+									})}
+								</div>
+							</div>
+
+							{/* `recorded` is inert: it plays the captured trace, so speed, turns and
+							    timing have nothing to reshape. Hiding them is the honest reading of
+							    "this section is unedited" — greying six controls says the same thing
+							    at four times the visual weight. */}
+							{region.preset !== "recorded" ? (
+								<>
+									<div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+										{paneRow(
+											ts("cursorMotion.speed"),
+											<span
+												style={{
+													fontSize: 12.5,
+													fontWeight: 600,
+													color: "var(--accent)",
+													fontVariantNumeric: "tabular-nums",
+												}}
+											>
+												{region.speed.toFixed(1)}×
+											</span>,
+										)}
+										<div style={{ display: "grid", gridTemplateColumns: "repeat(5, 1fr)", gap: 4 }}>
+											{CURSOR_MOTION_SPEED_PRESETS.map((speed) => (
+												<button
+													key={speed}
+													type="button"
+													aria-pressed={region.speed === speed}
+													onClick={() => void tl.updateCursorMotionSettings(region.id, { speed })}
+													style={{
+														...secondaryBtnStyle,
+														padding: "5px 0",
+														fontSize: 11,
+														...(region.speed === speed
+															? {
+																	borderColor: "var(--accent)",
+																	background: "var(--accent-soft)",
+																	color: "var(--accent)",
+																}
+															: {}),
+													}}
+												>
+													{speed}×
+												</button>
+											))}
+										</div>
+										<input
+											type="range"
+											min={CURSOR_MOTION_SPEED_MIN}
+											max={CURSOR_MOTION_SPEED_MAX}
+											step={0.1}
+											value={region.speed}
+											onChange={(e) =>
+												void tl.updateCursorMotionSettings(region.id, {
+													speed: Number(e.target.value),
+												})
+											}
+											style={{ width: "100%", accentColor: "var(--accent)" }}
+										/>
+										<p
+											style={{
+												margin: 0,
+												font: "400 11px/1.45 var(--font-sans)",
+												color: "var(--fg-2)",
+											}}
+										>
+											{ts("cursorMotion.speedHint")}
+										</p>
+									</div>
+
+									{region.preset === "wave" || region.preset === "loop" ? (
+										<div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+											{paneRow(
+												ts("cursorMotion.cycles"),
+												<span
+													style={{
+														fontSize: 12.5,
+														fontWeight: 600,
+														color: "var(--accent)",
+														fontVariantNumeric: "tabular-nums",
+													}}
+												>
+													{region.cycles}
+												</span>,
+											)}
+											<input
+												type="range"
+												min={CURSOR_MOTION_CYCLES_MIN}
+												max={CURSOR_MOTION_CYCLES_MAX}
+												step={1}
+												value={region.cycles}
+												onChange={(e) =>
+													void tl.updateCursorMotionSettings(region.id, {
+														cycles: Number(e.target.value),
+													})
+												}
+												style={{ width: "100%", accentColor: "var(--accent)" }}
+											/>
+										</div>
+									) : null}
+
+									{paneRow(
+										ts("cursorMotion.easing"),
+										<select
+											value={region.easing}
+											onChange={(e) =>
+												void tl.updateCursorMotionSettings(region.id, {
+													easing: e.target.value as CursorMotionEasing,
+												})
+											}
+											style={selectStyle}
+										>
+											{CURSOR_MOTION_EASINGS.map((easing) => (
+												<option key={easing} value={easing}>
+													{ts(`cursorMotion.easings.${easing}`)}
+												</option>
+											))}
+										</select>,
+									)}
+
+									<button
+										type="button"
+										onClick={() => {
+											void tl.applyCursorMotionToAllMoves(region.id).then((count) => {
+												if (count > 0) toast.success(ts("cursorMotion.appliedToAllMoves"));
+											});
+										}}
+										style={secondaryBtnStyle}
+									>
+										<Copy size={14} />
+										{ts("cursorMotion.applyToAllMoves")}
+									</button>
+								</>
+							) : null}
+						</>
+					)}
+
+					<p style={{ margin: 0, font: "400 11px/1.45 var(--font-sans)", color: "var(--fg-2)" }}>
+						{ts("cursorMotion.anchorHint")}
+					</p>
+
+					<button
+						type="button"
+						onClick={() => {
+							void tl.splitCursorMotionAtPlayhead(region.id).then((ok) => {
+								if (!ok) toast.info(ts("cursorMotion.splitOutsideRegion"));
+							});
+						}}
+						style={secondaryBtnStyle}
+					>
+						<Scissors size={14} />
+						{ts("cursorMotion.splitAtPlayhead")}
+					</button>
+
+					<button type="button" onClick={deleteAndClose} style={deleteBtnStyle}>
+						<Trash2 size={14} />
+						{ts("cursorMotion.delete")}
 					</button>
 				</div>
 			</div>

--- a/src/components/ai-edition/v4/V4Timeline.geometry.test.tsx
+++ b/src/components/ai-edition/v4/V4Timeline.geometry.test.tsx
@@ -80,6 +80,7 @@ function renderTimeline(
 		speedRegions: [],
 		cameraFullscreenRegions: [],
 		zoomRegions: [],
+		cursorMotionRegions: [],
 		trimRanges: [],
 		selection: null,
 		multiSelection: [],

--- a/src/components/ai-edition/v4/V4Timeline.tsx
+++ b/src/components/ai-edition/v4/V4Timeline.tsx
@@ -4,9 +4,11 @@ import {
 	Loader2,
 	Maximize2,
 	MessageSquare,
+	Pause,
 	Pencil,
 	Scissors,
 	Sparkles,
+	Spline,
 	SplitSquareHorizontal,
 	Trash2,
 	Wand2,
@@ -37,13 +39,17 @@ import { useChatPromptBus } from "@/lib/ai-edition/store/useChatPromptBus";
 import { useEditorSettings } from "@/lib/ai-edition/store/useEditorSettings";
 import type { useTimeline } from "@/lib/ai-edition/store/useTimeline";
 import { hasAnyClipWithCamera } from "@/lib/ai-edition/timeline/camera";
+import { toCursorMotionSamples } from "@/lib/ai-edition/timeline/cursorMotionRegions";
 import { formatSec } from "@/lib/ai-edition/timeline/format";
 import {
 	newRegionDurationSec,
 	setTimelineScale,
 } from "@/lib/ai-edition/timeline/newRegionDuration";
 import { ventilateSpanAcrossClips } from "@/lib/ai-edition/timeline/region-ventilation";
-import { coalesceRegionsForRuler } from "@/lib/ai-edition/timeline/timelineMap";
+import {
+	coalesceRegionsForRuler,
+	resolveNativePosition,
+} from "@/lib/ai-edition/timeline/timelineMap";
 import {
 	coalescedTrimGroups,
 	resolveTimelineSpanToTrim,
@@ -54,6 +60,7 @@ import {
 	buildAutoZoomSuggestionsForClips,
 } from "@/lib/ai-edition/timeline/zoom-suggestions";
 import { nativeBridgeClient } from "@/native/client";
+import { resolveVisibleClips } from "@/native/sceneDescription";
 import { TransportBar } from "../TransportBar";
 import type { VideoSource } from "../VirtualPreview";
 import styles from "./EditorShellV4.module.css";
@@ -337,12 +344,15 @@ const ClipWaveform = memo(function ClipWaveform({
 
 interface LanePill {
 	id: string;
-	kind: "annotation" | "speed" | "trim" | "zoom" | "cameraFullscreen";
+	kind: "annotation" | "speed" | "trim" | "zoom" | "cameraFullscreen" | "cursorMotion";
 	start: number;
 	end: number;
 	label: string;
 	/** Underlying row ids this pill represents — >1 for a coalesced trim group. */
 	sourceIds: string[];
+	/** A cursor-motion HOLD: the pointer stays where it stopped. Drawn quieter than
+	 *  a move because there is no path in it to direct — see `laneCursorHold`. */
+	quiet?: boolean;
 }
 
 export function V4Timeline({
@@ -509,6 +519,30 @@ export function V4Timeline({
 		label: `${(p.member.customScale ?? ZOOM_DEPTH_SCALES[p.member.depth]).toFixed(2)}×`,
 		sourceIds: p.ids,
 	}));
+	// Cursor motion is the one lane that does NOT coalesce. Everywhere else, two
+	// touching regions with equal properties are the same effect and merging them
+	// is what makes a ventilated region read as one pill. Here they are two
+	// SECTIONS, and being individually selectable is the whole feature: an editor
+	// tunes one move, walks to the next, tunes that one. Merging the two moves
+	// that happen to share a preset would silently take that away — and it is the
+	// state a fresh auto-split is always in, since every section starts
+	// `recorded` at 1x.
+	const cursorMotionPills: LanePill[] = (tl.cursorMotionRegions ?? []).map((region) => ({
+		id: region.id,
+		kind: "cursorMotion" as const,
+		start: region.startMs / 1000,
+		end: region.endMs / 1000,
+		// The speed rides on the label because it is the property with no other
+		// visible tell: a preset shows itself in the preview path, a 3x does not.
+		label:
+			region.segmentKind === "hold"
+				? t("cursorMotion.segmentKinds.hold")
+				: `${t(`cursorMotion.presets.${region.preset}`)}${
+						region.speed === 1 ? "" : ` ${region.speed.toFixed(1)}×`
+					}`,
+		sourceIds: [region.id],
+		quiet: region.segmentKind === "hold",
+	}));
 	// trims: content-free (no per-instance text/settings), so touching rows —
 	// inevitable once a trim is ventilated across a clip boundary — are
 	// coalesced into one pill. This is what makes growing a trim across a
@@ -665,6 +699,12 @@ export function V4Timeline({
 			e.preventDefault();
 			e.stopPropagation();
 			tl.selectRegion(pill.kind, pill.id, { additive: e.shiftKey });
+			// A cursor motion section selects but does not drag. Its two ends are not
+			// a span someone chose — they are a rest, a click, or a cut, each pinned to
+			// a POINT the recording puts the pointer at. Sliding the section would keep
+			// the anchors and move the times, so the path would start where the cursor
+			// no longer is. Re-splitting is how you change these boundaries.
+			if (pill.kind === "cursorMotion") return;
 			// Scale drag deltas against the canvas (full zoomed timeline) width, so a
 			// drag tracks the cursor exactly regardless of padding, scrollbar or zoom.
 			const el = canvasRef.current;
@@ -892,25 +932,37 @@ export function V4Timeline({
 		transform: `translateX(${(-nav.start * 100).toFixed(3)}%)`,
 	} as const;
 
-	const laneOf = (kind: LanePill["kind"]) =>
-		kind === "annotation"
+	const laneOf = (pill: LanePill) =>
+		pill.kind === "annotation"
 			? styles.laneAnnotation
-			: kind === "speed"
+			: pill.kind === "speed"
 				? styles.laneSpeed
-				: kind === "trim"
+				: pill.kind === "trim"
 					? styles.laneTrim
-					: kind === "cameraFullscreen"
+					: pill.kind === "cameraFullscreen"
 						? styles.laneCameraFullscreen
-						: styles.laneZoom;
-	const pillIcon = (kind: LanePill["kind"]) =>
-		kind === "annotation" ? (
+						: pill.kind === "cursorMotion"
+							? pill.quiet
+								? styles.laneCursorHold
+								: styles.laneCursorMotion
+							: styles.laneZoom;
+	const pillIcon = (pill: LanePill) =>
+		pill.kind === "annotation" ? (
 			<MessageSquare size={11} />
-		) : kind === "speed" ? (
+		) : pill.kind === "speed" ? (
 			<Clock size={11} />
-		) : kind === "trim" ? (
+		) : pill.kind === "trim" ? (
 			<Scissors size={11} />
-		) : kind === "cameraFullscreen" ? (
+		) : pill.kind === "cameraFullscreen" ? (
 			<Maximize2 size={11} />
+		) : pill.kind === "cursorMotion" ? (
+			// A hold is the absence of movement, so it gets the pause glyph rather
+			// than a dimmer copy of the path one — the lane already dims it.
+			pill.quiet ? (
+				<Pause size={11} />
+			) : (
+				<Spline size={11} />
+			)
 		) : (
 			<ZoomIn size={11} />
 		);
@@ -1081,6 +1133,56 @@ export function V4Timeline({
 		}
 	}, [videoSources, clips, tl, t]);
 
+	// Cursor motion — build the sections from the playhead to the next recorded
+	// click. Unlike auto-zoom above, this reads the RECORDING data rather than the
+	// position telemetry: the split points are clicks, and only the native cursor
+	// sampler records those. A capture with position-only telemetry (the fallback
+	// adapter, or a platform without the helper) therefore has nothing to split on,
+	// which is one of the three ways this can legitimately find nothing.
+	const [cursorMotionBusy, setCursorMotionBusy] = useState(false);
+	const runCursorMotion = useCallback(async () => {
+		const state = useProjectStore.getState();
+		const doc = state.document;
+		// Which recording's telemetry to read is decided by the clip UNDER THE
+		// PLAYHEAD, not by the primary asset: in a multi-clip project those are
+		// different recordings, and reading the wrong one produces sections whose
+		// anchors sit where that other capture's cursor was.
+		const position = doc
+			? resolveNativePosition(state.currentTimeSec ?? 0, resolveVisibleClips(doc), clips)
+			: null;
+		const source = position
+			? videoSources.find((s) => s.id === position.clip.assetId)
+			: videoSources[0];
+		if (!source) {
+			toast.error(t("toolbar.importRecordingFirst"));
+			return;
+		}
+		setCursorMotionBusy(true);
+		try {
+			const data = await nativeBridgeClient.cursor.getRecordingData(fromFileUrl(source.src));
+			const samples = data?.samples ?? [];
+			if (samples.length === 0) {
+				toast.info(t("cursorMotion.noCursorData"));
+				return;
+			}
+			const added = await tl.addCursorMotion(toCursorMotionSamples(samples));
+			// Nothing added has exactly one cause worth naming: there is no click left
+			// to reach. Saying "no cursor data" there would send the user looking for a
+			// recording problem they do not have.
+			if (added === 0) {
+				toast.info(t("cursorMotion.noFollowingClick"));
+				return;
+			}
+			toast.success(t("cursorMotion.createdSegments", { count: added }));
+		} catch (err) {
+			toast.error(t("cursorMotion.failed"), {
+				description: err instanceof Error ? err.message : String(err),
+			});
+		} finally {
+			setCursorMotionBusy(false);
+		}
+	}, [clips, videoSources, tl, t]);
+
 	// Auto-enhance option 2 — hand a generic prompt to the AI agent (smart
 	// zooms + cuts) via the chat prompt-bus. The chat panel owns the outcome
 	// toast: submitting is not the same as being accepted (no usable provider
@@ -1133,12 +1235,16 @@ export function V4Timeline({
 		// The box is exactly as long as the effect is; only what fits INSIDE it
 		// varies with the zoom.
 		const { compact, roomForLabel } = pillAffordance(durSec, pxPerSec);
+		// No edge handles on a cursor motion section: its boundaries are anchors the
+		// recording placed, not a span to stretch (see `startPillDrag`). Showing grab
+		// strips that refuse to grab is worse than showing none.
+		const resizable = p.kind !== "cursorMotion";
 		return (
 			<div
 				key={seg.key}
 				role={seg.interactive ? "button" : undefined}
 				tabIndex={seg.interactive ? 0 : undefined}
-				className={`${styles.lanePill} ${laneOf(p.kind)}${
+				className={`${styles.lanePill} ${laneOf(p)}${
 					compact ? ` ${styles.lanePillCompact}` : ""
 				}${seg.interactive && isPillSelected(p.id) ? ` ${styles.lanePillSel}` : ""}`}
 				style={{
@@ -1160,7 +1266,7 @@ export function V4Timeline({
 				onPointerDown={seg.interactive ? (e) => startPillDrag(e, p, "move") : undefined}
 				title={p.label}
 			>
-				{seg.interactive ? (
+				{seg.interactive && resizable ? (
 					<span
 						className={styles.lanePillHandle}
 						style={{ left: compact ? -PILL_HANDLE_OUT_PX : 0 }}
@@ -1169,11 +1275,11 @@ export function V4Timeline({
 				) : null}
 				{seg.showContent && roomForLabel ? (
 					<>
-						{pillIcon(p.kind)}
+						{pillIcon(p)}
 						<span className={styles.lanePillLabel}>{p.label}</span>
 					</>
 				) : null}
-				{seg.interactive ? (
+				{seg.interactive && resizable ? (
 					<span
 						className={styles.lanePillHandle}
 						style={{ right: compact ? -PILL_HANDLE_OUT_PX : 0 }}
@@ -1374,6 +1480,20 @@ export function V4Timeline({
 						<button
 							type="button"
 							className={styles.tlToolBtn}
+							title={t("buttons.addCursorMotion")}
+							aria-label={t("buttons.addCursorMotion")}
+							disabled={cursorMotionBusy}
+							onClick={() => void runCursorMotion()}
+						>
+							{cursorMotionBusy ? (
+								<Loader2 size={15} className={styles.spin} />
+							) : (
+								<Spline size={15} />
+							)}
+						</button>
+						<button
+							type="button"
+							className={styles.tlToolBtn}
 							title={t("buttons.addCameraFullscreen")}
 							aria-label={t("buttons.addCameraFullscreen")}
 							disabled={!hasAnyCamera}
@@ -1473,6 +1593,14 @@ export function V4Timeline({
 								</div>
 								<div className={styles.tlLane}>{renderPills(trimPills, t("hints.pressTrim"))}</div>
 								<div className={styles.tlLane}>{renderPills(zoomPills, t("hints.pressZoom"))}</div>
+								<div className={styles.tlLane}>
+									{/* No shortcut hint here, unlike every lane above: this one cannot be
+									    filled by a keystroke at an arbitrary playhead. It needs recorded
+									    cursor telemetry and a click after the playhead to reach, so the
+									    toolbar button is the only entry point and it says why when it
+									    refuses. */}
+									{renderPills(cursorMotionPills, t("hints.cursorMotionEmpty"))}
+								</div>
 								<div className={styles.tlLane}>
 									{/* Advertising "Press C" on a project with no webcam invites a keystroke
 									    that `addCameraFullscreen` now refuses (#353). The toolbar button is

--- a/src/components/ai-edition/v4/V4Timeline.waveform.test.tsx
+++ b/src/components/ai-edition/v4/V4Timeline.waveform.test.tsx
@@ -111,6 +111,7 @@ function renderBars(atGainDb: number): string[] {
 		speedRegions: [],
 		cameraFullscreenRegions: [],
 		zoomRegions: [],
+		cursorMotionRegions: [],
 		trimRanges: [],
 		selection: null,
 		multiSelection: [],

--- a/src/i18n/locales/ar/settings.json
+++ b/src/i18n/locales/ar/settings.json
@@ -329,35 +329,35 @@
 		"help": "اضبط مستوى إخراج الصوت. يُطبَّق بالطريقة نفسها في المعاينة وعند التصدير."
 	},
 	"cursorMotion": {
-		"title": "Cursor Motion",
-		"preset": "Path preset",
+		"title": "حركة المؤشر",
+		"preset": "شكل المسار",
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "كما سُجّلت",
+			"straight": "مستقيم",
+			"arc": "قوس",
+			"wave": "موجة",
+			"loop": "حلقة",
+			"overshoot": "تجاوز"
 		},
-		"speed": "Movement speed",
-		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
-		"cycles": "Turns",
-		"easing": "Timing",
+		"speed": "سرعة الحركة",
+		"speedHint": "السرعات الأعلى تقطع المسافة مبكرًا وتستقر قرب الهدف. تنتهي المقطع دائمًا عند النقرة المسجلة، في وقتها الأصلي.",
+		"cycles": "الدورات",
+		"easing": "الإيقاع",
 		"easings": {
-			"linear": "Linear",
-			"ease-in-out": "Smooth",
-			"ease-in": "Accelerate",
-			"ease-out": "Decelerate"
+			"linear": "خطي",
+			"ease-in-out": "سلس",
+			"ease-in": "تسارع",
+			"ease-out": "تباطؤ"
 		},
-		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
-		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
-		"applyToAllMoves": "Apply to all move sections",
-		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
-		"splitAtPlayhead": "Split at playhead",
-		"splitOutsideRegion": "Move the playhead inside this section to split it.",
-		"delete": "Delete Cursor Motion",
-		"previousSection": "Previous section",
-		"nextSection": "Next section",
-		"sectionCounter": "Section {{current}} / {{total}}"
+		"anchorHint": "تبدأ المقاطع وتنتهي حيث توقف المؤشر أو نقر، لذا لا يمكن سحبها. قسّم مقطعًا لتحريك حدّ.",
+		"holdDescription": "يبقى المؤشر حيث توقف. لا شيء لتشكيله هنا — هذا المقطع هو ما يُبقيه ثابتًا بينما تُوجَّه الحركات من حوله.",
+		"applyToAllMoves": "تطبيق على كل مقاطع الحركة",
+		"appliedToAllMoves": "تم نسخ الشكل والسرعة والدورات والإيقاع إلى كل مقاطع الحركة.",
+		"splitAtPlayhead": "تقسيم عند رأس التشغيل",
+		"splitOutsideRegion": "انقل رأس التشغيل إلى داخل هذا المقطع لتقسيمه.",
+		"delete": "حذف حركة المؤشر",
+		"previousSection": "المقطع السابق",
+		"nextSection": "المقطع التالي",
+		"sectionCounter": "المقطع {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/ar/settings.json
+++ b/src/i18n/locales/ar/settings.json
@@ -327,5 +327,37 @@
 		"outputGain": "ضبط مستوى الإخراج",
 		"reset": "إعادة ضبط الصوت",
 		"help": "اضبط مستوى إخراج الصوت. يُطبَّق بالطريقة نفسها في المعاينة وعند التصدير."
+	},
+	"cursorMotion": {
+		"title": "Cursor Motion",
+		"preset": "Path preset",
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"speed": "Movement speed",
+		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
+		"cycles": "Turns",
+		"easing": "Timing",
+		"easings": {
+			"linear": "Linear",
+			"ease-in-out": "Smooth",
+			"ease-in": "Accelerate",
+			"ease-out": "Decelerate"
+		},
+		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
+		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
+		"applyToAllMoves": "Apply to all move sections",
+		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
+		"splitAtPlayhead": "Split at playhead",
+		"splitOutsideRegion": "Move the playhead inside this section to split it.",
+		"delete": "Delete Cursor Motion",
+		"previousSection": "Previous section",
+		"nextSection": "Next section",
+		"sectionCounter": "Section {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/ar/timeline.json
+++ b/src/i18n/locales/ar/timeline.json
@@ -9,14 +9,16 @@
 		"addTrim": "إضافة قص (T)",
 		"addAnnotation": "إضافة شرح (A)",
 		"addSpeed": "إضافة سرعة (S)",
-		"addCameraFullscreen": "إضافة كاميرا كاملة الشاشة (C)"
+		"addCameraFullscreen": "إضافة كاميرا كاملة الشاشة (C)",
+		"addCursorMotion": "Split cursor path into editable sections"
 	},
 	"hints": {
 		"pressZoom": "اضغط Z لإضافة تكبير",
 		"pressTrim": "اضغط T لإضافة قص",
 		"pressAnnotation": "اضغط A لإضافة شرح",
 		"pressSpeed": "اضغط S لإضافة سرعة",
-		"pressCameraFullscreen": "اضغط C لإضافة مقطع كاميرا كاملة الشاشة"
+		"pressCameraFullscreen": "اضغط C لإضافة مقطع كاميرا كاملة الشاشة",
+		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
 	},
 	"labels": {
 		"pan": "تحريك",
@@ -86,5 +88,23 @@
 		"smartCutsNoAudio": "لا يحتوي هذا الملف على صوت",
 		"smartCutsNoSpeech": "لم يتم اكتشاف كلام",
 		"smartCutsFailed": "فشل النسخ — أعد المحاولة من قسم الوسائط"
+	},
+	"cursorMotion": {
+		"segmentKinds": {
+			"move": "Move",
+			"hold": "Hold"
+		},
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"noCursorData": "This recording has no cursor data to direct.",
+		"noFollowingClick": "No recorded click after the playhead to move towards.",
+		"createdSegments": "Split the cursor path into {{count}} sections.",
+		"failed": "Could not read the cursor recording"
 	}
 }

--- a/src/i18n/locales/ar/timeline.json
+++ b/src/i18n/locales/ar/timeline.json
@@ -10,7 +10,7 @@
 		"addAnnotation": "إضافة شرح (A)",
 		"addSpeed": "إضافة سرعة (S)",
 		"addCameraFullscreen": "إضافة كاميرا كاملة الشاشة (C)",
-		"addCursorMotion": "Split cursor path into editable sections"
+		"addCursorMotion": "تقسيم مسار المؤشر إلى مقاطع قابلة للتحرير"
 	},
 	"hints": {
 		"pressZoom": "اضغط Z لإضافة تكبير",
@@ -18,7 +18,7 @@
 		"pressAnnotation": "اضغط A لإضافة شرح",
 		"pressSpeed": "اضغط S لإضافة سرعة",
 		"pressCameraFullscreen": "اضغط C لإضافة مقطع كاميرا كاملة الشاشة",
-		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
+		"cursorMotionEmpty": "ضع رأس التشغيل قبل بعض نشاط المؤشر، ثم استخدم أداة المسار"
 	},
 	"labels": {
 		"pan": "تحريك",
@@ -91,20 +91,20 @@
 	},
 	"cursorMotion": {
 		"segmentKinds": {
-			"move": "Move",
-			"hold": "Hold"
+			"move": "حركة",
+			"hold": "توقف"
 		},
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "كما سُجّلت",
+			"straight": "مستقيم",
+			"arc": "قوس",
+			"wave": "موجة",
+			"loop": "حلقة",
+			"overshoot": "تجاوز"
 		},
-		"noCursorData": "This recording has no cursor data to direct.",
-		"noFollowingClick": "No recorded click after the playhead to move towards.",
-		"createdSegments": "Split the cursor path into {{count}} sections.",
-		"failed": "Could not read the cursor recording"
+		"noCursorData": "لا يحتوي هذا التسجيل على بيانات مؤشر لتوجيهها.",
+		"noFollowingClick": "لا توجد نقرة مسجلة بعد رأس التشغيل للتحرك نحوها.",
+		"createdSegments": "تم تقسيم مسار المؤشر إلى {{count}} مقاطع.",
+		"failed": "تعذّرت قراءة تسجيل المؤشر"
 	}
 }

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -327,5 +327,37 @@
 		"lineLength": "Line length",
 		"minWords": "Min words per line",
 		"maxWords": "Max words per line"
+	},
+	"cursorMotion": {
+		"title": "Cursor Motion",
+		"preset": "Path preset",
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"speed": "Movement speed",
+		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
+		"cycles": "Turns",
+		"easing": "Timing",
+		"easings": {
+			"linear": "Linear",
+			"ease-in-out": "Smooth",
+			"ease-in": "Accelerate",
+			"ease-out": "Decelerate"
+		},
+		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
+		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
+		"applyToAllMoves": "Apply to all move sections",
+		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
+		"splitAtPlayhead": "Split at playhead",
+		"splitOutsideRegion": "Move the playhead inside this section to split it.",
+		"delete": "Delete Cursor Motion",
+		"previousSection": "Previous section",
+		"nextSection": "Next section",
+		"sectionCounter": "Section {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/en/timeline.json
+++ b/src/i18n/locales/en/timeline.json
@@ -9,14 +9,16 @@
 		"addTrim": "Add Trim (T)",
 		"addAnnotation": "Add Annotation (A)",
 		"addSpeed": "Add Speed (S)",
-		"addCameraFullscreen": "Add Full Camera (C)"
+		"addCameraFullscreen": "Add Full Camera (C)",
+		"addCursorMotion": "Split cursor path into editable sections"
 	},
 	"hints": {
 		"pressZoom": "Press Z to add zoom",
 		"pressTrim": "Press T to add trim",
 		"pressAnnotation": "Press A to add annotation",
 		"pressSpeed": "Press S to add speed",
-		"pressCameraFullscreen": "Press C to add a Full Camera segment"
+		"pressCameraFullscreen": "Press C to add a Full Camera segment",
+		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
 	},
 	"labels": {
 		"pan": "Pan",
@@ -86,5 +88,23 @@
 		"smartCutsNoAudio": "This media has no audio",
 		"smartCutsNoSpeech": "No speech detected",
 		"smartCutsFailed": "Transcription failed — retry it from Media"
+	},
+	"cursorMotion": {
+		"segmentKinds": {
+			"move": "Move",
+			"hold": "Hold"
+		},
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"noCursorData": "This recording has no cursor data to direct.",
+		"noFollowingClick": "No recorded click after the playhead to move towards.",
+		"createdSegments": "Split the cursor path into {{count}} sections.",
+		"failed": "Could not read the cursor recording"
 	}
 }

--- a/src/i18n/locales/es/settings.json
+++ b/src/i18n/locales/es/settings.json
@@ -329,35 +329,35 @@
 		"help": "Ajusta el nivel de salida del audio. Se aplica igual en la vista previa y en la exportación."
 	},
 	"cursorMotion": {
-		"title": "Cursor Motion",
-		"preset": "Path preset",
+		"title": "Movimiento del cursor",
+		"preset": "Forma del trayecto",
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "Grabado",
+			"straight": "Recta",
+			"arc": "Arco",
+			"wave": "Onda",
+			"loop": "Bucle",
+			"overshoot": "Sobrepaso"
 		},
-		"speed": "Movement speed",
-		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
-		"cycles": "Turns",
-		"easing": "Timing",
+		"speed": "Velocidad del movimiento",
+		"speedHint": "A mayor velocidad, el cursor recorre la distancia antes y se detiene cerca del objetivo. La sección termina igualmente en el clic grabado, en su instante original.",
+		"cycles": "Vueltas",
+		"easing": "Ritmo",
 		"easings": {
-			"linear": "Linear",
-			"ease-in-out": "Smooth",
-			"ease-in": "Accelerate",
-			"ease-out": "Decelerate"
+			"linear": "Lineal",
+			"ease-in-out": "Suave",
+			"ease-in": "Acelerar",
+			"ease-out": "Desacelerar"
 		},
-		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
-		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
-		"applyToAllMoves": "Apply to all move sections",
-		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
-		"splitAtPlayhead": "Split at playhead",
-		"splitOutsideRegion": "Move the playhead inside this section to split it.",
-		"delete": "Delete Cursor Motion",
-		"previousSection": "Previous section",
-		"nextSection": "Next section",
-		"sectionCounter": "Section {{current}} / {{total}}"
+		"anchorHint": "Las secciones empiezan y terminan donde el cursor se detuvo o hizo clic, así que no se pueden arrastrar. Divide una para mover un límite.",
+		"holdDescription": "El cursor se queda donde se detuvo. Aquí no hay nada que dar forma: esta sección es lo que lo mantiene quieto mientras se dirigen los movimientos a su alrededor.",
+		"applyToAllMoves": "Aplicar a todas las secciones de movimiento",
+		"appliedToAllMoves": "Forma, velocidad, vueltas y ritmo copiados a cada sección de movimiento.",
+		"splitAtPlayhead": "Dividir en el cabezal de reproducción",
+		"splitOutsideRegion": "Mueve el cabezal de reproducción dentro de esta sección para dividirla.",
+		"delete": "Eliminar movimiento del cursor",
+		"previousSection": "Sección anterior",
+		"nextSection": "Sección siguiente",
+		"sectionCounter": "Sección {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/es/settings.json
+++ b/src/i18n/locales/es/settings.json
@@ -327,5 +327,37 @@
 		"outputGain": "Ajuste de salida",
 		"reset": "Restablecer audio",
 		"help": "Ajusta el nivel de salida del audio. Se aplica igual en la vista previa y en la exportación."
+	},
+	"cursorMotion": {
+		"title": "Cursor Motion",
+		"preset": "Path preset",
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"speed": "Movement speed",
+		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
+		"cycles": "Turns",
+		"easing": "Timing",
+		"easings": {
+			"linear": "Linear",
+			"ease-in-out": "Smooth",
+			"ease-in": "Accelerate",
+			"ease-out": "Decelerate"
+		},
+		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
+		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
+		"applyToAllMoves": "Apply to all move sections",
+		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
+		"splitAtPlayhead": "Split at playhead",
+		"splitOutsideRegion": "Move the playhead inside this section to split it.",
+		"delete": "Delete Cursor Motion",
+		"previousSection": "Previous section",
+		"nextSection": "Next section",
+		"sectionCounter": "Section {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/es/timeline.json
+++ b/src/i18n/locales/es/timeline.json
@@ -10,7 +10,7 @@
 		"addAnnotation": "Agregar anotación (A)",
 		"addSpeed": "Agregar velocidad (S)",
 		"addCameraFullscreen": "Agregar cámara a pantalla completa (C)",
-		"addCursorMotion": "Split cursor path into editable sections"
+		"addCursorMotion": "Dividir la trayectoria del cursor en secciones editables"
 	},
 	"hints": {
 		"pressZoom": "Presiona Z para agregar zoom",
@@ -18,7 +18,7 @@
 		"pressAnnotation": "Presiona A para agregar anotación",
 		"pressSpeed": "Presiona S para agregar velocidad",
 		"pressCameraFullscreen": "Presiona C para agregar un segmento de cámara a pantalla completa",
-		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
+		"cursorMotionEmpty": "Coloca el cabezal de reproducción antes de alguna actividad del cursor y usa la herramienta de trayectoria"
 	},
 	"labels": {
 		"pan": "Desplazar",
@@ -91,20 +91,20 @@
 	},
 	"cursorMotion": {
 		"segmentKinds": {
-			"move": "Move",
-			"hold": "Hold"
+			"move": "Movimiento",
+			"hold": "Pausa"
 		},
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "Grabado",
+			"straight": "Recta",
+			"arc": "Arco",
+			"wave": "Onda",
+			"loop": "Bucle",
+			"overshoot": "Sobrepaso"
 		},
-		"noCursorData": "This recording has no cursor data to direct.",
-		"noFollowingClick": "No recorded click after the playhead to move towards.",
-		"createdSegments": "Split the cursor path into {{count}} sections.",
-		"failed": "Could not read the cursor recording"
+		"noCursorData": "Esta grabación no tiene datos de cursor que dirigir.",
+		"noFollowingClick": "No hay ningún clic grabado después del cabezal de reproducción hacia el que moverse.",
+		"createdSegments": "Trayectoria del cursor dividida en {{count}} secciones.",
+		"failed": "No se pudo leer la grabación del cursor"
 	}
 }

--- a/src/i18n/locales/es/timeline.json
+++ b/src/i18n/locales/es/timeline.json
@@ -9,14 +9,16 @@
 		"addTrim": "Agregar recorte (T)",
 		"addAnnotation": "Agregar anotación (A)",
 		"addSpeed": "Agregar velocidad (S)",
-		"addCameraFullscreen": "Agregar cámara a pantalla completa (C)"
+		"addCameraFullscreen": "Agregar cámara a pantalla completa (C)",
+		"addCursorMotion": "Split cursor path into editable sections"
 	},
 	"hints": {
 		"pressZoom": "Presiona Z para agregar zoom",
 		"pressTrim": "Presiona T para agregar recorte",
 		"pressAnnotation": "Presiona A para agregar anotación",
 		"pressSpeed": "Presiona S para agregar velocidad",
-		"pressCameraFullscreen": "Presiona C para agregar un segmento de cámara a pantalla completa"
+		"pressCameraFullscreen": "Presiona C para agregar un segmento de cámara a pantalla completa",
+		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
 	},
 	"labels": {
 		"pan": "Desplazar",
@@ -86,5 +88,23 @@
 		"smartCutsNoAudio": "Este medio no tiene audio",
 		"smartCutsNoSpeech": "No se detectó voz",
 		"smartCutsFailed": "La transcripción falló: reinténtala desde Medios"
+	},
+	"cursorMotion": {
+		"segmentKinds": {
+			"move": "Move",
+			"hold": "Hold"
+		},
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"noCursorData": "This recording has no cursor data to direct.",
+		"noFollowingClick": "No recorded click after the playhead to move towards.",
+		"createdSegments": "Split the cursor path into {{count}} sections.",
+		"failed": "Could not read the cursor recording"
 	}
 }

--- a/src/i18n/locales/fr/settings.json
+++ b/src/i18n/locales/fr/settings.json
@@ -327,5 +327,37 @@
 		"outputGain": "Niveau de sortie",
 		"reset": "Réinitialiser l’audio",
 		"help": "Ajustez le niveau de sortie audio. Il s’applique à l’identique dans l’aperçu et à l’export."
+	},
+	"cursorMotion": {
+		"title": "Trajectoire du curseur",
+		"preset": "Forme du tracé",
+		"presets": {
+			"recorded": "Enregistrée",
+			"straight": "Droite",
+			"arc": "Arc",
+			"wave": "Vague",
+			"loop": "Boucle",
+			"overshoot": "Dépassement"
+		},
+		"speed": "Vitesse du mouvement",
+		"speedHint": "Plus la vitesse est élevée, plus le curseur couvre la distance tôt puis se pose près de la cible. La section se termine toujours sur le clic enregistré, à son instant d'origine.",
+		"cycles": "Tours",
+		"easing": "Progression",
+		"easings": {
+			"linear": "Linéaire",
+			"ease-in-out": "Douce",
+			"ease-in": "Accélération",
+			"ease-out": "Décélération"
+		},
+		"anchorHint": "Une section commence et finit là où le curseur s'est arrêté ou a cliqué : elle ne se déplace donc pas. Découpez-la pour changer une limite.",
+		"holdDescription": "Le curseur reste où il s'est arrêté. Rien à modeler ici : cette section est ce qui le maintient immobile pendant que les mouvements autour sont dirigés.",
+		"applyToAllMoves": "Appliquer à toutes les sections de mouvement",
+		"appliedToAllMoves": "Forme, vitesse, tours et progression copiés sur chaque section de mouvement.",
+		"splitAtPlayhead": "Découper à la tête de lecture",
+		"splitOutsideRegion": "Placez la tête de lecture dans cette section pour la découper.",
+		"delete": "Supprimer la trajectoire",
+		"previousSection": "Section précédente",
+		"nextSection": "Section suivante",
+		"sectionCounter": "Section {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/fr/timeline.json
+++ b/src/i18n/locales/fr/timeline.json
@@ -9,14 +9,16 @@
 		"addTrim": "Ajouter une coupe (T)",
 		"addAnnotation": "Ajouter une annotation (A)",
 		"addSpeed": "Ajouter une vitesse (S)",
-		"addCameraFullscreen": "Ajouter Caméra plein écran (C)"
+		"addCameraFullscreen": "Ajouter Caméra plein écran (C)",
+		"addCursorMotion": "Découper la trajectoire du curseur en sections éditables"
 	},
 	"hints": {
 		"pressZoom": "Appuyez sur Z pour ajouter un zoom",
 		"pressTrim": "Appuyez sur T pour ajouter une coupe",
 		"pressAnnotation": "Appuyez sur A pour ajouter une annotation",
 		"pressSpeed": "Appuyez sur S pour ajouter une vitesse",
-		"pressCameraFullscreen": "Appuyez sur C pour ajouter un segment Caméra plein écran"
+		"pressCameraFullscreen": "Appuyez sur C pour ajouter un segment Caméra plein écran",
+		"cursorMotionEmpty": "Placez la tête de lecture avant une activité du curseur, puis utilisez l'outil tracé"
 	},
 	"labels": {
 		"pan": "Panoramique",
@@ -86,5 +88,23 @@
 		"smartCutsNoAudio": "Ce média n'a pas d'audio",
 		"smartCutsNoSpeech": "Aucune parole détectée",
 		"smartCutsFailed": "Échec de la transcription — relancez-la depuis Médias"
+	},
+	"cursorMotion": {
+		"segmentKinds": {
+			"move": "Mouvement",
+			"hold": "Pause"
+		},
+		"presets": {
+			"recorded": "Enregistrée",
+			"straight": "Droite",
+			"arc": "Arc",
+			"wave": "Vague",
+			"loop": "Boucle",
+			"overshoot": "Dépassement"
+		},
+		"noCursorData": "Cet enregistrement n'a aucune donnée de curseur à diriger.",
+		"noFollowingClick": "Aucun clic enregistré après la tête de lecture.",
+		"createdSegments": "Trajectoire découpée en {{count}} sections.",
+		"failed": "Lecture de l'enregistrement du curseur impossible"
 	}
 }

--- a/src/i18n/locales/it/settings.json
+++ b/src/i18n/locales/it/settings.json
@@ -329,35 +329,35 @@
 		"help": "Regola il livello di uscita audio. Si applica allo stesso modo nell’anteprima e nell’esportazione."
 	},
 	"cursorMotion": {
-		"title": "Cursor Motion",
-		"preset": "Path preset",
+		"title": "Movimento del cursore",
+		"preset": "Forma del tracciato",
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "Registrata",
+			"straight": "Retta",
+			"arc": "Arco",
+			"wave": "Onda",
+			"loop": "Ciclo",
+			"overshoot": "Sforo"
 		},
-		"speed": "Movement speed",
-		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
-		"cycles": "Turns",
-		"easing": "Timing",
+		"speed": "Velocità del movimento",
+		"speedHint": "Con velocità più alte il cursore copre la distanza in anticipo e si ferma vicino al bersaglio. La sezione termina comunque sul clic registrato, al suo istante originale.",
+		"cycles": "Giri",
+		"easing": "Andamento",
 		"easings": {
-			"linear": "Linear",
-			"ease-in-out": "Smooth",
-			"ease-in": "Accelerate",
-			"ease-out": "Decelerate"
+			"linear": "Lineare",
+			"ease-in-out": "Fluido",
+			"ease-in": "Accelerazione",
+			"ease-out": "Decelerazione"
 		},
-		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
-		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
-		"applyToAllMoves": "Apply to all move sections",
-		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
-		"splitAtPlayhead": "Split at playhead",
-		"splitOutsideRegion": "Move the playhead inside this section to split it.",
-		"delete": "Delete Cursor Motion",
-		"previousSection": "Previous section",
-		"nextSection": "Next section",
-		"sectionCounter": "Section {{current}} / {{total}}"
+		"anchorHint": "Le sezioni iniziano e terminano dove il cursore si è fermato o ha fatto clic, quindi non si possono trascinare. Dividine una per spostare un limite.",
+		"holdDescription": "Il cursore resta dove si è fermato. Qui non c'è nulla da modellare: questa sezione è ciò che lo mantiene fermo mentre i movimenti intorno vengono diretti.",
+		"applyToAllMoves": "Applica a tutte le sezioni di movimento",
+		"appliedToAllMoves": "Forma, velocità, giri e andamento copiati su ogni sezione di movimento.",
+		"splitAtPlayhead": "Dividi sulla testina di riproduzione",
+		"splitOutsideRegion": "Sposta la testina di riproduzione dentro questa sezione per dividerla.",
+		"delete": "Elimina movimento del cursore",
+		"previousSection": "Sezione precedente",
+		"nextSection": "Sezione successiva",
+		"sectionCounter": "Sezione {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/it/settings.json
+++ b/src/i18n/locales/it/settings.json
@@ -327,5 +327,37 @@
 		"outputGain": "Livello di uscita",
 		"reset": "Reimposta audio",
 		"help": "Regola il livello di uscita audio. Si applica allo stesso modo nell’anteprima e nell’esportazione."
+	},
+	"cursorMotion": {
+		"title": "Cursor Motion",
+		"preset": "Path preset",
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"speed": "Movement speed",
+		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
+		"cycles": "Turns",
+		"easing": "Timing",
+		"easings": {
+			"linear": "Linear",
+			"ease-in-out": "Smooth",
+			"ease-in": "Accelerate",
+			"ease-out": "Decelerate"
+		},
+		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
+		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
+		"applyToAllMoves": "Apply to all move sections",
+		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
+		"splitAtPlayhead": "Split at playhead",
+		"splitOutsideRegion": "Move the playhead inside this section to split it.",
+		"delete": "Delete Cursor Motion",
+		"previousSection": "Previous section",
+		"nextSection": "Next section",
+		"sectionCounter": "Section {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/it/timeline.json
+++ b/src/i18n/locales/it/timeline.json
@@ -9,14 +9,16 @@
 		"addTrim": "Aggiungi taglio (T)",
 		"addAnnotation": "Aggiungi annotazione (A)",
 		"addSpeed": "Aggiungi velocità (S)",
-		"addCameraFullscreen": "Aggiungi Camera a schermo intero (C)"
+		"addCameraFullscreen": "Aggiungi Camera a schermo intero (C)",
+		"addCursorMotion": "Split cursor path into editable sections"
 	},
 	"hints": {
 		"pressZoom": "Premi Z per aggiungere zoom",
 		"pressTrim": "Premi T per aggiungere taglio",
 		"pressAnnotation": "Premi A per aggiungere annotazione",
 		"pressSpeed": "Premi S per aggiungere velocità",
-		"pressCameraFullscreen": "Premi C per aggiungere un segmento Camera a schermo intero"
+		"pressCameraFullscreen": "Premi C per aggiungere un segmento Camera a schermo intero",
+		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
 	},
 	"labels": {
 		"pan": "Panoramica",
@@ -86,5 +88,23 @@
 		"smartCutsNoAudio": "Questo contenuto non ha audio",
 		"smartCutsNoSpeech": "Nessun parlato rilevato",
 		"smartCutsFailed": "Trascrizione non riuscita: riprova da Contenuti multimediali"
+	},
+	"cursorMotion": {
+		"segmentKinds": {
+			"move": "Move",
+			"hold": "Hold"
+		},
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"noCursorData": "This recording has no cursor data to direct.",
+		"noFollowingClick": "No recorded click after the playhead to move towards.",
+		"createdSegments": "Split the cursor path into {{count}} sections.",
+		"failed": "Could not read the cursor recording"
 	}
 }

--- a/src/i18n/locales/it/timeline.json
+++ b/src/i18n/locales/it/timeline.json
@@ -10,7 +10,7 @@
 		"addAnnotation": "Aggiungi annotazione (A)",
 		"addSpeed": "Aggiungi velocità (S)",
 		"addCameraFullscreen": "Aggiungi Camera a schermo intero (C)",
-		"addCursorMotion": "Split cursor path into editable sections"
+		"addCursorMotion": "Dividi il tracciato del cursore in sezioni modificabili"
 	},
 	"hints": {
 		"pressZoom": "Premi Z per aggiungere zoom",
@@ -18,7 +18,7 @@
 		"pressAnnotation": "Premi A per aggiungere annotazione",
 		"pressSpeed": "Premi S per aggiungere velocità",
 		"pressCameraFullscreen": "Premi C per aggiungere un segmento Camera a schermo intero",
-		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
+		"cursorMotionEmpty": "Posiziona la testina di riproduzione prima di un'attività del cursore, poi usa lo strumento tracciato"
 	},
 	"labels": {
 		"pan": "Panoramica",
@@ -91,20 +91,20 @@
 	},
 	"cursorMotion": {
 		"segmentKinds": {
-			"move": "Move",
-			"hold": "Hold"
+			"move": "Movimento",
+			"hold": "Pausa"
 		},
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "Registrata",
+			"straight": "Retta",
+			"arc": "Arco",
+			"wave": "Onda",
+			"loop": "Ciclo",
+			"overshoot": "Sforo"
 		},
-		"noCursorData": "This recording has no cursor data to direct.",
-		"noFollowingClick": "No recorded click after the playhead to move towards.",
-		"createdSegments": "Split the cursor path into {{count}} sections.",
-		"failed": "Could not read the cursor recording"
+		"noCursorData": "Questa registrazione non ha dati del cursore da dirigere.",
+		"noFollowingClick": "Nessun clic registrato dopo la testina di riproduzione verso cui muoversi.",
+		"createdSegments": "Tracciato del cursore diviso in {{count}} sezioni.",
+		"failed": "Impossibile leggere la registrazione del cursore"
 	}
 }

--- a/src/i18n/locales/ja-JP/settings.json
+++ b/src/i18n/locales/ja-JP/settings.json
@@ -327,5 +327,37 @@
 		"outputGain": "出力レベル",
 		"reset": "オーディオをリセット",
 		"help": "音声の出力レベルを調整します。プレビューと書き出しで同じように適用されます。"
+	},
+	"cursorMotion": {
+		"title": "Cursor Motion",
+		"preset": "Path preset",
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"speed": "Movement speed",
+		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
+		"cycles": "Turns",
+		"easing": "Timing",
+		"easings": {
+			"linear": "Linear",
+			"ease-in-out": "Smooth",
+			"ease-in": "Accelerate",
+			"ease-out": "Decelerate"
+		},
+		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
+		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
+		"applyToAllMoves": "Apply to all move sections",
+		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
+		"splitAtPlayhead": "Split at playhead",
+		"splitOutsideRegion": "Move the playhead inside this section to split it.",
+		"delete": "Delete Cursor Motion",
+		"previousSection": "Previous section",
+		"nextSection": "Next section",
+		"sectionCounter": "Section {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/ja-JP/settings.json
+++ b/src/i18n/locales/ja-JP/settings.json
@@ -329,35 +329,35 @@
 		"help": "音声の出力レベルを調整します。プレビューと書き出しで同じように適用されます。"
 	},
 	"cursorMotion": {
-		"title": "Cursor Motion",
-		"preset": "Path preset",
+		"title": "カーソルの動き",
+		"preset": "パスの形状",
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "録画通り",
+			"straight": "直線",
+			"arc": "弧",
+			"wave": "波",
+			"loop": "ループ",
+			"overshoot": "オーバーシュート"
 		},
-		"speed": "Movement speed",
-		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
-		"cycles": "Turns",
-		"easing": "Timing",
+		"speed": "移動速度",
+		"speedHint": "速度を上げるほど、カーソルは早く距離をカバーして目標付近に落ち着きます。セクションは常に録画されたクリックの時刻どおりに終わります。",
+		"cycles": "周回数",
+		"easing": "タイミング",
 		"easings": {
-			"linear": "Linear",
-			"ease-in-out": "Smooth",
-			"ease-in": "Accelerate",
-			"ease-out": "Decelerate"
+			"linear": "リニア",
+			"ease-in-out": "スムーズ",
+			"ease-in": "加速",
+			"ease-out": "減速"
 		},
-		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
-		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
-		"applyToAllMoves": "Apply to all move sections",
-		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
-		"splitAtPlayhead": "Split at playhead",
-		"splitOutsideRegion": "Move the playhead inside this section to split it.",
-		"delete": "Delete Cursor Motion",
-		"previousSection": "Previous section",
-		"nextSection": "Next section",
-		"sectionCounter": "Section {{current}} / {{total}}"
+		"anchorHint": "セクションはカーソルが停止またはクリックした位置で始まり終わるため、ドラッグできません。境界を動かすには分割してください。",
+		"holdDescription": "カーソルは停止した位置にとどまります。ここで形を変えるものはありません。このセクションが、周囲の動きを演出している間の静止を担っています。",
+		"applyToAllMoves": "すべての移動セクションに適用",
+		"appliedToAllMoves": "形状・速度・周回数・タイミングをすべての移動セクションにコピーしました。",
+		"splitAtPlayhead": "再生ヘッドで分割",
+		"splitOutsideRegion": "分割するには、再生ヘッドをこのセクション内に移動してください。",
+		"delete": "カーソルの動きを削除",
+		"previousSection": "前のセクション",
+		"nextSection": "次のセクション",
+		"sectionCounter": "セクション {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/ja-JP/timeline.json
+++ b/src/i18n/locales/ja-JP/timeline.json
@@ -10,7 +10,7 @@
 		"addAnnotation": "注釈を追加 (A)",
 		"addSpeed": "再生速度を追加 (S)",
 		"addCameraFullscreen": "フルスクリーンカメラを追加 (C)",
-		"addCursorMotion": "Split cursor path into editable sections"
+		"addCursorMotion": "カーソルパスを編集可能なセクションに分割"
 	},
 	"hints": {
 		"pressZoom": "Zキーを押してズームを追加",
@@ -18,7 +18,7 @@
 		"pressAnnotation": "Aキーを押して注釈を追加",
 		"pressSpeed": "Sキーを押して再生速度を追加",
 		"pressCameraFullscreen": "Cキーを押してフルスクリーンカメラのセグメントを追加",
-		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
+		"cursorMotionEmpty": "再生ヘッドをカーソルの動きの前に置いてから、パスツールを使用してください"
 	},
 	"labels": {
 		"pan": "移動",
@@ -91,20 +91,20 @@
 	},
 	"cursorMotion": {
 		"segmentKinds": {
-			"move": "Move",
-			"hold": "Hold"
+			"move": "移動",
+			"hold": "静止"
 		},
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "録画通り",
+			"straight": "直線",
+			"arc": "弧",
+			"wave": "波",
+			"loop": "ループ",
+			"overshoot": "オーバーシュート"
 		},
-		"noCursorData": "This recording has no cursor data to direct.",
-		"noFollowingClick": "No recorded click after the playhead to move towards.",
-		"createdSegments": "Split the cursor path into {{count}} sections.",
-		"failed": "Could not read the cursor recording"
+		"noCursorData": "この録画には演出できるカーソルデータがありません。",
+		"noFollowingClick": "再生ヘッドより後ろに、目標にできる録画済みクリックがありません。",
+		"createdSegments": "カーソルパスを {{count}} 個のセクションに分割しました。",
+		"failed": "カーソルの録画データを読み込めませんでした"
 	}
 }

--- a/src/i18n/locales/ja-JP/timeline.json
+++ b/src/i18n/locales/ja-JP/timeline.json
@@ -9,14 +9,16 @@
 		"addTrim": "トリムを追加 (T)",
 		"addAnnotation": "注釈を追加 (A)",
 		"addSpeed": "再生速度を追加 (S)",
-		"addCameraFullscreen": "フルスクリーンカメラを追加 (C)"
+		"addCameraFullscreen": "フルスクリーンカメラを追加 (C)",
+		"addCursorMotion": "Split cursor path into editable sections"
 	},
 	"hints": {
 		"pressZoom": "Zキーを押してズームを追加",
 		"pressTrim": "Tキーを押してトリムを追加",
 		"pressAnnotation": "Aキーを押して注釈を追加",
 		"pressSpeed": "Sキーを押して再生速度を追加",
-		"pressCameraFullscreen": "Cキーを押してフルスクリーンカメラのセグメントを追加"
+		"pressCameraFullscreen": "Cキーを押してフルスクリーンカメラのセグメントを追加",
+		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
 	},
 	"labels": {
 		"pan": "移動",
@@ -86,5 +88,23 @@
 		"smartCutsNoAudio": "このメディアには音声がありません",
 		"smartCutsNoSpeech": "音声が検出されませんでした",
 		"smartCutsFailed": "文字起こしに失敗しました — メディアから再試行してください"
+	},
+	"cursorMotion": {
+		"segmentKinds": {
+			"move": "Move",
+			"hold": "Hold"
+		},
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"noCursorData": "This recording has no cursor data to direct.",
+		"noFollowingClick": "No recorded click after the playhead to move towards.",
+		"createdSegments": "Split the cursor path into {{count}} sections.",
+		"failed": "Could not read the cursor recording"
 	}
 }

--- a/src/i18n/locales/ko-KR/settings.json
+++ b/src/i18n/locales/ko-KR/settings.json
@@ -329,35 +329,35 @@
 		"help": "오디오 출력 레벨을 조정합니다. 미리보기와 내보내기에 동일하게 적용됩니다."
 	},
 	"cursorMotion": {
-		"title": "Cursor Motion",
-		"preset": "Path preset",
+		"title": "커서 움직임",
+		"preset": "경로 모양",
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "녹화 그대로",
+			"straight": "직선",
+			"arc": "호",
+			"wave": "물결",
+			"loop": "루프",
+			"overshoot": "오버슈트"
 		},
-		"speed": "Movement speed",
-		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
-		"cycles": "Turns",
-		"easing": "Timing",
+		"speed": "이동 속도",
+		"speedHint": "속도가 높을수록 커서가 거리를 일찍 이동하고 대상 근처에 안정됩니다. 구간은 항상 녹화된 클릭 시점에 그대로 끝납니다.",
+		"cycles": "회전 수",
+		"easing": "타이밍",
 		"easings": {
-			"linear": "Linear",
-			"ease-in-out": "Smooth",
-			"ease-in": "Accelerate",
-			"ease-out": "Decelerate"
+			"linear": "선형",
+			"ease-in-out": "부드럽게",
+			"ease-in": "가속",
+			"ease-out": "감속"
 		},
-		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
-		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
-		"applyToAllMoves": "Apply to all move sections",
-		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
-		"splitAtPlayhead": "Split at playhead",
-		"splitOutsideRegion": "Move the playhead inside this section to split it.",
-		"delete": "Delete Cursor Motion",
-		"previousSection": "Previous section",
-		"nextSection": "Next section",
-		"sectionCounter": "Section {{current}} / {{total}}"
+		"anchorHint": "구간은 커서가 멈추거나 클릭한 지점에서 시작하고 끝나므로 드래그할 수 없습니다. 경계를 옮기려면 구간을 나누세요.",
+		"holdDescription": "커서는 멈춘 위치에 그대로 있습니다. 여기서 모양을 바꿀 것은 없습니다. 이 구간이 주변 움직임이 연출되는 동안 커서를 가만히 두는 역할을 합니다.",
+		"applyToAllMoves": "모든 이동 구간에 적용",
+		"appliedToAllMoves": "모양, 속도, 회전 수, 타이밍을 모든 이동 구간에 복사했습니다.",
+		"splitAtPlayhead": "재생 헤드에서 나누기",
+		"splitOutsideRegion": "나누려면 재생 헤드를 이 구간 안으로 옮기세요.",
+		"delete": "커서 움직임 삭제",
+		"previousSection": "이전 구간",
+		"nextSection": "다음 구간",
+		"sectionCounter": "구간 {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/ko-KR/settings.json
+++ b/src/i18n/locales/ko-KR/settings.json
@@ -327,5 +327,37 @@
 		"outputGain": "출력 레벨",
 		"reset": "오디오 재설정",
 		"help": "오디오 출력 레벨을 조정합니다. 미리보기와 내보내기에 동일하게 적용됩니다."
+	},
+	"cursorMotion": {
+		"title": "Cursor Motion",
+		"preset": "Path preset",
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"speed": "Movement speed",
+		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
+		"cycles": "Turns",
+		"easing": "Timing",
+		"easings": {
+			"linear": "Linear",
+			"ease-in-out": "Smooth",
+			"ease-in": "Accelerate",
+			"ease-out": "Decelerate"
+		},
+		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
+		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
+		"applyToAllMoves": "Apply to all move sections",
+		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
+		"splitAtPlayhead": "Split at playhead",
+		"splitOutsideRegion": "Move the playhead inside this section to split it.",
+		"delete": "Delete Cursor Motion",
+		"previousSection": "Previous section",
+		"nextSection": "Next section",
+		"sectionCounter": "Section {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/ko-KR/timeline.json
+++ b/src/i18n/locales/ko-KR/timeline.json
@@ -10,7 +10,7 @@
 		"addAnnotation": "주석 추가 (A)",
 		"addSpeed": "속도 추가 (S)",
 		"addCameraFullscreen": "전체 화면 카메라 추가 (C)",
-		"addCursorMotion": "Split cursor path into editable sections"
+		"addCursorMotion": "커서 경로를 편집 가능한 구간으로 나누기"
 	},
 	"hints": {
 		"pressZoom": "Z를 눌러 줌 추가",
@@ -18,7 +18,7 @@
 		"pressAnnotation": "A를 눌러 주석 추가",
 		"pressSpeed": "S를 눌러 속도 추가",
 		"pressCameraFullscreen": "C를 눌러 전체 화면 카메라 구간을 추가하세요",
-		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
+		"cursorMotionEmpty": "재생 헤드를 커서 활동 이전 위치에 둔 뒤 경로 도구를 사용하세요"
 	},
 	"labels": {
 		"pan": "이동",
@@ -91,20 +91,20 @@
 	},
 	"cursorMotion": {
 		"segmentKinds": {
-			"move": "Move",
-			"hold": "Hold"
+			"move": "이동",
+			"hold": "정지"
 		},
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "녹화 그대로",
+			"straight": "직선",
+			"arc": "호",
+			"wave": "물결",
+			"loop": "루프",
+			"overshoot": "오버슈트"
 		},
-		"noCursorData": "This recording has no cursor data to direct.",
-		"noFollowingClick": "No recorded click after the playhead to move towards.",
-		"createdSegments": "Split the cursor path into {{count}} sections.",
-		"failed": "Could not read the cursor recording"
+		"noCursorData": "이 녹화에는 연출할 커서 데이터가 없습니다.",
+		"noFollowingClick": "재생 헤드 이후에 이동할 대상인 녹화된 클릭이 없습니다.",
+		"createdSegments": "커서 경로를 {{count}}개 구간으로 나눴습니다.",
+		"failed": "커서 녹화를 읽지 못했습니다"
 	}
 }

--- a/src/i18n/locales/ko-KR/timeline.json
+++ b/src/i18n/locales/ko-KR/timeline.json
@@ -9,14 +9,16 @@
 		"addTrim": "트림 추가 (T)",
 		"addAnnotation": "주석 추가 (A)",
 		"addSpeed": "속도 추가 (S)",
-		"addCameraFullscreen": "전체 화면 카메라 추가 (C)"
+		"addCameraFullscreen": "전체 화면 카메라 추가 (C)",
+		"addCursorMotion": "Split cursor path into editable sections"
 	},
 	"hints": {
 		"pressZoom": "Z를 눌러 줌 추가",
 		"pressTrim": "T를 눌러 트림 추가",
 		"pressAnnotation": "A를 눌러 주석 추가",
 		"pressSpeed": "S를 눌러 속도 추가",
-		"pressCameraFullscreen": "C를 눌러 전체 화면 카메라 구간을 추가하세요"
+		"pressCameraFullscreen": "C를 눌러 전체 화면 카메라 구간을 추가하세요",
+		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
 	},
 	"labels": {
 		"pan": "이동",
@@ -86,5 +88,23 @@
 		"smartCutsNoAudio": "이 미디어에는 오디오가 없습니다",
 		"smartCutsNoSpeech": "음성이 감지되지 않음",
 		"smartCutsFailed": "받아쓰기에 실패했습니다 — 미디어에서 다시 시도하세요"
+	},
+	"cursorMotion": {
+		"segmentKinds": {
+			"move": "Move",
+			"hold": "Hold"
+		},
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"noCursorData": "This recording has no cursor data to direct.",
+		"noFollowingClick": "No recorded click after the playhead to move towards.",
+		"createdSegments": "Split the cursor path into {{count}} sections.",
+		"failed": "Could not read the cursor recording"
 	}
 }

--- a/src/i18n/locales/pt-BR/settings.json
+++ b/src/i18n/locales/pt-BR/settings.json
@@ -327,5 +327,37 @@
 		"outputGain": "Nível de saída",
 		"reset": "Redefinir áudio",
 		"help": "Ajuste o nível de saída do áudio. Ele se aplica da mesma forma na prévia e na exportação."
+	},
+	"cursorMotion": {
+		"title": "Cursor Motion",
+		"preset": "Path preset",
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"speed": "Movement speed",
+		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
+		"cycles": "Turns",
+		"easing": "Timing",
+		"easings": {
+			"linear": "Linear",
+			"ease-in-out": "Smooth",
+			"ease-in": "Accelerate",
+			"ease-out": "Decelerate"
+		},
+		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
+		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
+		"applyToAllMoves": "Apply to all move sections",
+		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
+		"splitAtPlayhead": "Split at playhead",
+		"splitOutsideRegion": "Move the playhead inside this section to split it.",
+		"delete": "Delete Cursor Motion",
+		"previousSection": "Previous section",
+		"nextSection": "Next section",
+		"sectionCounter": "Section {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/pt-BR/settings.json
+++ b/src/i18n/locales/pt-BR/settings.json
@@ -329,35 +329,35 @@
 		"help": "Ajuste o nível de saída do áudio. Ele se aplica da mesma forma na prévia e na exportação."
 	},
 	"cursorMotion": {
-		"title": "Cursor Motion",
-		"preset": "Path preset",
+		"title": "Movimento do cursor",
+		"preset": "Forma do trajeto",
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "Gravado",
+			"straight": "Reta",
+			"arc": "Arco",
+			"wave": "Onda",
+			"loop": "Laço",
+			"overshoot": "Ultrapassagem"
 		},
-		"speed": "Movement speed",
-		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
-		"cycles": "Turns",
-		"easing": "Timing",
+		"speed": "Velocidade do movimento",
+		"speedHint": "Velocidades mais altas cobrem a distância mais cedo e assentam perto do alvo. A seção ainda termina no clique gravado, no momento original.",
+		"cycles": "Voltas",
+		"easing": "Ritmo",
 		"easings": {
 			"linear": "Linear",
-			"ease-in-out": "Smooth",
-			"ease-in": "Accelerate",
-			"ease-out": "Decelerate"
+			"ease-in-out": "Suave",
+			"ease-in": "Acelerar",
+			"ease-out": "Desacelerar"
 		},
-		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
-		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
-		"applyToAllMoves": "Apply to all move sections",
-		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
-		"splitAtPlayhead": "Split at playhead",
-		"splitOutsideRegion": "Move the playhead inside this section to split it.",
-		"delete": "Delete Cursor Motion",
-		"previousSection": "Previous section",
-		"nextSection": "Next section",
-		"sectionCounter": "Section {{current}} / {{total}}"
+		"anchorHint": "As seções começam e terminam onde o cursor parou ou clicou, por isso não podem ser arrastadas. Divida uma para mover um limite.",
+		"holdDescription": "O cursor fica onde parou. Não há nada para moldar aqui — esta seção é o que o mantém parado enquanto os movimentos ao redor são dirigidos.",
+		"applyToAllMoves": "Aplicar a todas as seções de movimento",
+		"appliedToAllMoves": "Forma, velocidade, voltas e ritmo copiados para cada seção de movimento.",
+		"splitAtPlayhead": "Dividir no cursor de reprodução",
+		"splitOutsideRegion": "Mova o cursor de reprodução para dentro desta seção para dividi-la.",
+		"delete": "Excluir movimento do cursor",
+		"previousSection": "Seção anterior",
+		"nextSection": "Próxima seção",
+		"sectionCounter": "Seção {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/pt-BR/timeline.json
+++ b/src/i18n/locales/pt-BR/timeline.json
@@ -10,7 +10,7 @@
 		"addAnnotation": "Adicionar Anotação (A)",
 		"addSpeed": "Adicionar Velocidade (S)",
 		"addCameraFullscreen": "Adicionar Câmera em Tela Cheia (C)",
-		"addCursorMotion": "Split cursor path into editable sections"
+		"addCursorMotion": "Dividir a trajetória do cursor em seções editáveis"
 	},
 	"hints": {
 		"pressZoom": "Pressione Z para adicionar zoom",
@@ -18,7 +18,7 @@
 		"pressAnnotation": "Pressione A para adicionar anotação",
 		"pressSpeed": "Pressione S para adicionar velocidade",
 		"pressCameraFullscreen": "Pressione C para adicionar um segmento de Câmera em Tela Cheia",
-		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
+		"cursorMotionEmpty": "Posicione o cursor de reprodução antes de alguma atividade do ponteiro do mouse e use a ferramenta de trajetória"
 	},
 	"labels": {
 		"pan": "Mover",
@@ -91,20 +91,20 @@
 	},
 	"cursorMotion": {
 		"segmentKinds": {
-			"move": "Move",
-			"hold": "Hold"
+			"move": "Movimento",
+			"hold": "Pausa"
 		},
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "Gravado",
+			"straight": "Reta",
+			"arc": "Arco",
+			"wave": "Onda",
+			"loop": "Laço",
+			"overshoot": "Ultrapassagem"
 		},
-		"noCursorData": "This recording has no cursor data to direct.",
-		"noFollowingClick": "No recorded click after the playhead to move towards.",
-		"createdSegments": "Split the cursor path into {{count}} sections.",
-		"failed": "Could not read the cursor recording"
+		"noCursorData": "Esta gravação não tem dados de cursor para dirigir.",
+		"noFollowingClick": "Nenhum clique gravado após o cursor de reprodução para mover em direção.",
+		"createdSegments": "Trajetória do cursor dividida em {{count}} seções.",
+		"failed": "Não foi possível ler a gravação do cursor"
 	}
 }

--- a/src/i18n/locales/pt-BR/timeline.json
+++ b/src/i18n/locales/pt-BR/timeline.json
@@ -9,14 +9,16 @@
 		"addTrim": "Adicionar Recorte (T)",
 		"addAnnotation": "Adicionar Anotação (A)",
 		"addSpeed": "Adicionar Velocidade (S)",
-		"addCameraFullscreen": "Adicionar Câmera em Tela Cheia (C)"
+		"addCameraFullscreen": "Adicionar Câmera em Tela Cheia (C)",
+		"addCursorMotion": "Split cursor path into editable sections"
 	},
 	"hints": {
 		"pressZoom": "Pressione Z para adicionar zoom",
 		"pressTrim": "Pressione T para adicionar recorte",
 		"pressAnnotation": "Pressione A para adicionar anotação",
 		"pressSpeed": "Pressione S para adicionar velocidade",
-		"pressCameraFullscreen": "Pressione C para adicionar um segmento de Câmera em Tela Cheia"
+		"pressCameraFullscreen": "Pressione C para adicionar um segmento de Câmera em Tela Cheia",
+		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
 	},
 	"labels": {
 		"pan": "Mover",
@@ -86,5 +88,23 @@
 		"smartCutsNoAudio": "Esta mídia não tem áudio",
 		"smartCutsNoSpeech": "Nenhuma fala detectada",
 		"smartCutsFailed": "Falha na transcrição — tente de novo em Mídia"
+	},
+	"cursorMotion": {
+		"segmentKinds": {
+			"move": "Move",
+			"hold": "Hold"
+		},
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"noCursorData": "This recording has no cursor data to direct.",
+		"noFollowingClick": "No recorded click after the playhead to move towards.",
+		"createdSegments": "Split the cursor path into {{count}} sections.",
+		"failed": "Could not read the cursor recording"
 	}
 }

--- a/src/i18n/locales/ru/settings.json
+++ b/src/i18n/locales/ru/settings.json
@@ -327,5 +327,37 @@
 		"outputGain": "Уровень выхода",
 		"reset": "Сбросить аудио",
 		"help": "Настройте уровень звука на выходе. Он одинаково применяется в предпросмотре и при экспорте."
+	},
+	"cursorMotion": {
+		"title": "Cursor Motion",
+		"preset": "Path preset",
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"speed": "Movement speed",
+		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
+		"cycles": "Turns",
+		"easing": "Timing",
+		"easings": {
+			"linear": "Linear",
+			"ease-in-out": "Smooth",
+			"ease-in": "Accelerate",
+			"ease-out": "Decelerate"
+		},
+		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
+		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
+		"applyToAllMoves": "Apply to all move sections",
+		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
+		"splitAtPlayhead": "Split at playhead",
+		"splitOutsideRegion": "Move the playhead inside this section to split it.",
+		"delete": "Delete Cursor Motion",
+		"previousSection": "Previous section",
+		"nextSection": "Next section",
+		"sectionCounter": "Section {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/ru/settings.json
+++ b/src/i18n/locales/ru/settings.json
@@ -329,35 +329,35 @@
 		"help": "Настройте уровень звука на выходе. Он одинаково применяется в предпросмотре и при экспорте."
 	},
 	"cursorMotion": {
-		"title": "Cursor Motion",
-		"preset": "Path preset",
+		"title": "Движение курсора",
+		"preset": "Форма траектории",
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "Как записано",
+			"straight": "Прямая",
+			"arc": "Дуга",
+			"wave": "Волна",
+			"loop": "Петля",
+			"overshoot": "Перелёт"
 		},
-		"speed": "Movement speed",
-		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
-		"cycles": "Turns",
-		"easing": "Timing",
+		"speed": "Скорость движения",
+		"speedHint": "Чем выше скорость, тем раньше курсор проходит расстояние и замирает у цели. Раздел по-прежнему заканчивается записанным щелчком в исходный момент.",
+		"cycles": "Обороты",
+		"easing": "Темп",
 		"easings": {
-			"linear": "Linear",
-			"ease-in-out": "Smooth",
-			"ease-in": "Accelerate",
-			"ease-out": "Decelerate"
+			"linear": "Линейный",
+			"ease-in-out": "Плавный",
+			"ease-in": "Разгон",
+			"ease-out": "Торможение"
 		},
-		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
-		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
-		"applyToAllMoves": "Apply to all move sections",
-		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
-		"splitAtPlayhead": "Split at playhead",
-		"splitOutsideRegion": "Move the playhead inside this section to split it.",
-		"delete": "Delete Cursor Motion",
-		"previousSection": "Previous section",
-		"nextSection": "Next section",
-		"sectionCounter": "Section {{current}} / {{total}}"
+		"anchorHint": "Разделы начинаются и заканчиваются там, где курсор остановился или щёлкнул, поэтому их нельзя перетаскивать. Разделите раздел, чтобы сдвинуть границу.",
+		"holdDescription": "Курсор остаётся там, где остановился. Здесь нечего формировать — этот раздел и есть то, что удерживает его на месте, пока движениями вокруг управляют.",
+		"applyToAllMoves": "Применить ко всем разделам движения",
+		"appliedToAllMoves": "Форма, скорость, обороты и темп скопированы в каждый раздел движения.",
+		"splitAtPlayhead": "Разделить по курсору воспроизведения",
+		"splitOutsideRegion": "Переместите курсор воспроизведения внутрь этого раздела, чтобы разделить его.",
+		"delete": "Удалить движение курсора",
+		"previousSection": "Предыдущий раздел",
+		"nextSection": "Следующий раздел",
+		"sectionCounter": "Раздел {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/ru/timeline.json
+++ b/src/i18n/locales/ru/timeline.json
@@ -10,7 +10,7 @@
 		"addAnnotation": "Добавить аннотацию (A)",
 		"addSpeed": "Изменить скорость (S)",
 		"addCameraFullscreen": "Добавить камеру на весь экран (C)",
-		"addCursorMotion": "Split cursor path into editable sections"
+		"addCursorMotion": "Разбить траекторию курсора на редактируемые разделы"
 	},
 	"hints": {
 		"pressZoom": "Нажмите Z для добавления масштабирования",
@@ -18,7 +18,7 @@
 		"pressAnnotation": "Нажмите A для добавления аннотации",
 		"pressSpeed": "Нажмите S для изменения скорости",
 		"pressCameraFullscreen": "Нажмите C, чтобы добавить сегмент камеры на весь экран",
-		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
+		"cursorMotionEmpty": "Поставьте курсор воспроизведения перед участком с активностью курсора, затем включите инструмент траектории"
 	},
 	"labels": {
 		"pan": "Панорамирование",
@@ -91,20 +91,20 @@
 	},
 	"cursorMotion": {
 		"segmentKinds": {
-			"move": "Move",
-			"hold": "Hold"
+			"move": "Движение",
+			"hold": "Пауза"
 		},
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "Как записано",
+			"straight": "Прямая",
+			"arc": "Дуга",
+			"wave": "Волна",
+			"loop": "Петля",
+			"overshoot": "Перелёт"
 		},
-		"noCursorData": "This recording has no cursor data to direct.",
-		"noFollowingClick": "No recorded click after the playhead to move towards.",
-		"createdSegments": "Split the cursor path into {{count}} sections.",
-		"failed": "Could not read the cursor recording"
+		"noCursorData": "В этой записи нет данных курсора для постановки.",
+		"noFollowingClick": "После курсора воспроизведения нет записанного щелчка, к которому двигаться.",
+		"createdSegments": "Траектория курсора разбита на разделы: {{count}}.",
+		"failed": "Не удалось прочитать запись курсора"
 	}
 }

--- a/src/i18n/locales/ru/timeline.json
+++ b/src/i18n/locales/ru/timeline.json
@@ -9,14 +9,16 @@
 		"addTrim": "Добавить обрезку (T)",
 		"addAnnotation": "Добавить аннотацию (A)",
 		"addSpeed": "Изменить скорость (S)",
-		"addCameraFullscreen": "Добавить камеру на весь экран (C)"
+		"addCameraFullscreen": "Добавить камеру на весь экран (C)",
+		"addCursorMotion": "Split cursor path into editable sections"
 	},
 	"hints": {
 		"pressZoom": "Нажмите Z для добавления масштабирования",
 		"pressTrim": "Нажмите T для добавления обрезки",
 		"pressAnnotation": "Нажмите A для добавления аннотации",
 		"pressSpeed": "Нажмите S для изменения скорости",
-		"pressCameraFullscreen": "Нажмите C, чтобы добавить сегмент камеры на весь экран"
+		"pressCameraFullscreen": "Нажмите C, чтобы добавить сегмент камеры на весь экран",
+		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
 	},
 	"labels": {
 		"pan": "Панорамирование",
@@ -86,5 +88,23 @@
 		"smartCutsNoAudio": "В этом медиафайле нет звука",
 		"smartCutsNoSpeech": "Речь не обнаружена",
 		"smartCutsFailed": "Не удалось расшифровать — повторите из раздела «Медиа»"
+	},
+	"cursorMotion": {
+		"segmentKinds": {
+			"move": "Move",
+			"hold": "Hold"
+		},
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"noCursorData": "This recording has no cursor data to direct.",
+		"noFollowingClick": "No recorded click after the playhead to move towards.",
+		"createdSegments": "Split the cursor path into {{count}} sections.",
+		"failed": "Could not read the cursor recording"
 	}
 }

--- a/src/i18n/locales/tr/settings.json
+++ b/src/i18n/locales/tr/settings.json
@@ -327,5 +327,37 @@
 		"outputGain": "Çıkış seviyesi",
 		"reset": "Sesi sıfırla",
 		"help": "Ses çıkış seviyesini ayarlayın. Önizlemede ve dışa aktarmada aynı şekilde uygulanır."
+	},
+	"cursorMotion": {
+		"title": "Cursor Motion",
+		"preset": "Path preset",
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"speed": "Movement speed",
+		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
+		"cycles": "Turns",
+		"easing": "Timing",
+		"easings": {
+			"linear": "Linear",
+			"ease-in-out": "Smooth",
+			"ease-in": "Accelerate",
+			"ease-out": "Decelerate"
+		},
+		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
+		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
+		"applyToAllMoves": "Apply to all move sections",
+		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
+		"splitAtPlayhead": "Split at playhead",
+		"splitOutsideRegion": "Move the playhead inside this section to split it.",
+		"delete": "Delete Cursor Motion",
+		"previousSection": "Previous section",
+		"nextSection": "Next section",
+		"sectionCounter": "Section {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/tr/settings.json
+++ b/src/i18n/locales/tr/settings.json
@@ -329,35 +329,35 @@
 		"help": "Ses çıkış seviyesini ayarlayın. Önizlemede ve dışa aktarmada aynı şekilde uygulanır."
 	},
 	"cursorMotion": {
-		"title": "Cursor Motion",
-		"preset": "Path preset",
+		"title": "İmleç hareketi",
+		"preset": "Yol şekli",
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "Kaydedildiği gibi",
+			"straight": "Düz",
+			"arc": "Yay",
+			"wave": "Dalga",
+			"loop": "Döngü",
+			"overshoot": "Aşma"
 		},
-		"speed": "Movement speed",
-		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
-		"cycles": "Turns",
-		"easing": "Timing",
+		"speed": "Hareket hızı",
+		"speedHint": "Daha yüksek hızlar mesafeyi daha erken kateder ve hedefin yakınında durur. Bölüm yine kayıtlı tıklamada, özgün zamanında biter.",
+		"cycles": "Tur sayısı",
+		"easing": "Zamanlama",
 		"easings": {
-			"linear": "Linear",
-			"ease-in-out": "Smooth",
-			"ease-in": "Accelerate",
-			"ease-out": "Decelerate"
+			"linear": "Doğrusal",
+			"ease-in-out": "Akıcı",
+			"ease-in": "Hızlanma",
+			"ease-out": "Yavaşlama"
 		},
-		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
-		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
-		"applyToAllMoves": "Apply to all move sections",
-		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
-		"splitAtPlayhead": "Split at playhead",
-		"splitOutsideRegion": "Move the playhead inside this section to split it.",
-		"delete": "Delete Cursor Motion",
-		"previousSection": "Previous section",
-		"nextSection": "Next section",
-		"sectionCounter": "Section {{current}} / {{total}}"
+		"anchorHint": "Bölümler imlecin durduğu veya tıkladığı yerde başlayıp bittiği için sürüklenemez. Bir sınırı taşımak için bir bölümü bölün.",
+		"holdDescription": "İmleç durduğu yerde kalır. Burada şekillenecek bir şey yok — bu bölüm, çevresindeki hareketler yönlendirilirken onu sabit tutan şeydir.",
+		"applyToAllMoves": "Tüm hareket bölümlerine uygula",
+		"appliedToAllMoves": "Yol şekli, hız, tur sayısı ve zamanlama her hareket bölümüne kopyalandı.",
+		"splitAtPlayhead": "Oynatma imlecinde böl",
+		"splitOutsideRegion": "Bölmek için oynatma imlecini bu bölümün içine taşıyın.",
+		"delete": "İmleç hareketini sil",
+		"previousSection": "Önceki bölüm",
+		"nextSection": "Sonraki bölüm",
+		"sectionCounter": "Bölüm {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/tr/timeline.json
+++ b/src/i18n/locales/tr/timeline.json
@@ -9,14 +9,16 @@
 		"addTrim": "Kırpma Ekle (T)",
 		"addAnnotation": "Açıklama Ekle (A)",
 		"addSpeed": "Hız Ekle (S)",
-		"addCameraFullscreen": "Tam Ekran Kamera Ekle (C)"
+		"addCameraFullscreen": "Tam Ekran Kamera Ekle (C)",
+		"addCursorMotion": "Split cursor path into editable sections"
 	},
 	"hints": {
 		"pressZoom": "Yakınlaştırma eklemek için Z tuşuna basın",
 		"pressTrim": "Kırpma eklemek için T tuşuna basın",
 		"pressAnnotation": "Açıklama eklemek için A tuşuna basın",
 		"pressSpeed": "Hız eklemek için S tuşuna basın",
-		"pressCameraFullscreen": "Tam Ekran Kamera bölümü eklemek için C tuşuna basın"
+		"pressCameraFullscreen": "Tam Ekran Kamera bölümü eklemek için C tuşuna basın",
+		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
 	},
 	"labels": {
 		"pan": "Kaydır",
@@ -86,5 +88,23 @@
 		"smartCutsNoAudio": "Bu medyada ses yok",
 		"smartCutsNoSpeech": "Konuşma algılanmadı",
 		"smartCutsFailed": "Metne dökme başarısız — Medya bölümünden yeniden deneyin"
+	},
+	"cursorMotion": {
+		"segmentKinds": {
+			"move": "Move",
+			"hold": "Hold"
+		},
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"noCursorData": "This recording has no cursor data to direct.",
+		"noFollowingClick": "No recorded click after the playhead to move towards.",
+		"createdSegments": "Split the cursor path into {{count}} sections.",
+		"failed": "Could not read the cursor recording"
 	}
 }

--- a/src/i18n/locales/tr/timeline.json
+++ b/src/i18n/locales/tr/timeline.json
@@ -10,7 +10,7 @@
 		"addAnnotation": "Açıklama Ekle (A)",
 		"addSpeed": "Hız Ekle (S)",
 		"addCameraFullscreen": "Tam Ekran Kamera Ekle (C)",
-		"addCursorMotion": "Split cursor path into editable sections"
+		"addCursorMotion": "İmleç yolunu düzenlenebilir bölümlere ayır"
 	},
 	"hints": {
 		"pressZoom": "Yakınlaştırma eklemek için Z tuşuna basın",
@@ -18,7 +18,7 @@
 		"pressAnnotation": "Açıklama eklemek için A tuşuna basın",
 		"pressSpeed": "Hız eklemek için S tuşuna basın",
 		"pressCameraFullscreen": "Tam Ekran Kamera bölümü eklemek için C tuşuna basın",
-		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
+		"cursorMotionEmpty": "Oynatma imlecini bir imleç etkinliğinin önüne koyun, sonra yol aracını kullanın"
 	},
 	"labels": {
 		"pan": "Kaydır",
@@ -91,20 +91,20 @@
 	},
 	"cursorMotion": {
 		"segmentKinds": {
-			"move": "Move",
-			"hold": "Hold"
+			"move": "Hareket",
+			"hold": "Bekleme"
 		},
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "Kaydedildiği gibi",
+			"straight": "Düz",
+			"arc": "Yay",
+			"wave": "Dalga",
+			"loop": "Döngü",
+			"overshoot": "Aşma"
 		},
-		"noCursorData": "This recording has no cursor data to direct.",
-		"noFollowingClick": "No recorded click after the playhead to move towards.",
-		"createdSegments": "Split the cursor path into {{count}} sections.",
-		"failed": "Could not read the cursor recording"
+		"noCursorData": "Bu kayıtta yönlendirilecek imleç verisi yok.",
+		"noFollowingClick": "Oynatma imlecinden sonra hareket edilecek kayıtlı bir tıklama yok.",
+		"createdSegments": "İmleç yolu {{count}} bölüme bölündü.",
+		"failed": "İmleç kaydı okunamadı"
 	}
 }

--- a/src/i18n/locales/vi/settings.json
+++ b/src/i18n/locales/vi/settings.json
@@ -327,5 +327,37 @@
 		"outputGain": "Mức đầu ra",
 		"reset": "Đặt lại âm thanh",
 		"help": "Điều chỉnh mức đầu ra của âm thanh. Nó được áp dụng giống hệt nhau trong bản xem trước và khi xuất."
+	},
+	"cursorMotion": {
+		"title": "Cursor Motion",
+		"preset": "Path preset",
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"speed": "Movement speed",
+		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
+		"cycles": "Turns",
+		"easing": "Timing",
+		"easings": {
+			"linear": "Linear",
+			"ease-in-out": "Smooth",
+			"ease-in": "Accelerate",
+			"ease-out": "Decelerate"
+		},
+		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
+		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
+		"applyToAllMoves": "Apply to all move sections",
+		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
+		"splitAtPlayhead": "Split at playhead",
+		"splitOutsideRegion": "Move the playhead inside this section to split it.",
+		"delete": "Delete Cursor Motion",
+		"previousSection": "Previous section",
+		"nextSection": "Next section",
+		"sectionCounter": "Section {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/vi/settings.json
+++ b/src/i18n/locales/vi/settings.json
@@ -329,35 +329,35 @@
 		"help": "Điều chỉnh mức đầu ra của âm thanh. Nó được áp dụng giống hệt nhau trong bản xem trước và khi xuất."
 	},
 	"cursorMotion": {
-		"title": "Cursor Motion",
-		"preset": "Path preset",
+		"title": "Quỹ đạo con trỏ",
+		"preset": "Hình dạng quỹ đạo",
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "Như bản ghi",
+			"straight": "Thẳng",
+			"arc": "Cung",
+			"wave": "Sóng",
+			"loop": "Vòng lặp",
+			"overshoot": "Vượt quá"
 		},
-		"speed": "Movement speed",
-		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
-		"cycles": "Turns",
-		"easing": "Timing",
+		"speed": "Tốc độ di chuyển",
+		"speedHint": "Tốc độ càng cao, con trỏ càng sớm đi hết quãng đường và dừng gần mục tiêu. Phần vẫn kết thúc ở cú nhấp đã ghi, đúng thời điểm gốc.",
+		"cycles": "Số vòng",
+		"easing": "Nhịp độ",
 		"easings": {
-			"linear": "Linear",
-			"ease-in-out": "Smooth",
-			"ease-in": "Accelerate",
-			"ease-out": "Decelerate"
+			"linear": "Tuyến tính",
+			"ease-in-out": "Mượt",
+			"ease-in": "Tăng tốc",
+			"ease-out": "Giảm tốc"
 		},
-		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
-		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
-		"applyToAllMoves": "Apply to all move sections",
-		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
-		"splitAtPlayhead": "Split at playhead",
-		"splitOutsideRegion": "Move the playhead inside this section to split it.",
-		"delete": "Delete Cursor Motion",
-		"previousSection": "Previous section",
-		"nextSection": "Next section",
-		"sectionCounter": "Section {{current}} / {{total}}"
+		"anchorHint": "Các phần bắt đầu và kết thúc nơi con trỏ dừng lại hoặc nhấp, nên không thể kéo. Hãy chia một phần để di chuyển ranh giới.",
+		"holdDescription": "Con trỏ giữ nguyên vị trí nó dừng lại. Không có gì để nắn hình ở đây — phần này chính là thứ giữ nó yên trong khi các chuyển động xung quanh được dàn dựng.",
+		"applyToAllMoves": "Áp dụng cho mọi phần di chuyển",
+		"appliedToAllMoves": "Đã sao chép hình dạng, tốc độ, số vòng và nhịp độ vào mọi phần di chuyển.",
+		"splitAtPlayhead": "Chia tại đầu phát",
+		"splitOutsideRegion": "Hãy chuyển đầu phát vào trong phần này để chia nó.",
+		"delete": "Xóa quỹ đạo con trỏ",
+		"previousSection": "Phần trước",
+		"nextSection": "Phần tiếp theo",
+		"sectionCounter": "Phần {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/vi/timeline.json
+++ b/src/i18n/locales/vi/timeline.json
@@ -10,7 +10,7 @@
 		"addAnnotation": "Thêm Chú thích (A)",
 		"addSpeed": "Thêm Tốc độ (S)",
 		"addCameraFullscreen": "Thêm Camera Toàn màn hình (C)",
-		"addCursorMotion": "Split cursor path into editable sections"
+		"addCursorMotion": "Chia quỹ đạo con trỏ thành các phần chỉnh sửa được"
 	},
 	"hints": {
 		"pressZoom": "Nhấn Z để thêm thu phóng",
@@ -18,7 +18,7 @@
 		"pressAnnotation": "Nhấn A để thêm chú thích",
 		"pressSpeed": "Nhấn S để thêm tốc độ",
 		"pressCameraFullscreen": "Nhấn C để thêm một đoạn Camera Toàn màn hình",
-		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
+		"cursorMotionEmpty": "Đặt đầu phát trước một đoạn có hoạt động của con trỏ, rồi dùng công cụ quỹ đạo"
 	},
 	"labels": {
 		"pan": "Xoay",
@@ -91,20 +91,20 @@
 	},
 	"cursorMotion": {
 		"segmentKinds": {
-			"move": "Move",
-			"hold": "Hold"
+			"move": "Di chuyển",
+			"hold": "Dừng"
 		},
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "Như bản ghi",
+			"straight": "Thẳng",
+			"arc": "Cung",
+			"wave": "Sóng",
+			"loop": "Vòng lặp",
+			"overshoot": "Vượt quá"
 		},
-		"noCursorData": "This recording has no cursor data to direct.",
-		"noFollowingClick": "No recorded click after the playhead to move towards.",
-		"createdSegments": "Split the cursor path into {{count}} sections.",
-		"failed": "Could not read the cursor recording"
+		"noCursorData": "Bản ghi này không có dữ liệu con trỏ để dàn dựng.",
+		"noFollowingClick": "Không có cú nhấp đã ghi nào sau đầu phát để hướng tới.",
+		"createdSegments": "Đã chia quỹ đạo con trỏ thành {{count}} phần.",
+		"failed": "Không đọc được bản ghi con trỏ"
 	}
 }

--- a/src/i18n/locales/vi/timeline.json
+++ b/src/i18n/locales/vi/timeline.json
@@ -9,14 +9,16 @@
 		"addTrim": "Thêm Cắt (T)",
 		"addAnnotation": "Thêm Chú thích (A)",
 		"addSpeed": "Thêm Tốc độ (S)",
-		"addCameraFullscreen": "Thêm Camera Toàn màn hình (C)"
+		"addCameraFullscreen": "Thêm Camera Toàn màn hình (C)",
+		"addCursorMotion": "Split cursor path into editable sections"
 	},
 	"hints": {
 		"pressZoom": "Nhấn Z để thêm thu phóng",
 		"pressTrim": "Nhấn T để thêm cắt",
 		"pressAnnotation": "Nhấn A để thêm chú thích",
 		"pressSpeed": "Nhấn S để thêm tốc độ",
-		"pressCameraFullscreen": "Nhấn C để thêm một đoạn Camera Toàn màn hình"
+		"pressCameraFullscreen": "Nhấn C để thêm một đoạn Camera Toàn màn hình",
+		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
 	},
 	"labels": {
 		"pan": "Xoay",
@@ -86,5 +88,23 @@
 		"smartCutsNoAudio": "Media này không có âm thanh",
 		"smartCutsNoSpeech": "Không phát hiện giọng nói",
 		"smartCutsFailed": "Phiên âm thất bại — thử lại trong Media"
+	},
+	"cursorMotion": {
+		"segmentKinds": {
+			"move": "Move",
+			"hold": "Hold"
+		},
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"noCursorData": "This recording has no cursor data to direct.",
+		"noFollowingClick": "No recorded click after the playhead to move towards.",
+		"createdSegments": "Split the cursor path into {{count}} sections.",
+		"failed": "Could not read the cursor recording"
 	}
 }

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -327,5 +327,37 @@
 		"outputGain": "输出电平",
 		"reset": "重置音频",
 		"help": "调整音频输出电平。它在预览和导出中的效果完全一致。"
+	},
+	"cursorMotion": {
+		"title": "Cursor Motion",
+		"preset": "Path preset",
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"speed": "Movement speed",
+		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
+		"cycles": "Turns",
+		"easing": "Timing",
+		"easings": {
+			"linear": "Linear",
+			"ease-in-out": "Smooth",
+			"ease-in": "Accelerate",
+			"ease-out": "Decelerate"
+		},
+		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
+		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
+		"applyToAllMoves": "Apply to all move sections",
+		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
+		"splitAtPlayhead": "Split at playhead",
+		"splitOutsideRegion": "Move the playhead inside this section to split it.",
+		"delete": "Delete Cursor Motion",
+		"previousSection": "Previous section",
+		"nextSection": "Next section",
+		"sectionCounter": "Section {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -329,35 +329,35 @@
 		"help": "调整音频输出电平。它在预览和导出中的效果完全一致。"
 	},
 	"cursorMotion": {
-		"title": "Cursor Motion",
-		"preset": "Path preset",
+		"title": "光标轨迹",
+		"preset": "路径形状",
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "原始录制",
+			"straight": "直线",
+			"arc": "弧线",
+			"wave": "波浪",
+			"loop": "环绕",
+			"overshoot": "过冲"
 		},
-		"speed": "Movement speed",
-		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
-		"cycles": "Turns",
-		"easing": "Timing",
+		"speed": "移动速度",
+		"speedHint": "速度越高，光标越早走完全程并在目标附近停稳。该区域仍会在原始时刻结束于录制的点击处。",
+		"cycles": "圈数",
+		"easing": "节奏",
 		"easings": {
-			"linear": "Linear",
-			"ease-in-out": "Smooth",
-			"ease-in": "Accelerate",
-			"ease-out": "Decelerate"
+			"linear": "线性",
+			"ease-in-out": "平滑",
+			"ease-in": "加速",
+			"ease-out": "减速"
 		},
-		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
-		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
-		"applyToAllMoves": "Apply to all move sections",
-		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
-		"splitAtPlayhead": "Split at playhead",
-		"splitOutsideRegion": "Move the playhead inside this section to split it.",
-		"delete": "Delete Cursor Motion",
-		"previousSection": "Previous section",
-		"nextSection": "Next section",
-		"sectionCounter": "Section {{current}} / {{total}}"
+		"anchorHint": "区域的起止点就是光标停顿或点击的位置，因此无法拖动。请分割区域来移动边界。",
+		"holdDescription": "光标停在原处。这里没有可塑形的内容——该区域的作用是在周围移动被编排时保持光标不动。",
+		"applyToAllMoves": "应用到所有移动区域",
+		"appliedToAllMoves": "已将形状、速度、圈数和节奏复制到每个移动区域。",
+		"splitAtPlayhead": "在播放头处分割",
+		"splitOutsideRegion": "将播放头移到该区域内即可分割。",
+		"delete": "删除光标轨迹",
+		"previousSection": "上一区域",
+		"nextSection": "下一区域",
+		"sectionCounter": "区域 {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/zh-CN/timeline.json
+++ b/src/i18n/locales/zh-CN/timeline.json
@@ -9,14 +9,16 @@
 		"addTrim": "添加剪辑 (T)",
 		"addAnnotation": "添加标注 (A)",
 		"addSpeed": "添加速度 (S)",
-		"addCameraFullscreen": "添加全屏摄像头 (C)"
+		"addCameraFullscreen": "添加全屏摄像头 (C)",
+		"addCursorMotion": "Split cursor path into editable sections"
 	},
 	"hints": {
 		"pressZoom": "按 Z 添加缩放",
 		"pressTrim": "按 T 添加剪辑",
 		"pressAnnotation": "按 A 添加标注",
 		"pressSpeed": "按 S 添加速度",
-		"pressCameraFullscreen": "按 C 添加一个全屏摄像头片段"
+		"pressCameraFullscreen": "按 C 添加一个全屏摄像头片段",
+		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
 	},
 	"labels": {
 		"pan": "平移",
@@ -86,5 +88,23 @@
 		"smartCutsNoAudio": "此媒体没有音频",
 		"smartCutsNoSpeech": "未检测到语音",
 		"smartCutsFailed": "转录失败 — 请在“媒体”中重试"
+	},
+	"cursorMotion": {
+		"segmentKinds": {
+			"move": "Move",
+			"hold": "Hold"
+		},
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"noCursorData": "This recording has no cursor data to direct.",
+		"noFollowingClick": "No recorded click after the playhead to move towards.",
+		"createdSegments": "Split the cursor path into {{count}} sections.",
+		"failed": "Could not read the cursor recording"
 	}
 }

--- a/src/i18n/locales/zh-CN/timeline.json
+++ b/src/i18n/locales/zh-CN/timeline.json
@@ -10,7 +10,7 @@
 		"addAnnotation": "添加标注 (A)",
 		"addSpeed": "添加速度 (S)",
 		"addCameraFullscreen": "添加全屏摄像头 (C)",
-		"addCursorMotion": "Split cursor path into editable sections"
+		"addCursorMotion": "将光标路径分割为可编辑的区域"
 	},
 	"hints": {
 		"pressZoom": "按 Z 添加缩放",
@@ -18,7 +18,7 @@
 		"pressAnnotation": "按 A 添加标注",
 		"pressSpeed": "按 S 添加速度",
 		"pressCameraFullscreen": "按 C 添加一个全屏摄像头片段",
-		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
+		"cursorMotionEmpty": "先将播放头放在光标活动之前，再使用路径工具"
 	},
 	"labels": {
 		"pan": "平移",
@@ -91,20 +91,20 @@
 	},
 	"cursorMotion": {
 		"segmentKinds": {
-			"move": "Move",
-			"hold": "Hold"
+			"move": "移动",
+			"hold": "停顿"
 		},
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "原始录制",
+			"straight": "直线",
+			"arc": "弧线",
+			"wave": "波浪",
+			"loop": "环绕",
+			"overshoot": "过冲"
 		},
-		"noCursorData": "This recording has no cursor data to direct.",
-		"noFollowingClick": "No recorded click after the playhead to move towards.",
-		"createdSegments": "Split the cursor path into {{count}} sections.",
-		"failed": "Could not read the cursor recording"
+		"noCursorData": "此录制没有可编排的光标数据。",
+		"noFollowingClick": "播放头之后没有可作为目标的已录制点击。",
+		"createdSegments": "已将光标路径分割为 {{count}} 个区域。",
+		"failed": "无法读取光标录制数据"
 	}
 }

--- a/src/i18n/locales/zh-TW/settings.json
+++ b/src/i18n/locales/zh-TW/settings.json
@@ -328,5 +328,37 @@
 		"outputGain": "輸出音量",
 		"reset": "重設音訊",
 		"help": "調整音訊輸出電平。它在預覽與匯出中的效果完全一致。"
+	},
+	"cursorMotion": {
+		"title": "Cursor Motion",
+		"preset": "Path preset",
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"speed": "Movement speed",
+		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
+		"cycles": "Turns",
+		"easing": "Timing",
+		"easings": {
+			"linear": "Linear",
+			"ease-in-out": "Smooth",
+			"ease-in": "Accelerate",
+			"ease-out": "Decelerate"
+		},
+		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
+		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
+		"applyToAllMoves": "Apply to all move sections",
+		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
+		"splitAtPlayhead": "Split at playhead",
+		"splitOutsideRegion": "Move the playhead inside this section to split it.",
+		"delete": "Delete Cursor Motion",
+		"previousSection": "Previous section",
+		"nextSection": "Next section",
+		"sectionCounter": "Section {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/zh-TW/settings.json
+++ b/src/i18n/locales/zh-TW/settings.json
@@ -330,35 +330,35 @@
 		"help": "調整音訊輸出電平。它在預覽與匯出中的效果完全一致。"
 	},
 	"cursorMotion": {
-		"title": "Cursor Motion",
-		"preset": "Path preset",
+		"title": "游標軌跡",
+		"preset": "路徑形狀",
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "原始錄製",
+			"straight": "直線",
+			"arc": "弧線",
+			"wave": "波浪",
+			"loop": "環繞",
+			"overshoot": "過衝"
 		},
-		"speed": "Movement speed",
-		"speedHint": "Higher speeds cover the distance early and settle near the target. The section still ends on the recorded click, at its original time.",
-		"cycles": "Turns",
-		"easing": "Timing",
+		"speed": "移動速度",
+		"speedHint": "速度越高，游標越早走完全程並在目標附近停穩。該區段仍會在原始時刻結束於錄製的點擊處。",
+		"cycles": "圈數",
+		"easing": "節奏",
 		"easings": {
-			"linear": "Linear",
-			"ease-in-out": "Smooth",
-			"ease-in": "Accelerate",
-			"ease-out": "Decelerate"
+			"linear": "線性",
+			"ease-in-out": "平滑",
+			"ease-in": "加速",
+			"ease-out": "減速"
 		},
-		"anchorHint": "Sections start and end where the cursor stopped or clicked, so they cannot be dragged. Split one to move a boundary.",
-		"holdDescription": "The cursor stays where it stopped. Nothing to shape here — this section is what keeps it still while the moves around it are directed.",
-		"applyToAllMoves": "Apply to all move sections",
-		"appliedToAllMoves": "Preset, speed, turns and timing copied to every move section.",
-		"splitAtPlayhead": "Split at playhead",
-		"splitOutsideRegion": "Move the playhead inside this section to split it.",
-		"delete": "Delete Cursor Motion",
-		"previousSection": "Previous section",
-		"nextSection": "Next section",
-		"sectionCounter": "Section {{current}} / {{total}}"
+		"anchorHint": "區段的起點與終點就是游標停頓或點擊的位置，因此無法拖曳。請分割區段來移動邊界。",
+		"holdDescription": "游標停在原處。這裡沒有可塑形的內容——這個區段的用意，就是在周圍的移動被編排時讓游標保持不動。",
+		"applyToAllMoves": "套用至所有移動區段",
+		"appliedToAllMoves": "已將形狀、速度、圈數與節奏複製到每個移動區段。",
+		"splitAtPlayhead": "在播放頭處分割",
+		"splitOutsideRegion": "將播放頭移到這個區段內即可分割。",
+		"delete": "刪除游標軌跡",
+		"previousSection": "上一個區段",
+		"nextSection": "下一個區段",
+		"sectionCounter": "區段 {{current}} / {{total}}"
 	}
 }

--- a/src/i18n/locales/zh-TW/timeline.json
+++ b/src/i18n/locales/zh-TW/timeline.json
@@ -10,7 +10,7 @@
 		"addAnnotation": "新增標註 (A)",
 		"addSpeed": "新增速度 (S)",
 		"addCameraFullscreen": "新增全螢幕攝影機 (C)",
-		"addCursorMotion": "Split cursor path into editable sections"
+		"addCursorMotion": "將游標路徑分割為可編輯的區段"
 	},
 	"hints": {
 		"pressZoom": "按 Z 新增縮放",
@@ -18,7 +18,7 @@
 		"pressAnnotation": "按 A 新增標註",
 		"pressSpeed": "按 S 新增速度",
 		"pressCameraFullscreen": "按 C 新增一個全螢幕攝影機片段",
-		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
+		"cursorMotionEmpty": "先將播放頭放在游標活動之前，再使用路徑工具"
 	},
 	"labels": {
 		"pan": "平移",
@@ -91,20 +91,20 @@
 	},
 	"cursorMotion": {
 		"segmentKinds": {
-			"move": "Move",
-			"hold": "Hold"
+			"move": "移動",
+			"hold": "停頓"
 		},
 		"presets": {
-			"recorded": "Recorded",
-			"straight": "Straight",
-			"arc": "Arc",
-			"wave": "Wave",
-			"loop": "Loop",
-			"overshoot": "Overshoot"
+			"recorded": "原始錄製",
+			"straight": "直線",
+			"arc": "弧線",
+			"wave": "波浪",
+			"loop": "環繞",
+			"overshoot": "過衝"
 		},
-		"noCursorData": "This recording has no cursor data to direct.",
-		"noFollowingClick": "No recorded click after the playhead to move towards.",
-		"createdSegments": "Split the cursor path into {{count}} sections.",
-		"failed": "Could not read the cursor recording"
+		"noCursorData": "這份錄製沒有可編排的游標資料。",
+		"noFollowingClick": "播放頭之後沒有可作為目標的已錄製點擊。",
+		"createdSegments": "已將游標路徑分割為 {{count}} 個區段。",
+		"failed": "無法讀取游標錄製資料"
 	}
 }

--- a/src/i18n/locales/zh-TW/timeline.json
+++ b/src/i18n/locales/zh-TW/timeline.json
@@ -9,14 +9,16 @@
 		"addTrim": "新增剪輯 (T)",
 		"addAnnotation": "新增標註 (A)",
 		"addSpeed": "新增速度 (S)",
-		"addCameraFullscreen": "新增全螢幕攝影機 (C)"
+		"addCameraFullscreen": "新增全螢幕攝影機 (C)",
+		"addCursorMotion": "Split cursor path into editable sections"
 	},
 	"hints": {
 		"pressZoom": "按 Z 新增縮放",
 		"pressTrim": "按 T 新增剪輯",
 		"pressAnnotation": "按 A 新增標註",
 		"pressSpeed": "按 S 新增速度",
-		"pressCameraFullscreen": "按 C 新增一個全螢幕攝影機片段"
+		"pressCameraFullscreen": "按 C 新增一個全螢幕攝影機片段",
+		"cursorMotionEmpty": "Place the playhead before some cursor activity, then use the path tool"
 	},
 	"labels": {
 		"pan": "平移",
@@ -86,5 +88,23 @@
 		"smartCutsNoAudio": "此媒體沒有音訊",
 		"smartCutsNoSpeech": "未偵測到語音",
 		"smartCutsFailed": "轉錄失敗 — 請在「媒體」中重試"
+	},
+	"cursorMotion": {
+		"segmentKinds": {
+			"move": "Move",
+			"hold": "Hold"
+		},
+		"presets": {
+			"recorded": "Recorded",
+			"straight": "Straight",
+			"arc": "Arc",
+			"wave": "Wave",
+			"loop": "Loop",
+			"overshoot": "Overshoot"
+		},
+		"noCursorData": "This recording has no cursor data to direct.",
+		"noFollowingClick": "No recorded click after the playhead to move towards.",
+		"createdSegments": "Split the cursor path into {{count}} sections.",
+		"failed": "Could not read the cursor recording"
 	}
 }

--- a/src/lib/ai-edition/document/outputFormat.test.ts
+++ b/src/lib/ai-edition/document/outputFormat.test.ts
@@ -67,6 +67,7 @@ function doc(assets: AxcutAsset[], clips: AxcutClip[]): AxcutDocument {
 		},
 		annotations: [],
 		zoomRanges: [],
+		cursorMotionRegions: [],
 		legacyEditor: null,
 	};
 }

--- a/src/lib/ai-edition/document/timeline.test.ts
+++ b/src/lib/ai-edition/document/timeline.test.ts
@@ -57,6 +57,7 @@ function makeDoc(overrides: Partial<AxcutDocument> = {}): AxcutDocument {
 		},
 		annotations: [],
 		zoomRanges: [],
+		cursorMotionRegions: [],
 		legacyEditor: null,
 		...overrides,
 	};

--- a/src/lib/ai-edition/document/timeline.ts
+++ b/src/lib/ai-edition/document/timeline.ts
@@ -17,7 +17,13 @@ import { createId } from "./ids";
  *  exist" has exactly one definition. `trim` is a source-time cut; the rest are pill-merged
  *  effects (zoom / speed / annotation / camera-fullscreen). Clips are removed via
  *  {@link removeClip}, not here — deleting a clip reflows the whole timeline. */
-export type RegionKind = "zoom" | "trim" | "annotation" | "speed" | "cameraFullscreen";
+export type RegionKind =
+	| "zoom"
+	| "trim"
+	| "annotation"
+	| "speed"
+	| "cameraFullscreen"
+	| "cursorMotion";
 
 /** Length a clip is given before its media has been probed. Lives here, in the pure
  *  document layer, because that layer decides which clips are still waiting for a real
@@ -879,6 +885,16 @@ export function removeRegion(document: AxcutDocument, kind: RegionKind, id: stri
 			};
 		case "annotation":
 			return { ...document, annotations: dropPillById(document.annotations, id) };
+		// Deleting a motion region is how an editor reverts to the recorded path for
+		// that stretch — it is the undo of a choice, not the loss of data.
+		case "cursorMotion":
+			return {
+				...document,
+				cursorMotionRegions: dropPillById(
+					document.cursorMotionRegions,
+					id,
+				) as AxcutDocument["cursorMotionRegions"],
+			};
 		case "trim":
 			return {
 				...document,

--- a/src/lib/ai-edition/document/transcribe.test.ts
+++ b/src/lib/ai-edition/document/transcribe.test.ts
@@ -49,6 +49,7 @@ function makeDoc(): AxcutDocument {
 		},
 		annotations: [],
 		zoomRanges: [],
+		cursorMotionRegions: [],
 		legacyEditor: null,
 	};
 }

--- a/src/lib/ai-edition/schema/index.ts
+++ b/src/lib/ai-edition/schema/index.ts
@@ -471,6 +471,61 @@ export const zoomRegionSchema = endGteStart(
 	"startMs",
 );
 
+const cursorMotionPointSchema = z.object({
+	cx: z.number().min(0).max(1),
+	cy: z.number().min(0).max(1),
+});
+
+// One editable stretch of cursor trajectory. The recorded telemetry stays the
+// source of truth: a region overrides the path drawn between its two anchors and
+// nothing else, so deleting it returns that stretch to the capture.
+//
+// Two shapes meet here and they are deliberately not the same:
+//
+//   - The DOCUMENT stores the region the way every other modifier is stored —
+//     `clipAnchorShape`, i.e. `{clipId, sourceStartSec, sourceEndSec}` with
+//     `startMs`/`endMs` as the derived cache. That is what survives a reorder or
+//     a trim (see technical-documentation/architecture/timeline-model.md), and
+//     forking the convention for one region kind would strand it exactly the way
+//     trims were stranded before v7.
+//   - The MODEL in `src/lib/cursor/cursorMotion.ts` works in `sourceStartMs` /
+//     `sourceEndMs` and takes `controlPoints[]`. It is a pure sampler with no
+//     knowledge of the document; the conversion happens at the call site.
+//
+// `controlPoint` is singular here where the model takes a list, because the
+// editor exposes exactly one handle and `SceneCursorMotionRegion` carries
+// exactly one. The model averages whatever list it is given, so passing
+// `[controlPoint]` is the same curve. Storing a list we never write a second
+// entry into would be a shape inviting a feature nobody asked for.
+export const cursorMotionRegionSchema = endGteStart(
+	z.object({
+		id: z.string().min(1),
+		startMs: z.number().nonnegative(),
+		endMs: z.number().nonnegative(),
+		...clipAnchorShape,
+		// Which asset's telemetry the points were resolved against. Optional because
+		// a clip resolves to its asset anyway; stored so a region survives being read
+		// without the timeline at hand (the CLI export path does exactly that).
+		assetId: z.string().min(1).optional(),
+		startPoint: cursorMotionPointSchema,
+		endPoint: cursorMotionPointSchema,
+		controlPoint: cursorMotionPointSchema,
+		startAnchor: z.enum(["manual", "rest", "click"]).default("manual"),
+		endAnchor: z.enum(["manual", "rest", "click"]).default("click"),
+		segmentKind: z.enum(["move", "hold"]).default("move"),
+		// `recorded` is inert and it is the default: creating regions must change
+		// nothing on screen until someone picks a shape.
+		preset: z
+			.enum(["recorded", "straight", "arc", "wave", "loop", "overshoot"])
+			.default("recorded"),
+		speed: z.number().min(1).max(4).default(1),
+		cycles: z.number().int().min(1).max(6).default(1),
+		easing: z.enum(["linear", "ease-in-out", "ease-in", "ease-out"]).default("ease-in-out"),
+	}),
+	"endMs",
+	"startMs",
+);
+
 // Legacy OpenScreen appearance / export settings that the v3 schema doesn't
 // normalize into the timeline / assets model. They are applied at export time
 // by the existing pipeline (see technical-documentation/architecture/document-model.md).
@@ -503,6 +558,10 @@ const documentSchemaShape = z.object({
 	}),
 	annotations: z.array(annotationRegionSchema).default([]),
 	zoomRanges: z.array(zoomRegionSchema).default([]),
+	// Additive, like `annotations` and `zoomRanges` were at v3: the default fills
+	// in for every document written before the field existed, so no version bump
+	// and no migration entry.
+	cursorMotionRegions: z.array(cursorMotionRegionSchema).default([]),
 	legacyEditor: legacyEditorSchema.nullable().default(null),
 });
 
@@ -941,6 +1000,7 @@ export type AxcutTimeline = z.infer<typeof timelineSchema>;
 export type AxcutTimelineOperation = z.infer<typeof timelineOperationSchema>;
 export type AxcutAnnotationRegion = z.infer<typeof annotationRegionSchema>;
 export type AxcutZoomRegion = z.infer<typeof zoomRegionSchema>;
+export type AxcutCursorMotionRegion = z.infer<typeof cursorMotionRegionSchema>;
 export type AxcutCameraTrack = z.infer<typeof cameraTrackSchema>;
 export type AxcutLegacyEditor = z.infer<typeof legacyEditorSchema>;
 export type AxcutDocument = z.infer<typeof documentSchema>;

--- a/src/lib/ai-edition/store/documentWriteAudit.test.ts
+++ b/src/lib/ai-edition/store/documentWriteAudit.test.ts
@@ -222,6 +222,13 @@ const DECLARED: WritePath[] = [
 	w("src/lib/ai-edition/store/useTimeline.ts", "addTrim", "save", "gesture"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "addZoom", "save", "gesture"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "addZoomsBulk", "save", "gesture"),
+	// Cursor motion. `addCursorMotion` writes several sections in one save, so the
+	// whole auto-split is one undo step — the same deal `addZoomsBulk` gets, and for
+	// the same reason: the user pressed one button.
+	w("src/lib/ai-edition/store/useTimeline.ts", "addCursorMotion", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "applyCursorMotionToAllMoves", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "splitCursorMotionAtPlayhead", "save", "gesture"),
+	w("src/lib/ai-edition/store/useTimeline.ts", "updateCursorMotionSettings", "save", "gesture"),
 	// The two drag commits. One undo step per gesture, recorded on release and only
 	// if the write lands — `historyBase` carries the pre-drag document.
 	w("src/lib/ai-edition/store/useTimeline.ts", "commitAnnotationChange", "save", "gesture"),
@@ -231,6 +238,14 @@ const DECLARED: WritePath[] = [
 	w("src/lib/ai-edition/store/useTimeline.ts", "commitAnnotationChange", "state", "unrecorded"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "commitZoomFocus", "save", "gesture"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "commitZoomFocus", "state", "unrecorded"),
+	// The third drag commit, same shape as the two above: the cursor motion handle.
+	w("src/lib/ai-edition/store/useTimeline.ts", "commitCursorMotionControlPoint", "save", "gesture"),
+	w(
+		"src/lib/ai-edition/store/useTimeline.ts",
+		"commitCursorMotionControlPoint",
+		"state",
+		"unrecorded",
+	),
 	w("src/lib/ai-edition/store/useTimeline.ts", "duplicateClip", "save", "gesture"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "insertClipAt", "save", "gesture"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "moveClip", "save", "gesture"),
@@ -243,6 +258,12 @@ const DECLARED: WritePath[] = [
 	w("src/lib/ai-edition/store/useTimeline.ts", "setTrimEntries", "save", "gesture"),
 	// The live halves of the two drags.
 	w("src/lib/ai-edition/store/useTimeline.ts", "updateAnnotationLive", "set", "automatic"),
+	w(
+		"src/lib/ai-edition/store/useTimeline.ts",
+		"updateCursorMotionControlPointLive",
+		"set",
+		"automatic",
+	),
 	w("src/lib/ai-edition/store/useTimeline.ts", "updateAnnotationSpan", "save", "gesture"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "updateCameraFullscreenSpan", "save", "gesture"),
 	w("src/lib/ai-edition/store/useTimeline.ts", "updateSpeedSpan", "save", "gesture"),

--- a/src/lib/ai-edition/store/editorSettings.test.ts
+++ b/src/lib/ai-edition/store/editorSettings.test.ts
@@ -29,6 +29,7 @@ const baseDoc: AxcutDocument = {
 	},
 	annotations: [],
 	zoomRanges: [],
+	cursorMotionRegions: [],
 	transcripts: [],
 	transcript: null,
 	legacyEditor: null,

--- a/src/lib/ai-edition/store/projectStore.test.ts
+++ b/src/lib/ai-edition/store/projectStore.test.ts
@@ -62,6 +62,7 @@ const sampleDoc = {
 	},
 	annotations: [],
 	zoomRanges: [],
+	cursorMotionRegions: [],
 	legacyEditor: null,
 };
 

--- a/src/lib/ai-edition/store/undo.modalGuard.test.tsx
+++ b/src/lib/ai-edition/store/undo.modalGuard.test.tsx
@@ -35,6 +35,7 @@ function doc(title: string): AxcutDocument {
 		},
 		annotations: [],
 		zoomRanges: [],
+		cursorMotionRegions: [],
 		legacyEditor: null,
 	};
 }

--- a/src/lib/ai-edition/store/useCaptions.test.ts
+++ b/src/lib/ai-edition/store/useCaptions.test.ts
@@ -71,6 +71,7 @@ const docA: AxcutDocument = {
 	},
 	annotations: [],
 	zoomRanges: [],
+	cursorMotionRegions: [],
 	legacyEditor: null,
 };
 

--- a/src/lib/ai-edition/store/useEditorSettings.test.ts
+++ b/src/lib/ai-edition/store/useEditorSettings.test.ts
@@ -74,6 +74,7 @@ const docA: AxcutDocument = {
 	},
 	annotations: [],
 	zoomRanges: [],
+	cursorMotionRegions: [],
 	legacyEditor: null,
 };
 

--- a/src/lib/ai-edition/store/useTimeline.cursorMotion.test.ts
+++ b/src/lib/ai-edition/store/useTimeline.cursorMotion.test.ts
@@ -1,0 +1,348 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { I18nProvider } from "@/contexts/I18nContext";
+import type { CursorMotionTelemetrySample } from "@/lib/cursor/cursorMotion";
+import type { AxcutCursorMotionRegion, AxcutDocument } from "../schema";
+import { axcutSchemaVersion } from "../schema";
+import { useProjectStore } from "./projectStore";
+import { useTimeline } from "./useTimeline";
+
+const renderTimeline = () => renderHook(() => useTimeline(), { wrapper: I18nProvider });
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() } }));
+
+const bridgeMocks = vi.hoisted(() => ({
+	get: vi.fn(),
+	create: vi.fn(),
+	save: vi.fn(),
+	addAsset: vi.fn(),
+	removeAsset: vi.fn(),
+	listProjects: vi.fn(),
+}));
+
+vi.mock("@/native/client", () => ({
+	nativeBridgeClient: { aiEdition: bridgeMocks },
+}));
+
+const baseDoc: AxcutDocument = {
+	schemaVersion: axcutSchemaVersion,
+	project: {
+		id: "proj_cm",
+		title: "Cursor motion",
+		createdAt: "2026-08-31T10:00:00.000Z",
+		updatedAt: "2026-08-31T10:00:00.000Z",
+		primaryAssetId: "asset_1",
+	},
+	assets: [
+		{
+			id: "asset_1",
+			kind: "video",
+			label: "screen.webm",
+			originalPath: "/tmp/screen.webm",
+			durationSec: 10,
+			video: { codec: "unknown", width: 1920, height: 1080, fps: 0 },
+			cameraTrack: null,
+		},
+	],
+	transcript: null,
+	transcripts: [],
+	timeline: {
+		clips: [
+			{
+				id: "clip_a",
+				assetId: "asset_1",
+				sourceStartSec: 0,
+				sourceEndSec: 10,
+				timelineStartSec: 0,
+				timelineEndSec: 10,
+				wordRefs: [],
+				origin: "user",
+				reason: "",
+			},
+		],
+		gaps: [],
+		trimRanges: [],
+		muteRanges: [],
+		speedRanges: [],
+		captionRanges: [],
+	},
+	annotations: [],
+	zoomRanges: [],
+	cursorMotionRegions: [],
+	legacyEditor: null,
+};
+
+/**
+ * A capture that moves, holds still for 450 ms, moves again, then clicks. The
+ * hold is what the rest detector is meant to find: 450 ms is over its 300 ms
+ * floor and the points never leave a 0.009-wide circle. Samples are 50 ms apart,
+ * well inside the detector's 150 ms maximum gap, so nothing here reads as
+ * telemetry dropping out.
+ */
+function tracedCapture(): CursorMotionTelemetrySample[] {
+	const samples: CursorMotionTelemetrySample[] = [];
+	for (let t = 1000; t <= 1100; t += 50) {
+		samples.push({ timeMs: t, cx: 0.1 + (t - 1000) / 3000, cy: 0.5, interactionType: "move" });
+	}
+	for (let t = 1150; t <= 1600; t += 50) {
+		samples.push({ timeMs: t, cx: 0.14, cy: 0.5, interactionType: "move" });
+	}
+	for (let t = 1650; t <= 2450; t += 50) {
+		samples.push({ timeMs: t, cx: 0.14 + (t - 1650) / 1600, cy: 0.5, interactionType: "move" });
+	}
+	samples.push({ timeMs: 2500, cx: 0.9, cy: 0.5, interactionType: "click" });
+	return samples;
+}
+
+const seed = (regions: AxcutCursorMotionRegion[] = [], currentTimeSec = 1) => {
+	useProjectStore.setState({
+		projectId: "proj_cm",
+		document: { ...baseDoc, cursorMotionRegions: regions },
+		revision: 1,
+		status: "ready",
+		error: null,
+		currentTimeSec,
+	});
+};
+
+const storedRegions = () => useProjectStore.getState().document?.cursorMotionRegions ?? [];
+
+const moveRegion = (patch: Partial<AxcutCursorMotionRegion> = {}): AxcutCursorMotionRegion => ({
+	id: "cm_move",
+	startMs: 1000,
+	endMs: 3000,
+	clipId: "clip_a",
+	assetId: "asset_1",
+	sourceStartSec: 1,
+	sourceEndSec: 3,
+	startPoint: { cx: 0.1, cy: 0.5 },
+	endPoint: { cx: 0.9, cy: 0.5 },
+	controlPoint: { cx: 0.5, cy: 0.1 },
+	startAnchor: "manual",
+	endAnchor: "click",
+	segmentKind: "move",
+	preset: "arc",
+	speed: 3,
+	cycles: 4,
+	easing: "ease-in",
+	...patch,
+});
+
+beforeEach(() => {
+	useProjectStore.getState().clear();
+	for (const mock of Object.values(bridgeMocks)) mock.mockReset();
+	bridgeMocks.save.mockImplementation(async (doc: AxcutDocument) => ({
+		success: true,
+		document: doc,
+	}));
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("addCursorMotion", () => {
+	it("splits the stretch at the rest and the click, and writes it in one save", async () => {
+		seed();
+		const { result } = renderTimeline();
+
+		await act(async () => {
+			expect(await result.current.addCursorMotion(tracedCapture())).toBeGreaterThan(1);
+		});
+
+		const regions = storedRegions();
+		// move → hold → move, i.e. the rest is carved out of the path instead of
+		// being curved through. Its own kind, not a shorter move.
+		expect(regions.map((r) => r.segmentKind)).toContain("hold");
+		expect(regions.map((r) => r.segmentKind)).toContain("move");
+		// One document write for the whole auto-split: the user pressed one button,
+		// so Ctrl+Z takes back one thing.
+		expect(bridgeMocks.save).toHaveBeenCalledTimes(1);
+		// Sections tile the span without gaps or overlap — a hole would leave a
+		// stretch of path nothing owns.
+		const ordered = [...regions].sort((a, b) => a.startMs - b.startMs);
+		for (let i = 1; i < ordered.length; i += 1) {
+			expect(ordered[i].startMs).toBe(ordered[i - 1].endMs);
+		}
+	});
+
+	it("creates every section inert, so nothing on screen changes", async () => {
+		// The non-destructive default. If a fresh section arrived as anything but
+		// `recorded` at 1x, pressing the button would silently restyle footage.
+		seed();
+		const { result } = renderTimeline();
+		await act(async () => {
+			await result.current.addCursorMotion(tracedCapture());
+		});
+		for (const region of storedRegions()) {
+			expect(region.preset).toBe("recorded");
+			expect(region.speed).toBe(1);
+		}
+	});
+
+	it("anchors every section to the clip under the playhead", async () => {
+		seed();
+		const { result } = renderTimeline();
+		await act(async () => {
+			await result.current.addCursorMotion(tracedCapture());
+		});
+		for (const region of storedRegions()) {
+			expect(region.clipId).toBe("clip_a");
+			expect(region.assetId).toBe("asset_1");
+		}
+	});
+
+	it("writes nothing when no recorded click follows the playhead", async () => {
+		// The section has to end SOMEWHERE the recording chose. With no later click
+		// there is no destination, and inventing one would put the cursor somewhere
+		// the user never clicked.
+		seed();
+		const { result } = renderTimeline();
+		const clickless = tracedCapture().filter((s) => s.interactionType !== "click");
+
+		await act(async () => {
+			expect(await result.current.addCursorMotion(clickless)).toBe(0);
+		});
+
+		expect(storedRegions()).toHaveLength(0);
+		expect(bridgeMocks.save).not.toHaveBeenCalled();
+	});
+
+	it("writes nothing when the recording carries no cursor samples at all", async () => {
+		seed();
+		const { result } = renderTimeline();
+		await act(async () => {
+			expect(await result.current.addCursorMotion([])).toBe(0);
+		});
+		expect(bridgeMocks.save).not.toHaveBeenCalled();
+	});
+});
+
+describe("applyCursorMotionToAllMoves", () => {
+	it("copies the styling to every move and leaves the holds alone", async () => {
+		const hold = moveRegion({
+			id: "cm_hold",
+			segmentKind: "hold",
+			preset: "recorded",
+			speed: 1,
+			cycles: 1,
+			easing: "ease-in-out",
+		});
+		const other = moveRegion({ id: "cm_other", preset: "straight", speed: 1, cycles: 1 });
+		seed([moveRegion(), hold, other]);
+		const { result } = renderTimeline();
+
+		await act(async () => {
+			expect(await result.current.applyCursorMotionToAllMoves("cm_move")).toBe(2);
+		});
+
+		const byId = Object.fromEntries(storedRegions().map((r) => [r.id, r]));
+		expect(byId.cm_other).toMatchObject({
+			preset: "arc",
+			speed: 3,
+			cycles: 4,
+			easing: "ease-in",
+		});
+		// A hold has no path to shape; restyling it would be writing a preset onto a
+		// section that renders nothing.
+		expect(byId.cm_hold).toMatchObject({ preset: "recorded", speed: 1 });
+	});
+
+	it("does not copy the control point", async () => {
+		// The control point is an ABSOLUTE position on the frame, not a shape
+		// parameter. Copying it would drag every other path towards this one's
+		// midpoint — which is exactly why the button says "apply the settings", and
+		// why #113 excluded it too.
+		const other = moveRegion({ id: "cm_other", controlPoint: { cx: 0.8, cy: 0.9 } });
+		seed([moveRegion(), other]);
+		const { result } = renderTimeline();
+
+		await act(async () => {
+			await result.current.applyCursorMotionToAllMoves("cm_move");
+		});
+
+		const target = storedRegions().find((r) => r.id === "cm_other");
+		expect(target?.controlPoint).toEqual({ cx: 0.8, cy: 0.9 });
+	});
+});
+
+describe("splitCursorMotionAtPlayhead", () => {
+	it("cuts at the playhead and makes the halves meet on the path", async () => {
+		seed([moveRegion()], 2);
+		const { result } = renderTimeline();
+
+		await act(async () => {
+			expect(await result.current.splitCursorMotionAtPlayhead("cm_move")).toBe(true);
+		});
+
+		const halves = [...storedRegions()].sort((a, b) => a.startMs - b.startMs);
+		expect(halves).toHaveLength(2);
+		// The shared point is sampled off the ORIGINAL curve, not interpolated between
+		// the endpoints: the two halves have to meet where the cursor already passed,
+		// or splitting an arc visibly teleports it.
+		expect(halves[0].endPoint).toEqual(halves[1].startPoint);
+		expect(halves[0].endPoint.cy).toBeLessThan(0.5);
+		// The cut is the editor's, so it is `manual` on both sides — it did not come
+		// from a rest or a click in the recording.
+		expect(halves[0].endAnchor).toBe("manual");
+		expect(halves[1].startAnchor).toBe("manual");
+		// The outer boundaries are untouched.
+		expect(halves[0].startPoint).toEqual(moveRegion().startPoint);
+		expect(halves[1].endPoint).toEqual(moveRegion().endPoint);
+		expect(halves[1].endAnchor).toBe("click");
+	});
+
+	it("keeps the styling on both halves", async () => {
+		seed([moveRegion()], 2);
+		const { result } = renderTimeline();
+		await act(async () => {
+			await result.current.splitCursorMotionAtPlayhead("cm_move");
+		});
+		for (const half of storedRegions()) {
+			expect(half).toMatchObject({ preset: "arc", speed: 3, cycles: 4, easing: "ease-in" });
+		}
+	});
+
+	it("refuses when the playhead is outside the section", async () => {
+		// Refusing is what lets the inspector say "move the playhead inside this
+		// section" instead of silently producing a zero-length half.
+		seed([moveRegion()], 8);
+		const { result } = renderTimeline();
+
+		await act(async () => {
+			expect(await result.current.splitCursorMotionAtPlayhead("cm_move")).toBe(false);
+		});
+
+		expect(storedRegions()).toHaveLength(1);
+		expect(bridgeMocks.save).not.toHaveBeenCalled();
+	});
+});
+
+describe("updateCursorMotionSettings", () => {
+	it("clamps speed and turns to what the model and the compositor agree on", async () => {
+		// The two sides carry the same bounds (1..4 and 1..6). A document written
+		// outside them would render one way in the preview and another in the export.
+		seed([moveRegion()]);
+		const { result } = renderTimeline();
+
+		await act(async () => {
+			await result.current.updateCursorMotionSettings("cm_move", { speed: 99, cycles: 99 });
+		});
+
+		expect(storedRegions()[0]).toMatchObject({ speed: 4, cycles: 6 });
+	});
+
+	it("changes only the named section", async () => {
+		seed([moveRegion(), moveRegion({ id: "cm_other", preset: "wave" })]);
+		const { result } = renderTimeline();
+
+		await act(async () => {
+			await result.current.updateCursorMotionSettings("cm_move", { preset: "loop" });
+		});
+
+		const byId = Object.fromEntries(storedRegions().map((r) => [r.id, r]));
+		expect(byId.cm_move.preset).toBe("loop");
+		expect(byId.cm_other.preset).toBe("wave");
+	});
+});

--- a/src/lib/ai-edition/store/useTimeline.test.ts
+++ b/src/lib/ai-edition/store/useTimeline.test.ts
@@ -110,6 +110,7 @@ const sampleDoc: AxcutDocument = {
 	},
 	annotations: [],
 	zoomRanges: [],
+	cursorMotionRegions: [],
 	legacyEditor: null,
 };
 

--- a/src/lib/ai-edition/store/useTimeline.ts
+++ b/src/lib/ai-edition/store/useTimeline.ts
@@ -7,6 +7,17 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { toFileUrl } from "@/components/video-editor/projectPersistence";
 import type { AnnotationRegion, AnnotationType } from "@/components/video-editor/types";
 import { useScopedT } from "@/contexts/I18nContext";
+import {
+	buildCursorMotionRegionDrafts,
+	type CursorMotionEasing,
+	type CursorMotionPoint,
+	type CursorMotionPreset,
+	type CursorMotionTelemetrySample,
+	clampCursorMotionCycles,
+	clampCursorMotionPoint,
+	clampCursorMotionSpeed,
+} from "@/lib/cursor/cursorMotion";
+import { resolveVisibleClips } from "@/native/sceneDescription";
 import { createId } from "../document/ids";
 import {
 	duplicateClip as duplicateClipInDocument,
@@ -19,13 +30,18 @@ import {
 	resequenceClips,
 	setClipSourceRange,
 } from "../document/timeline";
-import type { AxcutClipCropRegion, AxcutDocument } from "../schema";
+import type { AxcutClipCropRegion, AxcutCursorMotionRegion, AxcutDocument } from "../schema";
 import { hasAnyClipWithCamera } from "../timeline/camera";
+import {
+	sampleStoredCursorMotionRegion,
+	toModelCursorMotionRegion,
+} from "../timeline/cursorMotionRegions";
 import { probeVideoDimensions, probeVideoDuration } from "../timeline/duration";
 import {
 	anchorRegionsWithDerivedMs,
 	dropPillsByIds,
 	replacePillSpan,
+	resolveNativePosition,
 	resolvePillIds,
 } from "../timeline/timelineMap";
 import { dropTrimPillsByIds, resolveTimelineSpanToTrim } from "../timeline/trim-mapping";
@@ -275,6 +291,238 @@ export function useTimeline() {
 			};
 			if (!(await saveDocument(next, { history: true }))) return 0;
 			return suggestions.length;
+		},
+		[document, saveDocument],
+	);
+
+	// ---- Cursor motion -------------------------------------------------------
+	//
+	// The one add* that cannot invent its own span. Every other region is "2 s at
+	// the playhead" because 2 s of zoom is a meaningful thing to make; 2 s of
+	// cursor path is not. A motion region only means something between two moments
+	// the RECORDING contains, so the model reads the telemetry and hands back one
+	// draft per stretch, split at every cursor rest and every click, up to the
+	// first click after the playhead. No later click means no drafts — the caller
+	// gets 0 back and says so, rather than a region drawn over nothing.
+	//
+	// Samples arrive from the caller instead of being fetched here. They live
+	// behind the native bridge keyed by video path, and the pane that owns the
+	// button already holds them (`useCursorRecordingData`); pulling the IPC into
+	// the store would make every consumer of this hook wait on it.
+	const addCursorMotion = useCallback(
+		async (samples: readonly CursorMotionTelemetrySample[]) => {
+			if (!document || samples.length === 0) return 0;
+			const position = resolveNativePosition(
+				playheadSec(),
+				resolveVisibleClips(document),
+				document.timeline.clips,
+			);
+			if (!position) return 0;
+			const clip = position.clip;
+			const drafts = buildCursorMotionRegionDrafts({
+				owner: { clipId: clip.id, assetId: clip.assetId },
+				currentSourceTimeMs: position.sourceTimeSec * 1000,
+				currentVirtualTimeMs: playheadSec() * 1000,
+				clipSourceEndMs: (clip.sourceEndSec ?? clip.sourceStartSec) * 1000,
+				samples,
+			});
+			if (drafts.length === 0) return 0;
+			// Anchored the same way every other region is, rather than trusting the
+			// draft's own virtual times: the model offsets source→virtual linearly,
+			// which is only right when no trim sits between the clip start and the
+			// playhead. `anchorRegionsWithDerivedMs` resolves it against the real
+			// layout, so a region created after a trim lands where it was authored.
+			const anchored = anchorRegionsWithDerivedMs(
+				drafts.map((draft) => ({
+					id: createId("cursormotion"),
+					startMs: finiteMs(draft.startMs),
+					endMs: finiteMs(draft.endMs),
+					assetId: draft.assetId,
+					startPoint: draft.startPoint,
+					endPoint: draft.endPoint,
+					controlPoint: draft.controlPoints[0] ?? draft.startPoint,
+					startAnchor: draft.startAnchor,
+					endAnchor: draft.endAnchor,
+					segmentKind: draft.segmentKind,
+					preset: draft.preset,
+					speed: draft.speed,
+					cycles: draft.cycles,
+					easing: draft.easing,
+				})),
+				document.timeline.clips,
+				() => createId("cursormotion"),
+			);
+			const next: AxcutDocument = {
+				...document,
+				cursorMotionRegions: [
+					...(document.cursorMotionRegions ?? []),
+					...anchored,
+				] as AxcutDocument["cursorMotionRegions"],
+			};
+			if (!(await saveDocument(next, { history: true }))) return 0;
+			return anchored.length;
+		},
+		[document, saveDocument],
+	);
+
+	// Preset / speed / turns / timing. One setter for the four because they are one
+	// gesture in the inspector and each is a single clamped scalar; splitting them
+	// into four identical callbacks the way the zoom controls are split would buy
+	// nothing but four more lines of the same shape.
+	const updateCursorMotionSettings = useCallback(
+		async (
+			id: string,
+			patch: {
+				preset?: CursorMotionPreset;
+				speed?: number;
+				cycles?: number;
+				easing?: CursorMotionEasing;
+			},
+		) => {
+			if (!document) return;
+			const next: AxcutDocument = {
+				...document,
+				cursorMotionRegions: patchPillById(document.cursorMotionRegions ?? [], id, {
+					...(patch.preset !== undefined ? { preset: patch.preset } : {}),
+					...(patch.speed !== undefined ? { speed: clampCursorMotionSpeed(patch.speed) } : {}),
+					...(patch.cycles !== undefined ? { cycles: clampCursorMotionCycles(patch.cycles) } : {}),
+					...(patch.easing !== undefined ? { easing: patch.easing } : {}),
+				}) as AxcutDocument["cursorMotionRegions"],
+			};
+			await saveDocument(next, { history: true });
+		},
+		[document, saveDocument],
+	);
+
+	// Dragging the handle over the preview, live/commit exactly like the zoom focus
+	// point above — same rollback discipline, same reason: the whole drag has to be
+	// ONE undo step, recorded only once the write landed.
+	const cursorMotionLiveRef = useRef<AxcutDocument | null>(null);
+	const cursorMotionRollbackRef = useRef<AxcutDocument | null>(null);
+
+	const updateCursorMotionControlPointLive = useCallback(
+		(id: string, point: CursorMotionPoint) => {
+			const doc = useProjectStore.getState().document;
+			if (!doc) return;
+			if (cursorMotionLiveRef.current !== doc) cursorMotionRollbackRef.current = doc;
+			const next: AxcutDocument = {
+				...doc,
+				cursorMotionRegions: patchPillById(doc.cursorMotionRegions ?? [], id, {
+					controlPoint: clampCursorMotionPoint(point),
+				}) as AxcutDocument["cursorMotionRegions"],
+			};
+			setDocument(next, { history: false });
+			cursorMotionLiveRef.current = next;
+		},
+		[setDocument],
+	);
+
+	const commitCursorMotionControlPoint = useCallback(async () => {
+		const doc = useProjectStore.getState().document;
+		if (!doc) return;
+		const rollback = cursorMotionLiveRef.current === doc ? cursorMotionRollbackRef.current : null;
+		cursorMotionRollbackRef.current = null;
+		cursorMotionLiveRef.current = null;
+		if (!(await saveDocument(doc, { history: true, historyBase: rollback })) && rollback) {
+			useProjectStore.setState((state) =>
+				state.document === doc ? { document: rollback, revision: state.revision + 1 } : {},
+			);
+		}
+	}, [saveDocument]);
+
+	// Copy the LOOK of one section onto every move section: preset, speed, turns,
+	// timing. Deliberately not the control point — it is an absolute position on
+	// the frame, so copying it would drag every other path towards this one's
+	// midpoint. Holds are skipped because a hold has no path to shape.
+	const applyCursorMotionToAllMoves = useCallback(
+		async (id: string) => {
+			if (!document) return 0;
+			const regions = document.cursorMotionRegions ?? [];
+			const source = regions.find((region) => region.id === id);
+			if (!source) return 0;
+			const targets = regions.filter((region) => region.segmentKind === "move");
+			if (targets.length === 0) return 0;
+			const next: AxcutDocument = {
+				...document,
+				cursorMotionRegions: regions.map((region) =>
+					region.segmentKind === "move"
+						? {
+								...region,
+								preset: source.preset,
+								speed: source.speed,
+								cycles: source.cycles,
+								easing: source.easing,
+							}
+						: region,
+				) as AxcutDocument["cursorMotionRegions"],
+			};
+			if (!(await saveDocument(next, { history: true }))) return 0;
+			return targets.length;
+		},
+		[document, saveDocument],
+	);
+
+	// Cut one section in two at the playhead. The shared anchor is SAMPLED off the
+	// region's own path rather than interpolated between its endpoints: the halves
+	// have to meet where the cursor already passed, or splitting a curve visibly
+	// teleports it. The new anchor is `manual` on both sides — it is the editor's
+	// cut, not something the recording said.
+	const splitCursorMotionAtPlayhead = useCallback(
+		async (id: string) => {
+			if (!document) return false;
+			const region = (document.cursorMotionRegions ?? []).find((r) => r.id === id);
+			if (!region) return false;
+			const model = toModelCursorMotionRegion(region);
+			const position = resolveNativePosition(
+				playheadSec(),
+				resolveVisibleClips(document),
+				document.timeline.clips,
+			);
+			if (!position || position.clip.id !== region.clipId) return false;
+			const sourceMs = position.sourceTimeSec * 1000;
+			// A split needs room on both sides; the model's own floor for a section is
+			// 2 ms, and anything under it produces a region no renderer can sample.
+			if (sourceMs <= model.sourceStartMs + 2 || sourceMs >= model.sourceEndMs - 2) return false;
+			const middle = sampleStoredCursorMotionRegion(region, sourceMs);
+			const splitVirtualMs = finiteMs(
+				region.startMs +
+					((sourceMs - model.sourceStartMs) /
+						Math.max(1, model.sourceEndMs - model.sourceStartMs)) *
+						(region.endMs - region.startMs),
+			);
+			const halves: AxcutCursorMotionRegion[] = [
+				{
+					...region,
+					id: createId("cursormotion"),
+					endMs: splitVirtualMs,
+					sourceEndSec: sourceMs / 1000,
+					endPoint: middle,
+					endAnchor: "manual",
+					controlPoint: clampCursorMotionPoint({
+						cx: (region.startPoint.cx + middle.cx) / 2,
+						cy: (region.startPoint.cy + middle.cy) / 2,
+					}),
+				},
+				{
+					...region,
+					id: createId("cursormotion"),
+					startMs: splitVirtualMs,
+					sourceStartSec: sourceMs / 1000,
+					startPoint: middle,
+					startAnchor: "manual",
+					controlPoint: clampCursorMotionPoint({
+						cx: (middle.cx + region.endPoint.cx) / 2,
+						cy: (middle.cy + region.endPoint.cy) / 2,
+					}),
+				},
+			];
+			const next: AxcutDocument = {
+				...document,
+				cursorMotionRegions: (document.cursorMotionRegions ?? []).flatMap((r) =>
+					r.id === id ? halves : [r],
+				) as AxcutDocument["cursorMotionRegions"],
+			};
+			return await saveDocument(next, { history: true });
 		},
 		[document, saveDocument],
 	);
@@ -1175,6 +1423,7 @@ export function useTimeline() {
 
 	return {
 		zoomRegions: document?.zoomRanges ?? [],
+		cursorMotionRegions: document?.cursorMotionRegions ?? [],
 		trimRanges: document?.timeline.trimRanges ?? [],
 		annotationRegions: (document?.annotations ?? []) as unknown as AnnotationRegion[],
 		speedRegions,
@@ -1187,6 +1436,12 @@ export function useTimeline() {
 		clipSelection,
 		addZoom,
 		addZoomsBulk,
+		addCursorMotion,
+		updateCursorMotionSettings,
+		updateCursorMotionControlPointLive,
+		commitCursorMotionControlPoint,
+		applyCursorMotionToAllMoves,
+		splitCursorMotionAtPlayhead,
 		addTrim,
 		addAnnotation,
 		addSpeed,

--- a/src/lib/ai-edition/timeline/cursorMotionRegions.test.ts
+++ b/src/lib/ai-edition/timeline/cursorMotionRegions.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import type { AxcutCursorMotionRegion } from "../schema";
+import { sampleStoredCursorMotionRegion, toModelCursorMotionRegion } from "./cursorMotionRegions";
+
+const region = (patch: Partial<AxcutCursorMotionRegion> = {}): AxcutCursorMotionRegion => ({
+	id: "cm_1",
+	startMs: 2000,
+	endMs: 4000,
+	clipId: "clip_a",
+	assetId: "asset_1",
+	sourceStartSec: 1,
+	sourceEndSec: 3,
+	startPoint: { cx: 0.1, cy: 0.5 },
+	endPoint: { cx: 0.9, cy: 0.5 },
+	controlPoint: { cx: 0.5, cy: 0.2 },
+	startAnchor: "manual",
+	endAnchor: "click",
+	segmentKind: "move",
+	preset: "arc",
+	speed: 1,
+	cycles: 1,
+	easing: "linear",
+	...patch,
+});
+
+describe("toModelCursorMotionRegion", () => {
+	it("converts the stored anchor's seconds into the sampler's milliseconds", () => {
+		// The document stores `sourceStartSec`/`sourceEndSec` because that is the
+		// clip-anchor convention every region kind shares; the sampler works in ms.
+		// A conversion off by 1000 would put every region outside its own span and
+		// make the whole feature silently inert, so it gets its own assertion.
+		const model = toModelCursorMotionRegion(region());
+		expect(model.sourceStartMs).toBe(1000);
+		expect(model.sourceEndMs).toBe(3000);
+	});
+
+	it("wraps the single stored control point into the list the sampler takes", () => {
+		const model = toModelCursorMotionRegion(region());
+		expect(model.controlPoints).toEqual([{ cx: 0.5, cy: 0.2 }]);
+	});
+
+	it("survives a region with no clip anchor rather than producing NaN times", () => {
+		// The anchor is optional in the schema (shared with every other region kind,
+		// and v2 imports arrive without one). An unanchored region should collapse to
+		// a zero-length span, not to `NaN`, which would poison every comparison the
+		// sampler makes.
+		const model = toModelCursorMotionRegion(
+			region({ clipId: undefined, sourceStartSec: undefined, sourceEndSec: undefined }),
+		);
+		expect(model.sourceStartMs).toBe(0);
+		expect(model.sourceEndMs).toBe(0);
+		expect(model.clipId).toBe("");
+	});
+});
+
+describe("sampleStoredCursorMotionRegion", () => {
+	it("lands exactly on its anchors at both ends", () => {
+		// The endpoints are where the recording actually put the cursor. A path that
+		// starts or ends a pixel off teleports the pointer at the seam between two
+		// sections, which is the artefact the whole split-at-rests design exists to
+		// avoid.
+		const r = region();
+		expect(sampleStoredCursorMotionRegion(r, 1000)).toEqual(r.startPoint);
+		expect(sampleStoredCursorMotionRegion(r, 3000)).toEqual(r.endPoint);
+	});
+
+	it("clamps outside its span instead of extrapolating", () => {
+		const r = region();
+		expect(sampleStoredCursorMotionRegion(r, 0)).toEqual(r.startPoint);
+		expect(sampleStoredCursorMotionRegion(r, 99_000)).toEqual(r.endPoint);
+	});
+
+	it("bends towards the control point for an arc", () => {
+		// The control point sits above the chord (cy 0.2 against 0.5), so the middle
+		// of the path must too. This is the assertion that would fail if the control
+		// point were ever read as an offset rather than an absolute position.
+		const middle = sampleStoredCursorMotionRegion(region(), 2000);
+		expect(middle.cy).toBeLessThan(0.5);
+	});
+
+	it("leaves the chord alone when the preset is `recorded`", () => {
+		// `recorded` is inert by contract: it exists so a section can hold a selection
+		// without changing the picture. If it ever started bending, creating regions
+		// would silently alter footage nobody asked to edit.
+		const straight = sampleStoredCursorMotionRegion(region({ preset: "recorded" }), 2000);
+		expect(straight.cy).toBeCloseTo(0.5, 6);
+	});
+
+	it("reaches further along the path at 4x than at 1x, at the same instant", () => {
+		// Speed reshapes progress inside the section; it does not retime it. A quarter
+		// of the way through, the fast one has covered more ground — and both still
+		// end on the same anchor at the same time, which the anchor test above pins.
+		const at = (speed: number) =>
+			sampleStoredCursorMotionRegion(region({ preset: "straight", speed }), 1500).cx;
+		expect(at(4)).toBeGreaterThan(at(1));
+		expect(sampleStoredCursorMotionRegion(region({ preset: "straight", speed: 4 }), 3000)).toEqual(
+			region().endPoint,
+		);
+	});
+});

--- a/src/lib/ai-edition/timeline/cursorMotionRegions.ts
+++ b/src/lib/ai-edition/timeline/cursorMotionRegions.ts
@@ -1,0 +1,69 @@
+// The one conversion between the DOCUMENT's cursor motion region and the pure
+// sampler's. They differ on purpose — see the comment above
+// `cursorMotionRegionSchema` — and three callers need the bridge: the store (to
+// split a region at the playhead), the preview overlay (to draw the path), and
+// `sceneDescription` (to hand resolved geometry to the compositor). Writing it
+// three times is how the two shapes drift apart.
+
+import type {
+	CursorMotionPoint,
+	CursorMotionRegion,
+	CursorMotionTelemetrySample,
+} from "@/lib/cursor/cursorMotion";
+import { sampleCursorMotionRegion } from "@/lib/cursor/cursorMotion";
+import type { AxcutCursorMotionRegion } from "../schema";
+
+export function toModelCursorMotionRegion(region: AxcutCursorMotionRegion): CursorMotionRegion {
+	const sourceStartSec = region.sourceStartSec ?? 0;
+	const sourceEndSec = region.sourceEndSec ?? sourceStartSec;
+	return {
+		id: region.id,
+		// A stored region always carries its anchor — `addCursorMotion` runs the
+		// drafts through `anchorRegionsWithDerivedMs` before saving. The fallbacks
+		// exist because the SCHEMA leaves the anchor optional (it is shared with
+		// every other region kind, and v2 imports arrive without one); the sampler
+		// never reads either field, so an empty string here changes no geometry.
+		clipId: region.clipId ?? "",
+		assetId: region.assetId ?? "",
+		startMs: region.startMs,
+		endMs: region.endMs,
+		sourceStartMs: Math.round(sourceStartSec * 1000),
+		sourceEndMs: Math.round(sourceEndSec * 1000),
+		startPoint: region.startPoint,
+		endPoint: region.endPoint,
+		controlPoints: [region.controlPoint],
+		startAnchor: region.startAnchor,
+		endAnchor: region.endAnchor,
+		segmentKind: region.segmentKind,
+		preset: region.preset,
+		speed: region.speed,
+		cycles: region.cycles,
+		easing: region.easing,
+	};
+}
+
+/** Where the cursor sits at `sourceTimeMs` inside `region`, per the region's own
+ *  preset, speed and easing. Used to place a manual split's shared anchor: both
+ *  halves must start and end exactly where the path already passed, or the split
+ *  visibly moves the cursor. */
+export function sampleStoredCursorMotionRegion(
+	region: AxcutCursorMotionRegion,
+	sourceTimeMs: number,
+): CursorMotionPoint {
+	return sampleCursorMotionRegion(toModelCursorMotionRegion(region), sourceTimeMs);
+}
+
+/** Native cursor samples carry `interactionType` and `visible` already, and the
+ *  sampler asks for nothing else. This is a widening, not a conversion — it exists
+ *  so callers don't have to assert the structural match at every call site. */
+export function toCursorMotionSamples(
+	samples: readonly {
+		timeMs: number;
+		cx: number;
+		cy: number;
+		visible?: boolean;
+		interactionType?: string | null;
+	}[],
+): CursorMotionTelemetrySample[] {
+	return samples as CursorMotionTelemetrySample[];
+}

--- a/src/lib/ai-edition/transcription/status.test.ts
+++ b/src/lib/ai-edition/transcription/status.test.ts
@@ -243,6 +243,7 @@ describe("transcriptRelevantAssetIds", () => {
 		transcripts: [],
 		annotations: [],
 		zoomRanges: [],
+		cursorMotionRegions: [],
 		legacyEditor: null,
 	};
 

--- a/src/lib/cursor/cursorMotion.test.ts
+++ b/src/lib/cursor/cursorMotion.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from "vitest";
+import {
+	applyCursorMotionSpeed,
+	buildCursorMotionRegionDrafts,
+	type CursorMotionPath,
+	type CursorMotionPreset,
+	type CursorMotionRegion,
+	clampCursorMotionCycles,
+	clampCursorMotionSpeed,
+	findCursorMotionRegionAtSourceTime,
+	projectCursorMotionPointToCrop,
+	sampleCursorMotion,
+	sampleCursorMotionRegion,
+	unprojectCursorMotionPointFromCrop,
+} from "./cursorMotion";
+
+const owner = { clipId: "clip-1", assetId: "asset-1" };
+const start = { cx: 0.1, cy: 0.5 };
+const end = { cx: 0.8, cy: 0.5 };
+
+function region(overrides: Partial<CursorMotionRegion> = {}): CursorMotionRegion {
+	return {
+		id: "motion-1",
+		...owner,
+		startMs: 2000,
+		endMs: 3000,
+		sourceStartMs: 100,
+		sourceEndMs: 1100,
+		startPoint: start,
+		endPoint: end,
+		controlPoints: [{ cx: 0.45, cy: 0.2 }],
+		startAnchor: "manual",
+		endAnchor: "click",
+		segmentKind: "move",
+		preset: "arc",
+		speed: 1,
+		cycles: 2,
+		easing: "linear",
+		...overrides,
+	};
+}
+
+function linearPath(): CursorMotionPath {
+	return {
+		sampleAtSourceTime(sourceTimeMs) {
+			const progress = Math.max(0, Math.min(1, (sourceTimeMs - 100) / 1000));
+			return {
+				cx: start.cx + (end.cx - start.cx) * progress,
+				cy: start.cy,
+			};
+		},
+	};
+}
+
+describe("cursor motion sampling", () => {
+	it("preserves identity crop coordinates by reference", () => {
+		const point = { cx: 0.25, cy: 0.75 };
+		expect(projectCursorMotionPointToCrop(point, { x: 0, y: 0, width: 1, height: 1 })).toBe(point);
+	});
+
+	it("projects crop coordinates and keeps inclusive edges stable", () => {
+		const crop = { x: 0.2, y: 0.25, width: 0.5, height: 0.5 };
+		expect(projectCursorMotionPointToCrop({ cx: 0.45, cy: 0.5 }, crop)).toEqual({
+			cx: 0.5,
+			cy: 0.5,
+		});
+		expect(projectCursorMotionPointToCrop({ cx: 0.2, cy: 0.25 }, crop)).toEqual({
+			cx: 0,
+			cy: 0,
+		});
+		expect(projectCursorMotionPointToCrop({ cx: 0.7, cy: 0.75 }, crop)).toEqual({
+			cx: 1,
+			cy: 1,
+		});
+	});
+
+	it("hides points outside the crop and rejects invalid crop spans", () => {
+		const crop = { x: 0.2, y: 0.25, width: 0.5, height: 0.5 };
+		expect(projectCursorMotionPointToCrop({ cx: 0.199, cy: 0.5 }, crop)).toBeNull();
+		expect(projectCursorMotionPointToCrop({ cx: 0.45, cy: 0.751 }, crop)).toBeNull();
+		expect(projectCursorMotionPointToCrop({ cx: 0.45, cy: 0.5 }, { ...crop, width: 0 })).toBeNull();
+	});
+
+	it("maps dragged crop-space controls back to source normalized coordinates", () => {
+		const crop = { x: 0.2, y: 0.25, width: 0.5, height: 0.5 };
+		expect(unprojectCursorMotionPointFromCrop({ cx: 0.5, cy: 0.5 }, crop)).toEqual({
+			cx: 0.45,
+			cy: 0.5,
+		});
+		expect(unprojectCursorMotionPointFromCrop({ cx: -1, cy: 2 }, crop)).toEqual({
+			cx: 0.2,
+			cy: 0.75,
+		});
+	});
+
+	it("keeps every preset's normalized endpoints exact", () => {
+		const presets: CursorMotionPreset[] = [
+			"recorded",
+			"straight",
+			"arc",
+			"wave",
+			"loop",
+			"overshoot",
+		];
+		for (const preset of presets) {
+			const motion = region({ preset, speed: 4, cycles: 6, easing: "ease-in-out" });
+			expect(sampleCursorMotionRegion(motion, motion.sourceStartMs)).toBe(start);
+			expect(sampleCursorMotionRegion(motion, motion.sourceEndMs)).toBe(end);
+		}
+	});
+
+	it("preserves the recorded sample by reference until a creative preset is selected", () => {
+		const recorded = { cx: 0.37, cy: 0.61 };
+		const path: CursorMotionPath = { sampleAtSourceTime: () => recorded };
+		const result = sampleCursorMotion({
+			path,
+			regions: [region({ preset: "recorded", speed: 4 })],
+			owner,
+			sourceTimeMs: 400,
+		});
+		expect(result).toBe(recorded);
+	});
+
+	it("clamps and rounds speed, and accelerates without a frozen prefix", () => {
+		expect(clampCursorMotionSpeed(Number.NaN)).toBe(1);
+		expect(clampCursorMotionSpeed(Number.POSITIVE_INFINITY)).toBe(1);
+		expect(clampCursorMotionSpeed(0.2)).toBe(1);
+		expect(clampCursorMotionSpeed(2.26)).toBe(2.3);
+		expect(clampCursorMotionSpeed(99)).toBe(4);
+		expect(applyCursorMotionSpeed(0.25, 2)).toBeCloseTo(0.4375);
+		expect(applyCursorMotionSpeed(0, 4)).toBe(0);
+		expect(applyCursorMotionSpeed(1, 4)).toBe(1);
+	});
+
+	it("clamps wave and loop cycles to whole values from one through six", () => {
+		expect(clampCursorMotionCycles(Number.NaN)).toBe(1);
+		expect(clampCursorMotionCycles(0)).toBe(1);
+		expect(clampCursorMotionCycles(3.6)).toBe(4);
+		expect(clampCursorMotionCycles(20)).toBe(6);
+	});
+
+	it("uses a source-time half-open interval at adjacent boundaries", () => {
+		const first = region({ id: "first", sourceStartMs: 100, sourceEndMs: 500 });
+		const second = region({
+			id: "second",
+			sourceStartMs: 500,
+			sourceEndMs: 900,
+			startPoint: { cx: 0.45, cy: 0.5 },
+			preset: "straight",
+		});
+		expect(findCursorMotionRegionAtSourceTime([first, second], owner, 499.999)?.id).toBe("first");
+		expect(findCursorMotionRegionAtSourceTime([first, second], owner, 500)?.id).toBe("second");
+		expect(findCursorMotionRegionAtSourceTime([first, second], owner, 900)).toBeNull();
+	});
+
+	it("does not apply a region owned by another clip or asset", () => {
+		const recorded = { cx: 0.42, cy: 0.42 };
+		const path: CursorMotionPath = { sampleAtSourceTime: () => recorded };
+		const motion = region({ preset: "wave" });
+		expect(
+			sampleCursorMotion({
+				path,
+				regions: [motion],
+				owner: { clipId: "clip-2", assetId: "asset-1" },
+				sourceTimeMs: 500,
+			}),
+		).toBe(recorded);
+		expect(
+			sampleCursorMotion({
+				path,
+				regions: [motion],
+				owner: { clipId: "clip-1", assetId: "asset-2" },
+				sourceTimeMs: 500,
+			}),
+		).toBe(recorded);
+	});
+
+	it("produces distinct arc, wave, loop, and overshoot shapes", () => {
+		const arc = sampleCursorMotionRegion(region({ preset: "arc" }), 600);
+		const wave = sampleCursorMotionRegion(region({ preset: "wave" }), 300);
+		const loop = sampleCursorMotionRegion(region({ preset: "loop" }), 475);
+		const overshoot = Array.from({ length: 80 }, (_, index) =>
+			sampleCursorMotionRegion(
+				region({ preset: "overshoot", controlPoints: [{ cx: 0.45, cy: 0.5 }] }),
+				100 + (1000 * index) / 79,
+			),
+		);
+		expect(arc.cy).toBeLessThan(0.5);
+		expect(wave.cy).not.toBeCloseTo(0.5);
+		expect(loop.cy).not.toBeCloseTo(0.5);
+		expect(overshoot.some((point) => point.cx > end.cx)).toBe(true);
+	});
+});
+
+describe("cursor motion draft builder", () => {
+	it("builds only through the next click and keeps virtual and source time separate", () => {
+		const drafts = buildCursorMotionRegionDrafts({
+			owner,
+			currentSourceTimeMs: 500,
+			currentVirtualTimeMs: 4500,
+			clipSourceEndMs: 2000,
+			path: linearPath(),
+			samples: [
+				{ timeMs: 500, cx: 0.38, cy: 0.5 },
+				{ timeMs: 900, cx: 0.66, cy: 0.5, interactionType: "click" },
+				{ timeMs: 1500, cx: 0.8, cy: 0.5, interactionType: "click" },
+			],
+		});
+
+		expect(drafts).toHaveLength(1);
+		expect(drafts[0]).toMatchObject({
+			...owner,
+			startMs: 4500,
+			endMs: 4900,
+			sourceStartMs: 500,
+			sourceEndMs: 900,
+			startAnchor: "manual",
+			endAnchor: "click",
+			segmentKind: "move",
+			preset: "recorded",
+			speed: 1,
+			easing: "ease-in-out",
+		});
+	});
+
+	it("splits a recorded stop into move, hold, and move drafts", () => {
+		const drafts = buildCursorMotionRegionDrafts({
+			owner,
+			currentSourceTimeMs: 0,
+			currentVirtualTimeMs: 2000,
+			clipSourceEndMs: 1000,
+			samples: [
+				{ timeMs: 0, cx: 0.1, cy: 0.5 },
+				{ timeMs: 100, cx: 0.25, cy: 0.5 },
+				{ timeMs: 200, cx: 0.4, cy: 0.5 },
+				{ timeMs: 350, cx: 0.4, cy: 0.5 },
+				{ timeMs: 500, cx: 0.401, cy: 0.5 },
+				{ timeMs: 650, cx: 0.4, cy: 0.5 },
+				{ timeMs: 800, cx: 0.7, cy: 0.5 },
+				{ timeMs: 1000, cx: 0.9, cy: 0.5, interactionType: "click" },
+			],
+		});
+
+		expect(
+			drafts.map((draft) => [
+				draft.sourceStartMs,
+				draft.sourceEndMs,
+				draft.segmentKind,
+				draft.startAnchor,
+				draft.endAnchor,
+			]),
+		).toEqual([
+			[0, 200, "move", "manual", "rest"],
+			[200, 650, "hold", "rest", "rest"],
+			[650, 1000, "move", "rest", "click"],
+		]);
+		expect(drafts.every((draft) => draft.preset === "recorded" && draft.speed === 1)).toBe(true);
+	});
+
+	it("does not treat a telemetry gap longer than 150ms as a stop", () => {
+		const drafts = buildCursorMotionRegionDrafts({
+			owner,
+			currentSourceTimeMs: 0,
+			currentVirtualTimeMs: 0,
+			clipSourceEndMs: 1000,
+			samples: [
+				{ timeMs: 0, cx: 0.1, cy: 0.5 },
+				{ timeMs: 100, cx: 0.4, cy: 0.5 },
+				{ timeMs: 700, cx: 0.4, cy: 0.5 },
+				{ timeMs: 1000, cx: 0.8, cy: 0.5, interactionType: "click" },
+			],
+		});
+
+		expect(drafts).toHaveLength(1);
+		expect(drafts[0].segmentKind).toBe("move");
+	});
+
+	it("does not confuse a native cursor atlas asset id with media ownership", () => {
+		const activeSamples = [
+			{ timeMs: 0, cx: 0.1, cy: 0.5, assetId: "cursor-arrow" },
+			{
+				timeMs: 800,
+				cx: 0.7,
+				cy: 0.5,
+				interactionType: "click",
+				assetId: "cursor-pointer",
+			},
+		];
+		const drafts = buildCursorMotionRegionDrafts({
+			owner,
+			currentSourceTimeMs: 0,
+			currentVirtualTimeMs: 0,
+			clipSourceEndMs: 1000,
+			samples: activeSamples,
+		});
+
+		expect(drafts).toHaveLength(1);
+		expect(drafts[0].sourceEndMs).toBe(800);
+	});
+
+	it("returns no draft when the active clip has no following click", () => {
+		expect(
+			buildCursorMotionRegionDrafts({
+				owner,
+				currentSourceTimeMs: 500,
+				currentVirtualTimeMs: 2500,
+				clipSourceEndMs: 1000,
+				samples: [
+					{ timeMs: 500, cx: 0.4, cy: 0.5, interactionType: "click" },
+					{ timeMs: 800, cx: 0.7, cy: 0.5 },
+				],
+			}),
+		).toEqual([]);
+	});
+
+	it("does not create a microscopic segment for anchors within one millisecond", () => {
+		expect(
+			buildCursorMotionRegionDrafts({
+				owner,
+				currentSourceTimeMs: 0,
+				currentVirtualTimeMs: 0,
+				clipSourceEndMs: 100,
+				samples: [
+					{ timeMs: 0, cx: 0.4, cy: 0.5 },
+					{ timeMs: 0.5, cx: 0.4, cy: 0.5, interactionType: "click" },
+				],
+			}),
+		).toEqual([]);
+	});
+});

--- a/src/lib/cursor/cursorMotion.ts
+++ b/src/lib/cursor/cursorMotion.ts
@@ -1,0 +1,561 @@
+export const CURSOR_MOTION_PRESETS = [
+	"recorded",
+	"straight",
+	"arc",
+	"wave",
+	"loop",
+	"overshoot",
+] as const;
+
+export type CursorMotionPreset = (typeof CURSOR_MOTION_PRESETS)[number];
+
+export const CURSOR_MOTION_EASINGS = ["linear", "ease-in", "ease-out", "ease-in-out"] as const;
+
+export type CursorMotionEasing = (typeof CURSOR_MOTION_EASINGS)[number];
+
+export const CURSOR_MOTION_ANCHORS = ["manual", "rest", "click"] as const;
+
+export type CursorMotionAnchor = (typeof CURSOR_MOTION_ANCHORS)[number];
+
+export const CURSOR_MOTION_SEGMENT_KINDS = ["move", "hold"] as const;
+
+export type CursorMotionSegmentKind = (typeof CURSOR_MOTION_SEGMENT_KINDS)[number];
+
+export interface CursorMotionPoint {
+	cx: number;
+	cy: number;
+}
+
+export interface CursorMotionCropRegion {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+export interface CursorMotionOwner {
+	clipId: string;
+	assetId: string;
+}
+
+export interface CursorMotionTelemetrySample extends CursorMotionPoint {
+	timeMs: number;
+	visible?: boolean;
+	interactionType?: string | null;
+}
+
+export interface CursorMotionPath {
+	sampleAtSourceTime(sourceTimeMs: number): CursorMotionPoint | null;
+}
+
+export interface CursorMotionRegion extends CursorMotionOwner {
+	id: string;
+	startMs: number;
+	endMs: number;
+	sourceStartMs: number;
+	sourceEndMs: number;
+	startPoint: CursorMotionPoint;
+	endPoint: CursorMotionPoint;
+	controlPoints: CursorMotionPoint[];
+	startAnchor: CursorMotionAnchor;
+	endAnchor: CursorMotionAnchor;
+	segmentKind: CursorMotionSegmentKind;
+	preset: CursorMotionPreset;
+	speed: number;
+	cycles: number;
+	easing: CursorMotionEasing;
+}
+
+export type CursorMotionRegionDraft = Omit<CursorMotionRegion, "id">;
+
+export const CURSOR_MOTION_SPEED_MIN = 1;
+export const CURSOR_MOTION_SPEED_MAX = 4;
+export const DEFAULT_CURSOR_MOTION_SPEED = 1;
+export const CURSOR_MOTION_CYCLES_MIN = 1;
+export const CURSOR_MOTION_CYCLES_MAX = 6;
+
+const REST_MIN_DURATION_MS = 300;
+const REST_MAX_DIAMETER = 0.009;
+const REST_MAX_SAMPLE_GAP_MS = 150;
+const MIN_SEGMENT_DURATION_MS = 2;
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.min(max, Math.max(min, value));
+}
+
+export function clampCursorMotionPoint(point: CursorMotionPoint): CursorMotionPoint {
+	return {
+		cx: clamp(Number.isFinite(point.cx) ? point.cx : 0.5, 0, 1),
+		cy: clamp(Number.isFinite(point.cy) ? point.cy : 0.5, 0, 1),
+	};
+}
+
+export function projectCursorMotionPointToCrop(
+	point: CursorMotionPoint,
+	crop: CursorMotionCropRegion,
+): CursorMotionPoint | null {
+	if (
+		!Number.isFinite(point.cx) ||
+		!Number.isFinite(point.cy) ||
+		!Number.isFinite(crop.x) ||
+		!Number.isFinite(crop.y) ||
+		!Number.isFinite(crop.width) ||
+		!Number.isFinite(crop.height) ||
+		crop.width <= 0 ||
+		crop.height <= 0
+	) {
+		return null;
+	}
+	const right = crop.x + crop.width;
+	const bottom = crop.y + crop.height;
+	if (point.cx < crop.x || point.cx > right || point.cy < crop.y || point.cy > bottom) {
+		return null;
+	}
+	if (crop.x === 0 && crop.y === 0 && crop.width === 1 && crop.height === 1) return point;
+	return {
+		cx: point.cx === crop.x ? 0 : point.cx === right ? 1 : (point.cx - crop.x) / crop.width,
+		cy: point.cy === crop.y ? 0 : point.cy === bottom ? 1 : (point.cy - crop.y) / crop.height,
+	};
+}
+
+export function unprojectCursorMotionPointFromCrop(
+	point: CursorMotionPoint,
+	crop: CursorMotionCropRegion,
+): CursorMotionPoint | null {
+	if (
+		!Number.isFinite(point.cx) ||
+		!Number.isFinite(point.cy) ||
+		!Number.isFinite(crop.x) ||
+		!Number.isFinite(crop.y) ||
+		!Number.isFinite(crop.width) ||
+		!Number.isFinite(crop.height) ||
+		crop.width <= 0 ||
+		crop.height <= 0
+	) {
+		return null;
+	}
+	if (crop.x === 0 && crop.y === 0 && crop.width === 1 && crop.height === 1) {
+		return clampCursorMotionPoint(point);
+	}
+	return clampCursorMotionPoint({
+		cx: crop.x + clamp(point.cx, 0, 1) * crop.width,
+		cy: crop.y + clamp(point.cy, 0, 1) * crop.height,
+	});
+}
+
+export function clampCursorMotionSpeed(speed: number | null | undefined): number {
+	if (!Number.isFinite(speed)) return DEFAULT_CURSOR_MOTION_SPEED;
+	return (
+		Math.round(clamp(Number(speed), CURSOR_MOTION_SPEED_MIN, CURSOR_MOTION_SPEED_MAX) * 10) / 10
+	);
+}
+
+export function clampCursorMotionCycles(cycles: number | null | undefined): number {
+	if (!Number.isFinite(cycles)) return CURSOR_MOTION_CYCLES_MIN;
+	return clamp(Math.round(Number(cycles)), CURSOR_MOTION_CYCLES_MIN, CURSOR_MOTION_CYCLES_MAX);
+}
+
+export function applyCursorMotionSpeed(progress: number, speed: number | null | undefined): number {
+	const t = clamp(progress, 0, 1);
+	return 1 - (1 - t) ** clampCursorMotionSpeed(speed);
+}
+
+function applyCursorMotionEasing(progress: number, easing: CursorMotionEasing): number {
+	const t = clamp(progress, 0, 1);
+	switch (easing) {
+		case "ease-in":
+			return t ** 3;
+		case "ease-out":
+			return 1 - (1 - t) ** 3;
+		case "ease-in-out":
+			return t < 0.5 ? 4 * t ** 3 : 1 - (-2 * t + 2) ** 3 / 2;
+		default:
+			return t;
+	}
+}
+
+function lerp(a: number, b: number, progress: number): number {
+	return a + (b - a) * progress;
+}
+
+function cubicBezier(
+	start: number,
+	firstControl: number,
+	secondControl: number,
+	end: number,
+	progress: number,
+): number {
+	const inverse = 1 - progress;
+	return (
+		inverse ** 3 * start +
+		3 * inverse ** 2 * progress * firstControl +
+		3 * inverse * progress ** 2 * secondControl +
+		progress ** 3 * end
+	);
+}
+
+function easeOutBack(progress: number): number {
+	const overshoot = 1.70158;
+	const t = clamp(progress, 0, 1) - 1;
+	return 1 + (overshoot + 1) * t ** 3 + overshoot * t ** 2;
+}
+
+export function createDefaultCursorMotionControlPoint(
+	start: CursorMotionPoint,
+	end: CursorMotionPoint,
+): CursorMotionPoint {
+	const dx = end.cx - start.cx;
+	const dy = end.cy - start.cy;
+	const distance = Math.hypot(dx, dy);
+	const normalX = distance > 0.0001 ? dy / distance : 0;
+	const normalY = distance > 0.0001 ? -dx / distance : -1;
+	const amplitude = clamp(distance * 0.35, 0.06, 0.18);
+	return clampCursorMotionPoint({
+		cx: (start.cx + end.cx) / 2 + normalX * amplitude,
+		cy: (start.cy + end.cy) / 2 + normalY * amplitude,
+	});
+}
+
+function cursorMotionControlOffset(region: CursorMotionRegion): CursorMotionPoint {
+	const fallback = createDefaultCursorMotionControlPoint(region.startPoint, region.endPoint);
+	const controls = region.controlPoints.length > 0 ? region.controlPoints : [fallback];
+	const control = controls.reduce(
+		(sum, point) => ({ cx: sum.cx + point.cx, cy: sum.cy + point.cy }),
+		{ cx: 0, cy: 0 },
+	);
+	const midpoint = {
+		cx: (region.startPoint.cx + region.endPoint.cx) / 2,
+		cy: (region.startPoint.cy + region.endPoint.cy) / 2,
+	};
+	return {
+		cx: control.cx / controls.length - midpoint.cx,
+		cy: control.cy / controls.length - midpoint.cy,
+	};
+}
+
+export function sampleCursorMotionRegion(
+	region: CursorMotionRegion,
+	sourceTimeMs: number,
+): CursorMotionPoint {
+	const durationMs = Math.max(Number.EPSILON, region.sourceEndMs - region.sourceStartMs);
+	const rawProgress = clamp((sourceTimeMs - region.sourceStartMs) / durationMs, 0, 1);
+	if (rawProgress === 0) return region.startPoint;
+	if (rawProgress === 1) return region.endPoint;
+
+	const motionProgress = applyCursorMotionSpeed(rawProgress, region.speed);
+	const progress = applyCursorMotionEasing(motionProgress, region.easing);
+	const offset = cursorMotionControlOffset(region);
+	const base = {
+		cx: lerp(region.startPoint.cx, region.endPoint.cx, progress),
+		cy: lerp(region.startPoint.cy, region.endPoint.cy, progress),
+	};
+	const envelope = Math.sin(Math.PI * motionProgress);
+	const cycles = clampCursorMotionCycles(region.cycles);
+
+	let point: CursorMotionPoint;
+	switch (region.preset) {
+		case "arc": {
+			const first = region.controlPoints[0];
+			const second = region.controlPoints[1];
+			point =
+				first && second
+					? {
+							cx: cubicBezier(
+								region.startPoint.cx,
+								first.cx,
+								second.cx,
+								region.endPoint.cx,
+								progress,
+							),
+							cy: cubicBezier(
+								region.startPoint.cy,
+								first.cy,
+								second.cy,
+								region.endPoint.cy,
+								progress,
+							),
+						}
+					: { cx: base.cx + offset.cx * envelope, cy: base.cy + offset.cy * envelope };
+			break;
+		}
+		case "wave": {
+			const wave = Math.sin(Math.PI * 2 * cycles * motionProgress) * envelope;
+			point = { cx: base.cx + offset.cx * wave, cy: base.cy + offset.cy * wave };
+			break;
+		}
+		case "loop": {
+			const phase = Math.PI * 2 * cycles * motionProgress;
+			const tangentOffset = Math.sin(phase) * envelope;
+			const normalOffset = ((1 - Math.cos(phase)) / 2) * envelope;
+			point = {
+				cx: base.cx + offset.cx * tangentOffset - offset.cy * normalOffset,
+				cy: base.cy + offset.cy * tangentOffset + offset.cx * normalOffset,
+			};
+			break;
+		}
+		case "overshoot": {
+			const overshootProgress = easeOutBack(progress);
+			point = {
+				cx:
+					lerp(region.startPoint.cx, region.endPoint.cx, overshootProgress) +
+					offset.cx * envelope * 0.35,
+				cy:
+					lerp(region.startPoint.cy, region.endPoint.cy, overshootProgress) +
+					offset.cy * envelope * 0.35,
+			};
+			break;
+		}
+		default:
+			point = base;
+	}
+	return clampCursorMotionPoint(point);
+}
+
+export function findCursorMotionRegionAtSourceTime(
+	regions: readonly CursorMotionRegion[],
+	owner: CursorMotionOwner,
+	sourceTimeMs: number,
+): CursorMotionRegion | null {
+	for (let index = regions.length - 1; index >= 0; index -= 1) {
+		const region = regions[index];
+		if (
+			region.clipId === owner.clipId &&
+			region.assetId === owner.assetId &&
+			sourceTimeMs >= region.sourceStartMs &&
+			sourceTimeMs < region.sourceEndMs
+		) {
+			return region;
+		}
+	}
+	return null;
+}
+
+export function sampleCursorMotion(options: {
+	path: CursorMotionPath | null | undefined;
+	regions: readonly CursorMotionRegion[];
+	owner: CursorMotionOwner;
+	sourceTimeMs: number;
+}): CursorMotionPoint | null {
+	const recorded = options.path?.sampleAtSourceTime(options.sourceTimeMs) ?? null;
+	if (!recorded) return null;
+	const region = findCursorMotionRegionAtSourceTime(
+		options.regions,
+		options.owner,
+		options.sourceTimeMs,
+	);
+	if (!region || region.preset === "recorded") return recorded;
+	return sampleCursorMotionRegion(region, options.sourceTimeMs);
+}
+
+interface CursorMotionRestSpan {
+	startMs: number;
+	endMs: number;
+	point: CursorMotionPoint;
+}
+
+interface CursorMotionBuilderAnchor {
+	timeMs: number;
+	point: CursorMotionPoint;
+	kind: CursorMotionAnchor;
+}
+
+function isClickInteraction(interactionType: string | null | undefined): boolean {
+	return (
+		interactionType === "click" ||
+		interactionType === "double-click" ||
+		interactionType === "right-click" ||
+		interactionType === "middle-click"
+	);
+}
+
+function normalizeTelemetrySamples(
+	samples: readonly CursorMotionTelemetrySample[],
+): CursorMotionTelemetrySample[] {
+	return samples
+		.filter(
+			(sample) =>
+				sample.visible !== false &&
+				Number.isFinite(sample.timeMs) &&
+				Number.isFinite(sample.cx) &&
+				Number.isFinite(sample.cy),
+		)
+		.map((sample) => ({ ...sample, ...clampCursorMotionPoint(sample) }))
+		.sort((a, b) => a.timeMs - b.timeMs);
+}
+
+function detectCursorMotionRestSpans(
+	samples: readonly CursorMotionTelemetrySample[],
+): CursorMotionRestSpan[] {
+	const rests: CursorMotionRestSpan[] = [];
+	let startIndex = 0;
+	while (startIndex < samples.length - 1) {
+		let endIndex = startIndex + 1;
+		let minCx = samples[startIndex].cx;
+		let maxCx = minCx;
+		let minCy = samples[startIndex].cy;
+		let maxCy = minCy;
+		while (endIndex < samples.length) {
+			const sample = samples[endIndex];
+			if (sample.timeMs - samples[endIndex - 1].timeMs > REST_MAX_SAMPLE_GAP_MS) break;
+			const nextMinCx = Math.min(minCx, sample.cx);
+			const nextMaxCx = Math.max(maxCx, sample.cx);
+			const nextMinCy = Math.min(minCy, sample.cy);
+			const nextMaxCy = Math.max(maxCy, sample.cy);
+			if (Math.hypot(nextMaxCx - nextMinCx, nextMaxCy - nextMinCy) > REST_MAX_DIAMETER) {
+				break;
+			}
+			minCx = nextMinCx;
+			maxCx = nextMaxCx;
+			minCy = nextMinCy;
+			maxCy = nextMaxCy;
+			endIndex += 1;
+		}
+
+		const run = samples.slice(startIndex, endIndex);
+		if (run.at(-1)!.timeMs - run[0].timeMs >= REST_MIN_DURATION_MS) {
+			const click = run.find((sample) => isClickInteraction(sample.interactionType));
+			const point = click
+				? clampCursorMotionPoint(click)
+				: clampCursorMotionPoint({
+						cx: run.reduce((total, sample) => total + sample.cx, 0) / run.length,
+						cy: run.reduce((total, sample) => total + sample.cy, 0) / run.length,
+					});
+			rests.push({ startMs: run[0].timeMs, endMs: run.at(-1)!.timeMs, point });
+			startIndex = endIndex;
+		} else {
+			startIndex += 1;
+		}
+	}
+	return rests;
+}
+
+function nearestSamplePoint(
+	samples: readonly CursorMotionTelemetrySample[],
+	timeMs: number,
+): CursorMotionPoint | null {
+	let nearest: CursorMotionTelemetrySample | null = null;
+	let distance = Number.POSITIVE_INFINITY;
+	for (const sample of samples) {
+		const candidateDistance = Math.abs(sample.timeMs - timeMs);
+		if (candidateDistance < distance) {
+			nearest = sample;
+			distance = candidateDistance;
+		}
+	}
+	return nearest ? clampCursorMotionPoint(nearest) : null;
+}
+
+function anchorPriority(anchor: CursorMotionAnchor): number {
+	if (anchor === "click") return 3;
+	if (anchor === "rest") return 2;
+	return 1;
+}
+
+function normalizeBuilderAnchors(
+	anchors: CursorMotionBuilderAnchor[],
+): CursorMotionBuilderAnchor[] {
+	const sorted = [...anchors].sort(
+		(a, b) => a.timeMs - b.timeMs || anchorPriority(b.kind) - anchorPriority(a.kind),
+	);
+	const normalized: CursorMotionBuilderAnchor[] = [];
+	for (const anchor of sorted) {
+		const previous = normalized.at(-1);
+		if (previous && Math.abs(previous.timeMs - anchor.timeMs) <= 1) {
+			if (anchorPriority(anchor.kind) > anchorPriority(previous.kind)) {
+				normalized[normalized.length - 1] = anchor;
+			}
+			continue;
+		}
+		normalized.push(anchor);
+	}
+	return normalized;
+}
+
+function getCursorMotionSegmentKind(
+	start: CursorMotionBuilderAnchor,
+	end: CursorMotionBuilderAnchor,
+): CursorMotionSegmentKind {
+	if (start.kind === "rest" && end.kind === "rest") return "hold";
+	return Math.hypot(end.point.cx - start.point.cx, end.point.cy - start.point.cy) <=
+		REST_MAX_DIAMETER
+		? "hold"
+		: "move";
+}
+
+export function buildCursorMotionRegionDrafts(options: {
+	owner: CursorMotionOwner;
+	currentSourceTimeMs: number;
+	currentVirtualTimeMs: number;
+	clipSourceEndMs: number;
+	samples: readonly CursorMotionTelemetrySample[];
+	path?: CursorMotionPath | null;
+}): CursorMotionRegionDraft[] {
+	if (
+		!Number.isFinite(options.currentSourceTimeMs) ||
+		!Number.isFinite(options.currentVirtualTimeMs) ||
+		!Number.isFinite(options.clipSourceEndMs)
+	) {
+		return [];
+	}
+	const sourceStartMs = Math.max(0, options.currentSourceTimeMs);
+	const clipSourceEndMs = Math.max(sourceStartMs, options.clipSourceEndMs);
+	if (sourceStartMs >= clipSourceEndMs) return [];
+
+	const ownerSamples = normalizeTelemetrySamples(options.samples);
+	const endClick = ownerSamples.find(
+		(sample) =>
+			sample.timeMs > sourceStartMs &&
+			sample.timeMs <= clipSourceEndMs &&
+			isClickInteraction(sample.interactionType),
+	);
+	if (!endClick) return [];
+
+	const sourceEndMs = endClick.timeMs;
+	const samples = ownerSamples.filter(
+		(sample) => sample.timeMs >= sourceStartMs && sample.timeMs <= sourceEndMs,
+	);
+	const startPoint =
+		options.path?.sampleAtSourceTime(sourceStartMs) ?? nearestSamplePoint(samples, sourceStartMs);
+	if (!startPoint) return [];
+
+	const rests = detectCursorMotionRestSpans(samples);
+	const anchors: CursorMotionBuilderAnchor[] = [
+		{ timeMs: sourceStartMs, point: clampCursorMotionPoint(startPoint), kind: "manual" },
+		{ timeMs: sourceEndMs, point: clampCursorMotionPoint(endClick), kind: "click" },
+	];
+	for (const rest of rests) {
+		anchors.push(
+			{ timeMs: rest.startMs, point: rest.point, kind: "rest" },
+			{ timeMs: rest.endMs, point: rest.point, kind: "rest" },
+		);
+	}
+
+	const normalizedAnchors = normalizeBuilderAnchors(anchors).filter(
+		(anchor) => anchor.timeMs >= sourceStartMs && anchor.timeMs <= sourceEndMs,
+	);
+	const drafts: CursorMotionRegionDraft[] = [];
+	for (let index = 1; index < normalizedAnchors.length; index += 1) {
+		const start = normalizedAnchors[index - 1];
+		const end = normalizedAnchors[index];
+		if (end.timeMs - start.timeMs < MIN_SEGMENT_DURATION_MS) continue;
+		const virtualOffset = options.currentVirtualTimeMs - sourceStartMs;
+		drafts.push({
+			...options.owner,
+			startMs: start.timeMs + virtualOffset,
+			endMs: end.timeMs + virtualOffset,
+			sourceStartMs: start.timeMs,
+			sourceEndMs: end.timeMs,
+			startPoint: start.point,
+			endPoint: end.point,
+			controlPoints: [createDefaultCursorMotionControlPoint(start.point, end.point)],
+			startAnchor: start.kind,
+			endAnchor: end.kind,
+			segmentKind: getCursorMotionSegmentKind(start, end),
+			preset: "recorded",
+			speed: DEFAULT_CURSOR_MOTION_SPEED,
+			cycles: CURSOR_MOTION_CYCLES_MIN,
+			easing: "ease-in-out",
+		});
+	}
+	return drafts;
+}

--- a/src/native/sceneDescription.test.ts
+++ b/src/native/sceneDescription.test.ts
@@ -1863,9 +1863,24 @@ describe("buildSceneDescription.cursor.motion", () => {
 	});
 
 	it("hands the geometry over resolved, in the compositor's own vocabulary", () => {
-		const scene = buildSceneDescription(makeDoc({ cursorMotionRegions: [region] }));
+		const doc = makeDoc({
+			assets: [makeAsset({ id: "a1", originalPath: "/rec.mp4" })],
+			clips: [
+				makeClip({
+					id: "c1",
+					assetId: "a1",
+					sourceStartSec: 3,
+					sourceEndSec: 10,
+					timelineStartSec: 0,
+					timelineEndSec: 7,
+				}),
+			],
+			cursorMotionRegions: [region],
+		});
+		const scene = buildSceneDescription(doc);
 		expect(scene.cursor.motion?.[0]).toEqual({
 			id: "cm_1",
+			clipIndex: 0,
 			startSec: 3.5,
 			endSec: 5.5,
 			startPoint: { cx: 0.1, cy: 0.2 },
@@ -1876,6 +1891,52 @@ describe("buildSceneDescription.cursor.motion", () => {
 			speed: 2,
 			easing: "ease-out",
 		});
+	});
+
+	it("tags each region with its owning clip's index in SCENE order", () => {
+		// The compositor filters the region list per clip before applying it to that
+		// clip's cursor track, so the tag is what keeps the second recording's regions
+		// off the first recording's track in a multi-asset project. The index is the
+		// position in `SceneDescription.clips` — the timeline-sorted order, which here
+		// differs from the document order the fixtures are declared in.
+		const asset = makeAsset({ id: "a1", originalPath: "/rec.mp4" });
+		const doc = makeDoc({
+			assets: [asset],
+			clips: [
+				makeClip({
+					id: "c2",
+					assetId: "a1",
+					sourceStartSec: 20,
+					sourceEndSec: 25,
+					timelineStartSec: 10,
+					timelineEndSec: 15,
+				}),
+				makeClip({
+					id: "c1",
+					assetId: "a1",
+					sourceStartSec: 3,
+					sourceEndSec: 10,
+					timelineStartSec: 2,
+					timelineEndSec: 7,
+				}),
+			],
+			cursorMotionRegions: [
+				{ ...region, id: "second-clip", clipId: "c2" },
+				{ ...region, id: "first-clip", clipId: "c1" },
+				{ ...region, id: "deleted-clip", clipId: "gone" },
+				{ ...region, id: "legacy", clipId: undefined },
+			],
+		});
+		const byId = new Map(
+			(buildSceneDescription(doc).cursor.motion ?? []).map((r) => [r.id, r.clipIndex]),
+		);
+		expect(byId.get("first-clip")).toBe(0);
+		expect(byId.get("second-clip")).toBe(1);
+		// A clip that no longer resolves (deleted, hidden) and a region that never
+		// carried one are emitted UNTAGGED: they apply to every track, the historical
+		// behaviour, rather than silently vanishing from the render.
+		expect(byId.get("deleted-clip")).toBeUndefined();
+		expect(byId.get("legacy")).toBeUndefined();
 	});
 
 	it("emits an empty list for a project that never opened the feature", () => {

--- a/src/native/sceneDescription.test.ts
+++ b/src/native/sceneDescription.test.ts
@@ -91,6 +91,7 @@ function makeDoc(
 		},
 		annotations: overrides.annotations ?? [],
 		zoomRanges: overrides.zoomRanges ?? [],
+		cursorMotionRegions: overrides.cursorMotionRegions ?? [],
 		legacyEditor: overrides.legacyEditor ?? null,
 	};
 }
@@ -1822,5 +1823,64 @@ describe("buildSceneDescription.captions", () => {
 		// The text colour is independently chosen via ColorField (hex); the background is the
 		// only piece that goes through the opacity-combining path.
 		expect(text?.color).toBe("#ffffff");
+	});
+});
+
+// --- cursor motion ---------------------------------------------------------
+
+describe("buildSceneDescription.cursor.motion", () => {
+	const region = {
+		id: "cm_1",
+		startMs: 4000,
+		endMs: 6000,
+		clipId: "c1",
+		assetId: "a1",
+		// The clip starts at source 3s, so the region's SOURCE span (3.5..5.5) is
+		// deliberately different from its virtual span (4..6). That difference is the
+		// whole point of these assertions.
+		sourceStartSec: 3.5,
+		sourceEndSec: 5.5,
+		startPoint: { cx: 0.1, cy: 0.2 },
+		endPoint: { cx: 0.8, cy: 0.9 },
+		controlPoint: { cx: 0.4, cy: 0.3 },
+		startAnchor: "rest" as const,
+		endAnchor: "click" as const,
+		segmentKind: "move" as const,
+		preset: "arc" as const,
+		speed: 2,
+		cycles: 3,
+		easing: "ease-out" as const,
+	};
+
+	it("emits the SOURCE span, not the timeline one", () => {
+		// `CursorTrack::with_motion` applies these to the cursor track, which is
+		// loaded per asset with its own offset already removed. Emitting virtual time
+		// here would drift the whole path by however much sits before the clip —
+		// silently, and only in projects that have anything before it.
+		const scene = buildSceneDescription(makeDoc({ cursorMotionRegions: [region] }));
+		expect(scene.cursor.motion).toHaveLength(1);
+		expect(scene.cursor.motion?.[0]).toMatchObject({ startSec: 3.5, endSec: 5.5 });
+	});
+
+	it("hands the geometry over resolved, in the compositor's own vocabulary", () => {
+		const scene = buildSceneDescription(makeDoc({ cursorMotionRegions: [region] }));
+		expect(scene.cursor.motion?.[0]).toEqual({
+			id: "cm_1",
+			startSec: 3.5,
+			endSec: 5.5,
+			startPoint: { cx: 0.1, cy: 0.2 },
+			endPoint: { cx: 0.8, cy: 0.9 },
+			controlPoint: { cx: 0.4, cy: 0.3 },
+			preset: "arc",
+			cycles: 3,
+			speed: 2,
+			easing: "ease-out",
+		});
+	});
+
+	it("emits an empty list for a project that never opened the feature", () => {
+		// Absent or empty means "play the recorded trajectory", which is what every
+		// existing project must keep doing.
+		expect(buildSceneDescription(makeDoc()).cursor.motion).toEqual([]);
 	});
 });

--- a/src/native/sceneDescription.ts
+++ b/src/native/sceneDescription.ts
@@ -847,6 +847,36 @@ export function buildSceneDescription(
 			clickBounce: settings.cursor.clickBounce,
 			clipToBounds: settings.cursor.clipToBounds,
 			theme: settings.cursorTheme,
+			// Emitted in SOURCE seconds and deliberately NOT run through
+			// `projectRegionsToSource` like the zoom and annotation regions above.
+			// Those are matched against each frame's time; these are applied once to
+			// the CURSOR TRACK (`CursorTrack::with_motion`), which is loaded per asset
+			// with its own offset already subtracted — the same clock the region's
+			// `sourceStartSec`/`sourceEndSec` are stored in. Projecting them would
+			// convert a value that is already in the target base.
+			//
+			// LIMITATION, multi-asset: `Scene.cursor.motion` carries no owner, and the
+			// compositor applies the whole list to whichever track is loaded. In a
+			// project whose clips draw on two different RECORDINGS, the second one's
+			// regions land on the first one's track. Single-asset projects — every
+			// project this feature has been used on so far — are unaffected. The fix
+			// belongs in the contract (an owner field, filtered in `live.rs` beside
+			// `resolve_scene_clip_index`), not here.
+			motion: (document.cursorMotionRegions ?? []).map((region) => {
+				const startSec = region.sourceStartSec ?? 0;
+				return {
+					id: region.id,
+					startSec,
+					endSec: region.sourceEndSec ?? startSec,
+					startPoint: region.startPoint,
+					endPoint: region.endPoint,
+					controlPoint: region.controlPoint,
+					preset: region.preset,
+					cycles: region.cycles,
+					speed: region.speed,
+					easing: region.easing,
+				};
+			}),
 		},
 		audio: {
 			gainDb: settings.audioGainDb,

--- a/src/native/sceneDescription.ts
+++ b/src/native/sceneDescription.ts
@@ -356,6 +356,12 @@ export type SceneCursorMotionEasing = "linear" | "ease-in-out" | "ease-in" | "ea
  *  preset. */
 export interface SceneCursorMotionRegion {
 	id: string;
+	/** Index of the clip (within `SceneDescription.clips`) whose source time this region's
+	 *  `startSec`/`endSec` are expressed in — the compositor filters the region list per
+	 *  clip before applying it to that clip's cursor track. Unset for a region whose owning
+	 *  clip can't be resolved (deleted, hidden): it then applies to every clip, the
+	 *  historical behaviour of payloads from before the field existed. */
+	clipIndex?: number;
 	startSec: number;
 	endSec: number;
 	/** Normalised screen-frame position the region starts from. */
@@ -518,6 +524,11 @@ export function buildSceneDescription(
 
 	const assetById = new Map(document.assets.map((a) => [a.id, a]));
 	const visibleClips = resolveVisibleClips(document);
+	// Region → clip ownership resolves through this map: `clipId` (document space) →
+	// index in `SceneDescription.clips` (scene space), the identity the compositor's
+	// per-clip cursor-motion filtering keys on. Order IS the identity here: `clips`
+	// below and this map must both read `visibleClips`, never two different orderings.
+	const clipIndexById = new Map(visibleClips.map((clip, index) => [clip.id, index] as const));
 	const clips: CompositorClipInput[] = visibleClips.flatMap((clip) => {
 		const asset = assetById.get(clip.assetId);
 		if (!asset?.originalPath) return [];
@@ -855,17 +866,19 @@ export function buildSceneDescription(
 			// `sourceStartSec`/`sourceEndSec` are stored in. Projecting them would
 			// convert a value that is already in the target base.
 			//
-			// LIMITATION, multi-asset: `Scene.cursor.motion` carries no owner, and the
-			// compositor applies the whole list to whichever track is loaded. In a
-			// project whose clips draw on two different RECORDINGS, the second one's
-			// regions land on the first one's track. Single-asset projects — every
-			// project this feature has been used on so far — are unaffected. The fix
-			// belongs in the contract (an owner field, filtered in `live.rs` beside
-			// `resolve_scene_clip_index`), not here.
+			// Each region is tagged with its owning clip's index in `SceneDescription.clips`
+			// (resolved from the document region's `clipId`), and the compositor filters
+			// the list per clip before applying it to that clip's track — so in a project
+			// whose clips draw on two different RECORDINGS, the second one's regions land
+			// on the second one's track, not the first's. A region whose `clipId` no longer
+			// resolves (clip deleted or hidden) or that never carried one (pre-field
+			// documents) is emitted UNTAGGED and applies to every track, the historical
+			// behaviour.
 			motion: (document.cursorMotionRegions ?? []).map((region) => {
 				const startSec = region.sourceStartSec ?? 0;
 				return {
 					id: region.id,
+					clipIndex: region.clipId ? clipIndexById.get(region.clipId) : undefined,
 					startSec,
 					endSec: region.sourceEndSec ?? startSec,
 					startPoint: region.startPoint,

--- a/src/native/sceneDescription.ts
+++ b/src/native/sceneDescription.ts
@@ -306,6 +306,48 @@ export interface SceneEffects {
 	motionBlur: number;
 }
 
+/** Shape a cursor motion region draws between its two anchors. `recorded` keeps the
+ *  captured trajectory, i.e. the region is inert — it exists so the editor can hold a
+ *  selection without altering the path. */
+export type SceneCursorMotionPreset =
+	| "recorded"
+	| "straight"
+	| "arc"
+	| "wave"
+	| "loop"
+	| "overshoot";
+
+export type SceneCursorMotionEasing = "linear" | "ease-in-out" | "ease-in" | "ease-out";
+
+/** One editable stretch of cursor trajectory, overriding the recorded telemetry between
+ *  `startSec` and `endSec`.
+ *
+ *  Anchors arrive RESOLVED: the editor owns anchor discovery (rests, clicks, manual
+ *  splits) and hands over absolute normalised points, so the compositor never has to
+ *  re-derive them from telemetry. That keeps this contract a pure geometry description —
+ *  the same list yields the same path whatever produced it.
+ *
+ *  `controlPoint` is absolute too, not an offset: the sampler takes its displacement from
+ *  the start/end midpoint, so a control point left at the midpoint is a no-op for every
+ *  preset. */
+export interface SceneCursorMotionRegion {
+	id: string;
+	startSec: number;
+	endSec: number;
+	/** Normalised screen-frame position the region starts from. */
+	startPoint: { cx: number; cy: number };
+	endPoint: { cx: number; cy: number };
+	/** Absolute normalised point steering the curve; midpoint = straight line. */
+	controlPoint: { cx: number; cy: number };
+	preset: SceneCursorMotionPreset;
+	/** Oscillations for `wave` and `loop`, 1..6. Ignored by the other presets. */
+	cycles: number;
+	/** 1..4. Higher settles near the destination sooner; it reshapes progress, it does
+	 *  not retime the region. */
+	speed: number;
+	easing: SceneCursorMotionEasing;
+}
+
 /** Cursor rendering, from the editor settings. */
 export interface SceneCursor {
 	show: boolean;
@@ -318,6 +360,10 @@ export interface SceneCursor {
 	clipToBounds: boolean;
 	/** Cursor theme id (sprite set). */
 	theme: string;
+	/** Editable motion regions, in timeline order. Absent or empty means the recorded
+	 *  trajectory plays untouched — which is what every project without the cursor
+	 *  choreography editor produces. */
+	motion?: SceneCursorMotionRegion[];
 }
 
 /** Everything native needs to compose the scene, serialized from one document. */


### PR DESCRIPTION
## Summary

Builds the editor half of cursor choreography on the v4 shell, and lands the two halves that were already written but never connected to anything.

Recorded cursor movement wanders on its way to a button, overshoots, then drifts while the presenter reads. This makes the path between two meaningful moments editable — a shape, a speed, a timing curve, and a handle to steer the curve on the preview — without touching the recording.

The branch carries three commits' worth of work:

- **`00d7018f`** — @YoneRai12's motion model, the exact head of #116. Merging this lands that PR's content.
- **`5b744971`** — the compositor half from `feat/cursor-motion-contract`: `SceneCursor.motion` plus the sampling in `crates/compositor/src/cursor.rs`.
- **`51cfab86`** — the editor layer, new here.

## Related issue

Refs #548, #113, #116

Not `Fixes`: #548 records open product questions and gaps this PR does not close (multi-asset ownership, GIF export, auto-split of an existing section, and whether six presets is the right number).

## What the editor does

1. Playhead in a clip → the path tool on the timeline toolbar.
2. The stretch from the playhead to the **next recorded click** is cut into sections, split at every click and every cursor stop (300 ms or longer, inside a circle 0.9% of the frame wide).
3. Sections appear on their own timeline lane, labelled Move or Hold, each carrying its speed.
4. Selecting one opens the inspector: preset, speed, timing, and — for wave and loop only — turns.
5. The preview draws the recorded trajectory and the edited one together, with a handle at the control point.
6. Previous / next walks the sections; apply-to-all copies the styling across every move.

The interaction model is @YoneRai12's, from #113, rebuilt rather than ported — every file that PR touches was deleted from `main` on 1 Aug when the v4 editor became the only editor. Two faults in it are fixed rather than reproduced: the panel had no label for the `recorded` preset, so the first button in the grid rendered blank, and the speed help text described a leading pause its own code comment says was reverted for looking broken.

## Design decisions worth reviewing

**Creating a region changes nothing.** New sections are born `recorded` at 1x. Projects that never open the feature render exactly as they do today.

**A pause is a section, not a stretch of path.** Rests become Hold sections that stay put. One continuous curve across a two-second pause makes the cursor drift while the presenter is deliberately holding still.

**Speed reshapes progress, it does not retime.** A section always ends on the recorded click at its original timestamp.

**The lane does not coalesce and does not drag.** Unlike every other lane: two touching sections with the same preset are still two sections, and being individually selectable is the feature — which is the state a fresh auto-split is always in. Their boundaries are anchors the recording placed, not a span to stretch, so the resize handles are gone and dragging is refused.

**`sceneDescription` emits the SOURCE span**, deliberately not projected the way zoom and annotation regions are: the compositor applies these once to the cursor track, which is already loaded in that clock.

## Known gaps

- **Multi-asset.** `Scene.cursor.motion` carries no owner, so in a project whose clips draw on two different recordings the second one's regions land on the first one's track. Commented at the site; the fix belongs in the contract, beside `resolve_scene_clip_index`.
- **The composited render is unverified here.** The Rust sampling is on the branch but the addon was not rebuilt in this checkout, so the cursor following the edited path has not been seen end to end.
- Auto-split of an existing section, GIF export, the agent tools and the CLI are unwired.
- Eleven locales carry English placeholders; French is translated.

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [ ] Patch
- [x] Minor
- [ ] Major / breaking change
- [ ] No release note needed

`cursorMotionRegions` is additive with a `[]` default, mirroring how `annotations` and `zoomRanges` landed at v3 — old projects load unchanged and no schema version bump is needed.

## Desktop impact
- [x] Windows
- [x] macOS
- [x] Linux
- [ ] Installer / packaging
- [ ] Not platform-specific

## Screenshots / video

Not attached yet. The editor layer was driven in the v4 browser preview (`vite.v4preview.config.ts`) against a seeded project: the lane rendering six sections, the inspector round-tripping a preset change into the pill label, the Hold section replacing the preset grid with its own copy, and a control-point drag reshaping the path and persisting. A recording against real footage should follow once the compositor addon is rebuilt.

## Testing

- `npx tsc --noEmit` — clean
- `npx vitest run src/lib/ai-edition src/native src/lib/cursor src/components/ai-edition` — 86 files, 1082 tests passing, of which 23 are new
- `npm run i18n:check` — passes, all 12 locales match en across 7 namespaces
- `npx biome check` on the touched trees — clean

New coverage: the document↔model bridge (seconds/milliseconds, the control point as an absolute position, `recorded` staying inert, speed advancing further without moving the end anchor), the store actions (split at rests and clicks, sections created inert, one write per auto-split, refusal with no following click, apply-to-all skipping holds and not copying the control point, split sampling the curve so both halves meet where the cursor passed), and the scene emit (source span, resolved geometry, empty list for untouched projects).

Writing those tests found a real defect: `tsc` does not cover test files, so a document built without the new field compiles and then crashes at runtime — which is exactly what broke the timeline tests first. The reads are defensive now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1544255706813825056 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cursor-motion editing with recorded, straight, arc, wave, loop, and overshoot presets.
  * Added speed, easing, cycles, control-point, split, delete, and apply-to-all controls.
  * Added move and hold timeline sections with dedicated styling.
  * Added preview overlays with recorded and edited paths and draggable control points.
  * Added scene export support and localized interface strings across supported languages.

* **Bug Fixes**
  * Preserved cursor clicks, cursor types, and unaffected motion data during edits.
  * Prevented cursor-motion sections from being deleted when copying fails.
  * Improved overlapping motion handling and clip-specific motion playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->