### PR TITLE
refactor(schema): drop the declarations nothing has ever read

### DIFF
--- a/src/lib/ai-edition/schema/index.ts
+++ b/src/lib/ai-edition/schema/index.ts
@@ -945,21 +945,6 @@ export const createProjectInputSchema = z.object({
 	title: z.string().trim().min(1).default("Untitled Project"),
 });
 
-export const addAssetInputSchema = z.object({
-	path: z.string().trim().min(1),
-	label: z.string().trim().optional(),
-	// "audio" imports an external voiceover / BGM / SFX file (issue #350); it has
-	// no video stream and never becomes the project's primary asset. Defaults to
-	// "video" so every existing caller keeps its current behaviour.
-	kind: z.enum(["video", "audio"]).default("video"),
-	autoTranscribe: z.boolean().default(true),
-});
-
-export const chatInputSchema = z.object({
-	sessionId: z.string().trim().min(1).optional(),
-	message: z.string().trim().min(1),
-});
-
 // Every code whisper.cpp's multilingual model can resolve, plus "auto" for
 // detection. Codes and order mirror whisper.cpp's own `g_lang` table
 // (`src/whisper.cpp`, verified against the tag `nix/whisper-stt.nix` pins —

--- a/src/lib/ai-edition/schema/index.ts
+++ b/src/lib/ai-edition/schema/index.ts
@@ -1081,8 +1081,6 @@ export type AxcutLegacyEditor = z.infer<typeof legacyEditorSchema>;
 export type AxcutDocument = z.infer<typeof documentSchema>;
 export type AxcutDocumentInput = z.input<typeof documentSchema>;
 export type CreateProjectInput = z.infer<typeof createProjectInputSchema>;
-export type AddAssetInput = z.infer<typeof addAssetInputSchema>;
-export type ChatInput = z.infer<typeof chatInputSchema>;
 export type TranscriptLanguageCode = z.infer<typeof transcriptLanguageSchema>;
 /** A real whisper.cpp language code — `TranscriptLanguageCode` minus the "auto" detection sentinel. */
 export type WhisperLanguageCode = Exclude<TranscriptLanguageCode, "auto">;


### PR DESCRIPTION
## Summary

Three removals in `schema/index.ts`, all of them declarations nothing ever read.

**`addAssetInputSchema.autoTranscribe`** — declared with a `true` default, one occurrence in the whole tree: its own line. Worse than clutter, because it reads like the switch that decides whether an imported asset gets transcribed. The next person working on transcription finds it, believes the decision already has a home, and wires their logic to a flag no code path consults. It surfaced while designing #560, which needs somewhere to express "transcribe only what can carry speech" — and this looked like it.

**`addAssetInputSchema`** itself, and the `AddAssetInput` it exported. No parse site, no import, no namespace import of the module. It named an IPC contract that no boundary validates against. It was also actively confusing: `document-service.ts` declares a **same-named** `AddAssetInput` interface (line 38) and *that* is the one every caller uses. Two types, one name, and the one that looked canonical was inert.

**`chatInputSchema`** and its `ChatInput` — same story, no shadowing twist.

## What is NOT removed, and why it looked removable

`createProjectInputSchema` stays. It reads as dead by exactly the same grep — zero references outside `schema/index.ts` — but its inferred `CreateProjectInput` types `createEmptyDocument`, which has **50 call sites**. The reference is one line below the type export, inside the same file, and is easy to miss.

Worth stating rather than quietly keeping: "no references outside its own module" is not a liveness test for a type that a function in that module consumes.

## Related issue

Refs #560 — found while pinning down where automatic transcription should be decided.

## Type of change
- [x] Refactor / maintenance

## Release impact
- [x] No release note needed

## Desktop impact
- [x] Not platform-specific

## Screenshots / video

_None — no user-visible change._

## Testing

- `npm run test` — **2236 passed, 4 skipped, 0 failed** (187 files)
- `npx tsc --noEmit` and `npx tsc -p tsconfig.test.json --noEmit` — clean
- `npm run lint` (Biome) — clean (15 pre-existing warnings in untouched files)

No test asserted on any of the removed declarations, so none needed changing. The typecheck is the real proof here: had any of the three been reachable, both `tsc` passes would say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the AI editing input validation schemas and their associated input types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->