### PR TITLE
feat(website): route all Discord links through getopenscreen.com/discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://github.com/getopenscreen/openscreen/blob/main/LICENSE"><img src="https://img.shields.io/github/license/getopenscreen/openscreen?style=for-the-badge&label=License" alt="License" /></a>
   <a href="https://github.com/getopenscreen/openscreen/releases/latest"><img src="https://img.shields.io/github/v/release/getopenscreen/openscreen?style=for-the-badge&label=Release" alt="Latest Release" /></a>
   <a href="https://github.com/getopenscreen/openscreen/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/getopenscreen/openscreen/ci.yml?style=for-the-badge&label=CI" alt="CI Status" /></a>
-  <a href="https://discord.gg/VvT6Vtnyh"><img src="https://img.shields.io/badge/Discord-Join%20us-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" /></a>
+  <a href="https://getopenscreen.com/discord"><img src="https://img.shields.io/badge/Discord-Join%20us-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" /></a>
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey?style=for-the-badge" alt="Platform" />
 </p>
 
@@ -194,7 +194,7 @@ For safety, download OpenScreen only from the official GitHub Releases linked fr
 
 OpenScreen is community-driven. If you need help, want to report a bug, or just want to chat with other users and contributors:
 
-- 💬 **Discord** — [Join the OpenScreen Discord](https://discord.gg/VvT6Vtnyh) for real-time help, showcase, and discussion
+- 💬 **Discord** — [Join the OpenScreen Discord](https://getopenscreen.com/discord) for real-time help, showcase, and discussion
 - 🐞 **[GitHub Issues](https://github.com/getopenscreen/openscreen/issues)** — bug reports and feature requests
 - 🗺️ **[Roadmap](./ROADMAP.md)** — see what we're building next
 

--- a/website/blog/2026-06-15-picking-up-openscreen.md
+++ b/website/blog/2026-06-15-picking-up-openscreen.md
@@ -28,7 +28,7 @@ Forking a popular archived project is a good way to quietly turn it into somethi
 - Stability before features. The recorder has to work on macOS, Windows and Linux. Bugs from real users go first.
 - It's not production-grade, and I'll keep saying so. Expect rough edges and breaking changes, including to the project format.
 
-The [roadmap](https://github.com/getopenscreen/openscreen/blob/main/ROADMAP.md) is public: record, edit, export, plus an optional AI editing layer that's off by default and never required. There's a [Discord](https://discord.gg/VvT6Vtnyh) with a roadmap channel if you want to argue about any of it.
+The [roadmap](https://github.com/getopenscreen/openscreen/blob/main/ROADMAP.md) is public: record, edit, export, plus an optional AI editing layer that's off by default and never required. There's a [Discord](https://getopenscreen.com/discord) with a roadmap channel if you want to argue about any of it.
 
 ## It already had contributors
 

--- a/website/blog/2026-08-24-store-and-crash-safe-recordings.md
+++ b/website/blog/2026-08-24-store-and-crash-safe-recordings.md
@@ -57,4 +57,4 @@ Webcam background effects have landed on all three compositor backends. Blur or 
 
 Still open: hardware encode on Linux, and measurements on discrete GPUs and QSV. It is still pre-1.x, so rough edges are expected and bug reports are welcome.
 
-Three months, ten releases. [Discord](https://discord.gg/VvT6Vtnyh) is open if you want to argue with any of it.
+Three months, ten releases. [Discord](https://getopenscreen.com/discord) is open if you want to argue with any of it.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -8,7 +8,7 @@ const SITE_URL = "https://getopenscreen.com";
 const REPO_SLUG = "getopenscreen/openscreen";
 const REPO_URL = `https://github.com/${REPO_SLUG}`;
 const UPSTREAM_REPO_URL = "https://github.com/siddharthvaddem/openscreen";
-const DISCORD_URL = "https://discord.gg/VvT6Vtnyh";
+const DISCORD_URL = "https://getopenscreen.com/discord";
 
 // Kept under ~155 characters: past that, Google truncates the snippet mid-word.
 const SITE_DESCRIPTION =

--- a/website/src/theme/Footer/index.tsx
+++ b/website/src/theme/Footer/index.tsx
@@ -48,7 +48,7 @@ export default function Footer(): ReactNode {
 							<Link href="https://github.com/getopenscreen/openscreen/blob/main/LICENSE">
 								License (MIT)
 							</Link>
-							<Link href="https://discord.gg/VvT6Vtnyh">Discord</Link>
+							<Link href="https://getopenscreen.com/discord">Discord</Link>
 						</div>
 					</div>
 				</div>

--- a/website/static/discord/index.html
+++ b/website/static/discord/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>OpenScreen Discord</title>
+		<!--
+			Single source of truth for the community invite. Every repo and site link
+			points at /discord, so rotating or expiring the invite only means editing
+			the URL below. GitHub Pages cannot serve real 301s; this meta refresh is
+			the supported equivalent.
+		-->
+		<meta http-equiv="refresh" content="0; url=https://discord.gg/WAqYMxdV8K" />
+		<link rel="canonical" href="https://discord.gg/WAqYMxdV8K" />
+	</head>
+	<body>
+		<p>Redirecting to the OpenScreen Discord… If nothing happens, <a href="https://discord.gg/WAqYMxdV8K">join here</a>.</p>
+		<script>
+			location.replace("https://discord.gg/WAqYMxdV8K");
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
## Summary
Every repo and website reference to the Discord invite now points at a single controlled URL — `https://getopenscreen.com/discord` — served by a redirect page on GitHub Pages. Rotating or expiring the invite now means editing one file (`website/static/discord/index.html`) instead of hunting hard-coded `discord.gg/...` links across the README, site config, footer and blog posts.

- README badge + community section, Docusaurus config (`sameAs`, navbar CTA) and footer now link to `getopenscreen.com/discord`.
- New `website/static/discord/index.html`: meta-refresh + JS redirect to the current permanent invite (no expiry, no usage limit). GitHub Pages cannot serve real 301s, so this is the supported equivalent.
- Two blog posts with hard-coded `discord.gg/VvT6Vtnyh` links updated to the stable URL.

## Related issue
N/A

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [ ] Patch
- [ ] Minor
- [ ] Major / breaking change
- [x] No release note needed

## Desktop impact
- [ ] Windows
- [ ] macOS
- [ ] Linux
- [ ] Installer / packaging
- [x] Not platform-specific

## Screenshots / video
N/A — link change only.

## Testing
- Invite verified against the public Discord API: `GET /invites/WAqYMxdV8K` → guild `OpenScreen` (1489517664467681310), `expires_at: null` (permanent).
- `grep -r VvT6Vtnyh` across md/ts/tsx/html/yml returns no remaining references.
- Docs workflow builds the site with the new page under `static/` (plain HTML, no build impact).

<!-- discord-thread-id:1544625236492689450 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Discord links across the README, website navigation, footer, and blog posts to use the project’s vanity URL.
  * Added a dedicated Discord redirect page for easier access to the community.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->