### PR TITLE
feat(editor): 【openscreen】既定背景をオレンジにし余白をなくす

### DIFF
--- a/src/components/ai-edition/recordingImport.test.ts
+++ b/src/components/ai-edition/recordingImport.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { replaceTimeline as replaceTimelineOp } from "@/lib/ai-edition/document/timeline";
 import { type AxcutDocument, createEmptyDocument } from "@/lib/ai-edition/schema";
+import { getEditorSettings } from "@/lib/ai-edition/store/editorSettings";
 import { useProjectStore } from "@/lib/ai-edition/store/projectStore";
 import { undo } from "@/lib/ai-edition/store/undo";
 import { clearHistory, past } from "@/lib/ai-edition/store/undoStack";
@@ -161,6 +162,10 @@ describe("what the recording import leaves on the undo stack", () => {
 
 		expect(past).toHaveLength(0);
 		expect(undo()).toBe(false);
+		expect(getEditorSettings(useProjectStore.getState().document)).toMatchObject({
+			wallpaper: "/wallpapers/wallpaper2.jpg",
+			padding: 0,
+		});
 	});
 
 	it("still has its clip after the first Ctrl+Z", async () => {

--- a/src/components/video-editor/editorDefaults.test.ts
+++ b/src/components/video-editor/editorDefaults.test.ts
@@ -11,6 +11,11 @@ import {
 import { normalizeProjectEditor } from "./projectPersistence";
 
 describe("editor defaults SSOT", () => {
+	it("starts new projects with the orange wallpaper and no padding", () => {
+		expect(DEFAULT_EDITOR_LAYOUT_SETTINGS.wallpaper).toBe("/wallpapers/wallpaper2.jpg");
+		expect(DEFAULT_EDITOR_LAYOUT_SETTINGS.padding).toBe(0);
+	});
+
 	it("keeps history defaults aligned with editor defaults", () => {
 		expect(INITIAL_EDITOR_STATE).toMatchObject({
 			...DEFAULT_EDITOR_APPEARANCE_SETTINGS,

--- a/src/components/video-editor/editorDefaults.ts
+++ b/src/components/video-editor/editorDefaults.ts
@@ -50,7 +50,7 @@ export const DEFAULT_EDITOR_LAYOUT_SETTINGS: {
 	cropRegion: typeof DEFAULT_CROP_REGION;
 	wallpaper: string;
 } = {
-	padding: 50,
+	padding: 0,
 	aspectRatio: "16:9",
 	cropRegion: DEFAULT_CROP_REGION,
 	wallpaper: DEFAULT_WALLPAPER,

--- a/src/components/video-editor/projectPersistence.test.ts
+++ b/src/components/video-editor/projectPersistence.test.ts
@@ -267,6 +267,6 @@ describe("wallpaper legacy normalization", () => {
 		const normalized = normalizeProjectEditor({
 			wallpaper: "file:///opt/Openscreen/resources/wallpapers/wallpaper99.jpg",
 		});
-		expect(normalized.wallpaper).toBe("/wallpapers/wallpaper1.jpg");
+		expect(normalized.wallpaper).toBe("/wallpapers/wallpaper2.jpg");
 	});
 });

--- a/src/lib/ai-edition/document/migrate.test.ts
+++ b/src/lib/ai-edition/document/migrate.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { EditorProjectData } from "@/components/video-editor/projectPersistence";
 import { getEditorSettings } from "@/lib/ai-edition/store/editorSettings";
-import { documentSchema } from "../schema";
+import { createEmptyDocument, documentSchema } from "../schema";
 import {
 	migrateAxcutDocumentToProjectData,
 	migrateProjectDataToAxcutDocument,
@@ -235,6 +235,14 @@ describe("migrateProjectDataToAxcutDocument", () => {
 });
 
 describe("migrateAxcutDocumentToProjectData", () => {
+	it("uses the current layout defaults when the document has no legacy editor settings", () => {
+		const doc = createEmptyDocument({ projectId: "new-project", title: "New project" });
+		const back = migrateAxcutDocumentToProjectData(doc);
+
+		expect(back.editor.wallpaper).toBe("/wallpapers/wallpaper2.jpg");
+		expect(back.editor.padding).toBe(0);
+	});
+
 	it("round-trips trimRanges back to trimRegions", () => {
 		const v2 = makeV2Project({
 			editor: {

--- a/src/lib/ai-edition/document/migrate.ts
+++ b/src/lib/ai-edition/document/migrate.ts
@@ -9,6 +9,7 @@
 // for AI-edition. (schemaVersion 3->4 upgrades for already-existing v3
 // documents are handled transparently inside documentSchema itself.)
 
+import { DEFAULT_EDITOR_LAYOUT_SETTINGS } from "@/components/video-editor/editorDefaults";
 import {
 	type EditorProjectData,
 	PROJECT_VERSION,
@@ -284,12 +285,12 @@ export function migrateAxcutDocumentToProjectData(input: AxcutDocument): EditorP
 	}));
 
 	const editor: ProjectEditorState = {
-		wallpaper: "",
+		wallpaper: DEFAULT_EDITOR_LAYOUT_SETTINGS.wallpaper,
 		shadowIntensity: 0,
 		showBlur: false,
 		motionBlurAmount: 0,
 		borderRadius: 0,
-		padding: 50,
+		padding: DEFAULT_EDITOR_LAYOUT_SETTINGS.padding,
 		cropRegion: { x: 0, y: 0, width: 1, height: 1 } as CropRegion,
 		zoomRegions: [],
 		cameraFullscreenRegions: [],

--- a/src/lib/ai-edition/store/editorSettings.test.ts
+++ b/src/lib/ai-edition/store/editorSettings.test.ts
@@ -37,6 +37,9 @@ const baseDoc: AxcutDocument = {
 describe("getEditorSettings", () => {
 	it("returns the defaults when the document has no legacyEditor", () => {
 		const snap = getEditorSettings(baseDoc);
+		expect(snap.wallpaper).toBe("/wallpapers/wallpaper2.jpg");
+		expect(snap.padding).toBe(0);
+		expect(snap.webcamWallpaper).toBe("/wallpapers/wallpaper1.jpg");
 		expect(snap.wallpaper).toBe(DEFAULT_EDITOR_SETTINGS.wallpaper);
 		expect(snap.aspectRatio).toBe("16:9");
 		expect(snap.shadowIntensity).toBe(DEFAULT_EDITOR_SETTINGS.shadowIntensity);

--- a/src/lib/ai-edition/store/editorSettings.ts
+++ b/src/lib/ai-edition/store/editorSettings.ts
@@ -33,7 +33,7 @@ import {
 	type WebcamSizePreset,
 } from "@/components/video-editor/types";
 import { DEFAULT_CURSOR_THEME_ID } from "@/lib/cursor/cursorThemes";
-import { DEFAULT_WALLPAPER } from "@/lib/wallpaper";
+import { DEFAULT_WALLPAPER, DEFAULT_WEBCAM_WALLPAPER } from "@/lib/wallpaper";
 import type { AspectRatio } from "@/utils/aspectRatioUtils";
 import { clamp01 } from "@/utils/math";
 import type { AxcutDocument } from "../schema";
@@ -124,7 +124,7 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettingsSnapshot = {
 	showBlur: false,
 	motionBlurAmount: 0.2,
 	borderRadius: 40,
-	padding: 50,
+	padding: 0,
 	cropRegion: DEFAULT_CROP_REGION,
 	webcamLayoutPreset: DEFAULT_WEBCAM_LAYOUT_PRESET,
 	webcamMaskShape: DEFAULT_WEBCAM_MASK_SHAPE,
@@ -136,7 +136,7 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettingsSnapshot = {
 	webcamCropPan: DEFAULT_CROP_PAN,
 	audioGainDb: 0,
 	webcamBackgroundMode: DEFAULT_WEBCAM_BACKGROUND_MODE,
-	webcamWallpaper: DEFAULT_WALLPAPER,
+	webcamWallpaper: DEFAULT_WEBCAM_WALLPAPER,
 	webcamBlurIntensity: DEFAULT_WEBCAM_BLUR_INTENSITY,
 	cursor: {
 		size: DEFAULT_CURSOR_SIZE,

--- a/src/lib/wallpaper.test.ts
+++ b/src/lib/wallpaper.test.ts
@@ -4,6 +4,7 @@ import {
 	BackgroundLoadError,
 	classifyWallpaper,
 	DEFAULT_WALLPAPER,
+	DEFAULT_WEBCAM_WALLPAPER,
 	resolveImageWallpaperUrl,
 	UnsafeImagePrefixError,
 	WALLPAPER_COUNT,
@@ -15,8 +16,9 @@ describe("WALLPAPER_PATHS", () => {
 		expect(WALLPAPER_PATHS).toHaveLength(WALLPAPER_COUNT);
 	});
 
-	it("DEFAULT_WALLPAPER is WALLPAPER_PATHS[0]", () => {
-		expect(DEFAULT_WALLPAPER).toBe(WALLPAPER_PATHS[0]);
+	it("uses the orange second wallpaper as the default", () => {
+		expect(DEFAULT_WALLPAPER).toBe(WALLPAPER_PATHS[1]);
+		expect(DEFAULT_WEBCAM_WALLPAPER).toBe(WALLPAPER_PATHS[0]);
 	});
 });
 

--- a/src/lib/wallpaper.ts
+++ b/src/lib/wallpaper.ts
@@ -17,7 +17,8 @@ export const WALLPAPER_THUMB_PATHS: readonly string[] = Array.from(
 	(_, i) => `/wallpapers/thumbs/wallpaper${i + 1}.jpg`,
 );
 
-export const DEFAULT_WALLPAPER = WALLPAPER_PATHS[0];
+export const DEFAULT_WALLPAPER = WALLPAPER_PATHS[1];
+export const DEFAULT_WEBCAM_WALLPAPER = WALLPAPER_PATHS[0];
 
 export type WallpaperClassification =
 	| { kind: "color"; value: string }

--- a/test-board.yaml
+++ b/test-board.yaml
@@ -1,0 +1,66 @@
+version: 1
+project:
+  name: "openscreen"
+  test_command: "npm run test"
+  repo: "nanameru/openscreen"
+
+source_roots:
+  - src
+  - electron
+  - tests
+
+cases:
+  - id: TC-002
+    title: "既定背景は画像一覧の上段左から2番目になる"
+    feature: "コンポジション既定背景"
+    scenario: "新規プロジェクトの既定背景"
+    status: done
+    priority: medium
+    type: regression
+    source: [src/lib/wallpaper.ts]
+    test_file: "src/lib/wallpaper.test.ts"
+    issues: [5]
+
+  - id: TC-003
+    title: "legacy editorの新規状態は余白0で始まる"
+    feature: "コンポジション既定余白"
+    scenario: "legacy editorの新規プロジェクト"
+    status: done
+    priority: medium
+    type: regression
+    source: [src/components/video-editor/editorDefaults.ts]
+    test_file: "src/components/video-editor/editorDefaults.test.ts"
+    issues: [5]
+
+  - id: TC-004
+    title: "AI editorの新規状態はオレンジ背景かつ余白0で始まる"
+    feature: "AI editor既定コンポジション"
+    scenario: "legacyEditorが未設定の新規プロジェクト"
+    status: done
+    priority: medium
+    type: regression
+    source: [src/lib/ai-edition/store/editorSettings.ts]
+    test_file: "src/lib/ai-edition/store/editorSettings.test.ts"
+    issues: [5]
+
+  - id: TC-005
+    title: "録画後の自動生成プロジェクトもオレンジ背景かつ余白0になる"
+    feature: "録画後プロジェクトの既定コンポジション"
+    scenario: "録画セッションの自動インポート"
+    status: done
+    priority: medium
+    type: regression
+    source: [src/components/ai-edition/recordingImport.ts]
+    test_file: "src/components/ai-edition/recordingImport.test.ts"
+    issues: [5]
+
+  - id: TC-006
+    title: "AI編集から通常編集へ切り替えても新規既定値を維持する"
+    feature: "エディタ既定コンポジション"
+    scenario: "legacyEditor未保存の新規ドキュメントを通常編集形式へ変換"
+    status: done
+    priority: medium
+    type: regression
+    source: [src/lib/ai-edition/document/migrate.ts]
+    test_file: "src/lib/ai-edition/document/migrate.test.ts"
+    issues: [5]


### PR DESCRIPTION
## 概要

新規プロジェクトの既定コンポジションを、背景一覧の上段左から2番目のオレンジ画像・余白0へ変更します。

Closes nanameru/openscreen#5

## 変更内容

- 既定背景を `/wallpapers/wallpaper2.jpg` に変更
- legacy editor / AI editorの既定paddingを `0` に変更
- 録画後の自動生成プロジェクトにも同じ既定値を適用
- AI編集から通常編集への切り替えでも既定値を維持
- 既存プロジェクトの明示保存値は維持
- Webカメラ背景の既定値は従来の `wallpaper1.jpg` を維持
- test-board TC-002〜TC-006を追加

## 検証

- `NODE_OPTIONS=--no-experimental-webstorage npm run test`: 187 files passed / 2240 tests passed / 2 skipped
- `npx vitest run ...`: 対象6 files / 115 tests passed
- `npx tsc -p tsconfig.test.json --noEmit`: passed
- `npm run lint`: passed（既存warning 15件）
- `npm run build-vite`: passed
- `test-board impact`: TC-002〜TC-006を検出

## リスク

既定値だけを変更し、既存プロジェクトに保存済みの背景・余白は上書きしません。

<!-- discord-thread-id:1544703657835237397 -->