### PR TITLE
chore: add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [EtienneLescot]

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 github: [EtienneLescot]
+ko_fi: etiennelescot

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ OpenScreen is community-driven. If you need help, want to report a bug, or just 
 - 💬 **Discord** — [Join the OpenScreen Discord](https://getopenscreen.com/discord) for real-time help, showcase, and discussion
 - 🐞 **[GitHub Issues](https://github.com/getopenscreen/openscreen/issues)** — bug reports and feature requests
 - 🗺️ **[Roadmap](./ROADMAP.md)** — see what we're building next
+- ❤️ **[Sponsor](https://github.com/sponsors/EtienneLescot)** — support continued development of OpenScreen
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ OpenScreen is community-driven. If you need help, want to report a bug, or just 
 - 💬 **Discord** — [Join the OpenScreen Discord](https://getopenscreen.com/discord) for real-time help, showcase, and discussion
 - 🐞 **[GitHub Issues](https://github.com/getopenscreen/openscreen/issues)** — bug reports and feature requests
 - 🗺️ **[Roadmap](./ROADMAP.md)** — see what we're building next
-- ❤️ **[Sponsor](https://github.com/sponsors/EtienneLescot)** — support continued development of OpenScreen
+- ❤️ **Support the project** — [GitHub Sponsors](https://github.com/sponsors/EtienneLescot) or [Ko-fi](https://ko-fi.com/etiennelescot)
 
 ---
 


### PR DESCRIPTION
Adds `.github/FUNDING.yml` so GitHub displays a Sponsor button on the repository.

```yaml
github: [EtienneLescot]
```

Single file, no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1544722219253633075 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Community section to label sponsorship as “Support the project.”
  * Added a Ko-fi support link alongside the existing GitHub Sponsors option.

* **Chores**
  * Added Ko-fi to the project’s funding information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->