### PR TITLE
chore(ffmpeg): say that the encoder list is reported, not verified

### DIFF
--- a/scripts/fetch-ffmpeg.mjs
+++ b/scripts/fetch-ffmpeg.mjs
@@ -156,8 +156,23 @@ const GPL_LIBS = [
 /** Worse than GPL: these make the binary unredistributable at all. */
 const NONFREE_LIBS = ["libfdk-aac", "libfdk_aac"];
 
-/** The encoders the export path actually selects, per platform. */
-const WANTED_ENCODERS = {
+/**
+ * The hardware encoders we look for in a vendored build, per platform.
+ *
+ * REPORTED, NOT VERIFIED — and the distinction has bitten. Presence in
+ * `-encoders` means the build was compiled with the wrapper; it says nothing
+ * about whether the encoder RUNS on a given machine. The vendored builds list
+ * `h264_vaapi` on Linux, yet on any host with libva < 2.21 (Ubuntu 24.04 LTS
+ * included) it used to take the whole process down with SIGABRT rather than
+ * return an error, because the implib trampoline `abort()`s on a symbol it
+ * cannot resolve. See issues #552 and #576.
+ *
+ * So this list drives a log line and nothing else. The only evidence that an
+ * encoder works is a frame going through it — `vaapi_encodes_from_an_exported_dmabuf`
+ * in `crates/compositor/src/pipeline_linux.rs` is that evidence for the Linux
+ * hardware path, and the export falls back to software whenever it is absent.
+ */
+const REPORTED_ENCODERS = {
 	win32: ["h264_nvenc", "h264_qsv", "h264_amf"],
 	linux: ["h264_nvenc", "h264_vaapi"],
 };
@@ -230,13 +245,14 @@ function assertLgpl(exePath, extraEnv) {
 
 function reportEncoders(exePath, platform) {
 	const encoders = run(exePath, ["-hide_banner", "-encoders"]).stdout ?? "";
-	const wanted = WANTED_ENCODERS[platform] ?? [];
+	const wanted = REPORTED_ENCODERS[platform] ?? [];
 	const found = wanted.filter((e) => new RegExp(`\\s${e}\\s`).test(encoders));
 	const missing = wanted.filter((e) => !found.includes(e));
-	console.log(`  hardware encoders: ${found.join(", ") || "(none)"}`);
+	console.log(`  hardware encoders present (not verified): ${found.join(", ") || "(none)"}`);
 	if (missing.length > 0) {
-		// Not fatal: which encoders a build exposes is separate from which GPU the
-		// machine has. selectVideoEncoder() probes at runtime regardless.
+		// Not fatal, and deliberately so: which encoders a build EXPOSES is
+		// separate both from which GPU the machine has and from whether the
+		// encoder is usable there at all. The runtime probes regardless.
 		console.log(`  not in this build: ${missing.join(", ")}`);
 	}
 }


### PR DESCRIPTION
Follow-up to #576, which observed that the vendor-time encoder check asserts something it does not test.

Slightly narrower than the issue framed it: the check is not a gate, it is already non-fatal and only logs. The problem is the **naming and the wording**, which promise more than is verified — `hardware encoders: h264_vaapi` reads as "this works here", when all that was tested is that the name appears in `-encoders`.

That gap is not hypothetical. The vendored builds list `h264_vaapi`, and on any host with libva < 2.21 — Ubuntu 24.04 LTS included — reaching it through the CPU upload path aborts the process with `SIGABRT` rather than returning an error, because the implib trampoline `abort()`s on a symbol it cannot resolve.

So: `REPORTED_ENCODERS`, a log line that says `present (not verified)`, and a comment recording why, pointing at #552 and #576.

**No behaviour change** — same list, same non-fatal path, same output structure. What changes is that it stops implying a guarantee it never made.

For the record on the other half of #576: the hardware ladder it warns about has since shipped (#559) and runs on exactly that configuration, because it uses `av_hwframe_map` and never `av_hwframe_transfer_data` — the abort lives in the upload path only. Details in https://github.com/getopenscreen/openscreen/issues/576#issuecomment-5522341161.

<!-- discord-thread-id:1545018884975763508 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that reported hardware encoders indicate build presence only and are not verified for runtime usability.
  * Updated status messages to distinguish encoder availability from confirmed functionality.

* **Bug Fixes**
  * Missing hardware encoders are now explicitly treated as non-fatal when reporting build capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->