### PR TITLE
fix(build): stop hiding the shared dependencies behind cfg(linux)

### DIFF
--- a/crates/compositor/Cargo.toml
+++ b/crates/compositor/Cargo.toml
@@ -24,21 +24,27 @@ segmentation = ["dep:ort", "dep:ndarray"]
 
 [dependencies]
 anyhow.workspace = true
-[target.'cfg(target_os = "linux")'.dependencies]
-# Acces Vulkan brut, UNIQUEMENT pour ouvrir le device avec les extensions de
-# memoire externe (cf. `d3d_linux::open_device_with_dmabuf_export`). Les versions
-# sont celles que wgpu 24 tire deja : en prendre d'autres ferait cohabiter deux
-# bindings pour un meme `VkDevice`.
 wgpu.workspace = true
 pollster.workspace = true
 cosmic-text.workspace = true
-ash = "0.38"
-wgpu-hal = { version = "24", features = ["vulkan"] }
 ort = { workspace = true, optional = true }
 ndarray = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 image.workspace = true
+
+# Acces Vulkan brut, UNIQUEMENT pour ouvrir le device avec les extensions de
+# memoire externe (cf. `d3d_linux::open_device_with_dmabuf_export`). Les versions
+# sont celles que wgpu 24 tire deja : en prendre d'autres ferait cohabiter deux
+# bindings pour un meme `VkDevice`.
+#
+# LINUX SEULEMENT, et rien d'autre ne doit venir ici : ces deux lignes ont ete
+# ajoutees sous cet en-tete par une edition qui l'a place trop haut, emportant
+# `wgpu`, `serde`, `ort` et le reste avec elles. Windows et macOS ont alors cesse
+# de compiler.
+[target.'cfg(target_os = "linux")'.dependencies]
+ash = "0.38"
+wgpu-hal = { version = "24", features = ["vulkan"] }
 
 # Windows : D3D11 + D3D11VA + Direct2D/DirectWrite + HLSL à l'exécution.
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
**Windows and macOS have not compiled since #559.** My fault, and an editing mistake rather than a design one.

Adding `ash` and `wgpu-hal` placed the `[target.'cfg(target_os = "linux")'.dependencies]` header immediately after `anyhow`, so every dependency below it became Linux-only:

```
error[E0432]: unresolved import `serde`
error[E0433]: cannot find module or crate `ort` in this scope
```

`wgpu`, `pollster`, `cosmic-text`, `ort`, `ndarray`, `serde`, `serde_json` and `image` are back in `[dependencies]`. The header moved below them, with a note saying what it is for — because the failure mode is invisible on the platform you develop on. The Linux build never stopped working, which is exactly why this reached main.

Verified by manifest rather than by assertion:

```
cargo metadata --no-deps
  target-gated : ash, wgpu-hal        (and nothing else)
  shared       : wgpu, serde, ort, image, pollster
```

Linux still builds. **I could not check the Windows and macOS builds locally** — those targets are not installed on this machine — so this rests on the manifest structure and on CI. Worth a look at the two red checks on this PR before merging.

Found while checking why #579 and #580 were red: both showed the same two failures, and #579 only touches a `.js` file, so they could not have been caused by either.

<!-- discord-thread-id:1545042265817358357 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored cross-platform builds by making shared rendering and media dependencies available across supported platforms.
  * Kept Linux-only Vulkan dependencies limited to Linux environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->