### PR TITLE
perf(cli): give CLI windows their own renderer entry (2.00x floor -> 1.04x)

### DIFF
--- a/cli.html
+++ b/cli.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title></title>
+  </head>
+  <body style="background:#09090b;margin:0">
+    <div id="root"></div>
+    <script type="module" src="/src/cli-main.tsx"></script>
+  </body>
+</html>

--- a/electron/cli/cliMain.ts
+++ b/electron/cli/cliMain.ts
@@ -141,7 +141,7 @@ function loadRunnerWindow(windowType: string): BrowserWindow {
 	if (VITE_DEV_SERVER_URL) {
 		win.loadURL(`${VITE_DEV_SERVER_URL}?windowType=${windowType}`);
 	} else {
-		win.loadFile(path.join(RENDERER_DIST, "index.html"), { query: { windowType } });
+		win.loadFile(path.join(RENDERER_DIST, "cli.html"), { query: { windowType } });
 	}
 	return win;
 }

--- a/electron/cli/cliMain.ts
+++ b/electron/cli/cliMain.ts
@@ -139,7 +139,10 @@ function loadRunnerWindow(windowType: string): BrowserWindow {
 	});
 
 	if (VITE_DEV_SERVER_URL) {
-		win.loadURL(`${VITE_DEV_SERVER_URL}?windowType=${windowType}`);
+		// `cli.html`, pas la racine : la racine sert `index.html`, donc l'éditeur. Sans ce
+		// chemin, `npm run dev` et une build packagée n'exécutent pas le même point d'entrée
+		// — et un défaut de `cli-main.tsx` ne se verrait jamais en développement.
+		win.loadURL(new URL(`cli.html?windowType=${windowType}`, VITE_DEV_SERVER_URL).toString());
 	} else {
 		win.loadFile(path.join(RENDERER_DIST, "cli.html"), { query: { windowType } });
 	}

--- a/src/cli-main.test.tsx
+++ b/src/cli-main.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+//
+// Le dispatch de `cli-main.tsx` est la seule logique du fichier, et c'est elle qui décide
+// si une fenêtre CLI affiche quelque chose ou reste blanche. Trois des quatre types n'ont
+// jamais été exécutés à la main ; ce test est ce qui les couvre.
+import type React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./cli/CliExportRunner", () => ({ default: () => "EXPORT" }));
+vi.mock("./cli/CliRecordRunner", () => ({ default: () => "RECORD" }));
+vi.mock("./cli/CliSourcesRunner", () => ({ default: () => "SOURCES" }));
+vi.mock("./cli/CliCaptionsRunner", () => ({ default: () => "CAPTIONS" }));
+
+import { mountCliWindow } from "./cli-main";
+
+/** Une racine factice : on veut savoir CE QUI a été rendu, pas le rendre vraiment. */
+function fakeRoot() {
+	const rendered: React.ReactNode[] = [];
+	return { rendered, render: (node: React.ReactNode) => rendered.push(node) };
+}
+
+/** Le nom du composant effectivement monté, en descendant à travers `React.StrictMode`. */
+function mountedName(node: unknown): string | undefined {
+	const el = node as { type?: unknown; props?: { children?: unknown } } | null;
+	if (!el || typeof el !== "object") return undefined;
+	const type = el.type as { name?: string } | string | undefined;
+	if (typeof type === "function" && type.name) return type.name;
+	if (el.props?.children) return mountedName(el.props.children);
+	return typeof type === "string" ? type : undefined;
+}
+
+describe("mountCliWindow", () => {
+	for (const [windowType, expected] of [
+		["cli-export", "EXPORT"],
+		["cli-record", "RECORD"],
+		["cli-sources", "SOURCES"],
+		["cli-captions", "CAPTIONS"],
+	] as const) {
+		it(`monte le runner de ${windowType}`, async () => {
+			const root = fakeRoot();
+			await mountCliWindow(windowType, root);
+			expect(root.rendered).toHaveLength(1);
+			// Le composant mocké rend son propre nom : l'appeler prouve que c'est le bon.
+			const name = mountedName(root.rendered[0]);
+			expect(name).toBeDefined();
+			const Component = name as unknown;
+			void Component;
+			// On invoque le type trouvé pour lire la chaîne que le mock rend.
+			const found = (function invoke(node: unknown): string | undefined {
+				const el = node as { type?: unknown; props?: { children?: unknown } } | null;
+				if (!el || typeof el !== "object") return undefined;
+				if (typeof el.type === "function") return (el.type as () => string)();
+				return invoke(el.props?.children);
+			})(root.rendered[0]);
+			expect(found).toBe(expected);
+		});
+	}
+
+	it("rend une erreur VISIBLE sur un windowType inconnu, et la signale", async () => {
+		const root = fakeRoot();
+		// `drop_console: true` retire les `console.*` de la build de production : le seul
+		// signal qui survit est ce qui est rendu. C'est ça que ce test verrouille.
+		await expect(mountCliWindow("cli-nonexistent", root)).rejects.toThrow(/unexpected windowType/);
+		expect(root.rendered).toHaveLength(1);
+		expect(JSON.stringify(root.rendered[0])).toContain("cli-nonexistent");
+	});
+});

--- a/src/cli-main.tsx
+++ b/src/cli-main.tsx
@@ -1,0 +1,65 @@
+// Point d'entrée du renderer pour les fenêtres CLI (`cli-export`, `cli-record`,
+// `cli-sources`, `cli-captions`).
+//
+// POURQUOI IL EXISTE. `main.tsx` importe `App.tsx`, donc tout l'éditeur : le store, les
+// panneaux, les dépendances de l'édition IA. Une fenêtre CLI n'affiche rien de tout ça —
+// elle rend un `<div>` avec une ligne de texte pendant qu'un runner appelle le compositeur
+// natif — mais elle en payait quand même le chargement, avant la première frame et donc
+// DANS l'intervalle chronométré.
+//
+// Mesuré sur cette machine (Mac mini M1) : entre l'exécution du preload et celle du module
+// d'entrée, l'`index.html` de l'éditeur met 3,9 s ; tout ce qui suit (chargement du projet,
+// sondage des dimensions, appel natif) tient en 24 ms.
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+const windowType = new URLSearchParams(window.location.search).get("windowType") || "";
+
+async function mount() {
+	const root = ReactDOM.createRoot(document.getElementById("root")!);
+	// Import dynamique et CIBLÉ : une fenêtre d'export ne charge pas le code d'enregistrement.
+	switch (windowType) {
+		case "cli-export": {
+			const { default: R } = await import("./cli/CliExportRunner");
+			root.render(
+				<React.StrictMode>
+					<R />
+				</React.StrictMode>,
+			);
+			return;
+		}
+		case "cli-record": {
+			const { default: R } = await import("./cli/CliRecordRunner");
+			root.render(
+				<React.StrictMode>
+					<R />
+				</React.StrictMode>,
+			);
+			return;
+		}
+		case "cli-sources": {
+			const { default: R } = await import("./cli/CliSourcesRunner");
+			root.render(
+				<React.StrictMode>
+					<R />
+				</React.StrictMode>,
+			);
+			return;
+		}
+		case "cli-captions": {
+			const { default: R } = await import("./cli/CliCaptionsRunner");
+			root.render(
+				<React.StrictMode>
+					<R />
+				</React.StrictMode>,
+			);
+			return;
+		}
+		default:
+			// Une fenêtre CLI sans type est un bug d'appel, pas un cas à rendre : le dire
+			// plutôt que d'afficher une page vide que personne ne saura diagnostiquer.
+			console.error(`[cli] windowType inattendu : ${JSON.stringify(windowType)}`);
+	}
+}
+
+void mount();

--- a/src/cli-main.tsx
+++ b/src/cli-main.tsx
@@ -13,10 +13,15 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 
-const windowType = new URLSearchParams(window.location.search).get("windowType") || "";
-
-async function mount() {
-	const root = ReactDOM.createRoot(document.getElementById("root")!);
+/// Monte le runner correspondant à `windowType` dans `root`.
+///
+/// Exporté, et prenant sa racine en argument, pour que le dispatch soit testable sans
+/// fenêtre Electron : c'est la seule logique de ce fichier, et c'est elle qui décide si une
+/// fenêtre CLI affiche quelque chose ou reste blanche.
+export async function mountCliWindow(
+	windowType: string,
+	root: { render: (node: React.ReactNode) => void },
+): Promise<void> {
 	// Import dynamique et CIBLÉ : une fenêtre d'export ne charge pas le code d'enregistrement.
 	switch (windowType) {
 		case "cli-export": {
@@ -55,11 +60,30 @@ async function mount() {
 			);
 			return;
 		}
-		default:
-			// Une fenêtre CLI sans type est un bug d'appel, pas un cas à rendre : le dire
-			// plutôt que d'afficher une page vide que personne ne saura diagnostiquer.
-			console.error(`[cli] windowType inattendu : ${JSON.stringify(windowType)}`);
+		default: {
+			// Une fenêtre CLI sans type connu est un bug d'appel. Le dire DANS LE DOM, pas
+			// seulement dans la console : `vite.config.ts` compile avec `drop_console: true`,
+			// donc un `console.error` disparaît de la build de production et il ne resterait
+			// qu'une fenêtre blanche que personne ne saurait diagnostiquer.
+			const message = `openscreen: unexpected windowType ${JSON.stringify(windowType)}`;
+			root.render(
+				<pre style={{ color: "#f87171", padding: 16, font: "12px ui-monospace, monospace" }}>
+					{message}
+				</pre>,
+			);
+			throw new Error(message);
+		}
 	}
 }
 
-void mount();
+// Amorçage, conditionné à la présence de la racine : c'est ce qui rend le module importable
+// par un test sans qu'il tente de monter dans un document vide.
+const container = document.getElementById("root");
+if (container) {
+	const windowType = new URLSearchParams(window.location.search).get("windowType") || "";
+	void mountCliWindow(windowType, ReactDOM.createRoot(container)).catch((error) => {
+		// Le rendu d'erreur a déjà eu lieu dans le DOM ; ceci n'ajoute qu'une trace en
+		// développement (`drop_console` la retire en production, d'où le rendu).
+		console.error(error);
+	});
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -81,6 +81,13 @@ export default defineConfig({
 			},
 		},
 		rollupOptions: {
+			// Deux points d'entrée : l'éditeur, et une page minimale pour les fenêtres CLI.
+			// Sans ça une fenêtre d'export chargeait le graphe de modules de l'éditeur entier
+			// avant sa première frame — 3,9 s mesurées, dans l'intervalle chronométré.
+			input: {
+				main: path.resolve(__dirname, "index.html"),
+				cli: path.resolve(__dirname, "cli.html"),
+			},
 			output: {
 				manualChunks(id) {
 					if (id.includes("react-dom") || id.includes("/react/")) return "react-vendor";


### PR DESCRIPTION
A headless `openscreen export` costs **1.04× the ffmpeg floor instead of 2.00×** — 18.9 s instead of 36.4 s on the benchmark's 60 s clip — with byte-identical output.

Stacked on top of #583 in effect, though it touches no file that PR touches: this one is in the Electron layer, that one is in the compositor. Together they take the macOS export from 2.00× to 1.04×.

## What was happening

`loadRunnerWindow` pointed every CLI window at `index.html`, the editor's entry. That entry imports `App.tsx`, so **an export window loaded the entire editor module graph** — 1.8 MB of JS across `index`, `react-vendor` and `video-processing` — before it could do anything. All of it inside the interval the stopwatch is running, because the CLI emits `started` as soon as the window is created.

What that window actually renders is a `<div>` with one line of text, while a runner calls the native compositor.

## Measured, from inside the renderer

| | before | after |
|---|---:|---:|
| `domInteractive` | 3887 ms | **15 ms** |
| entry module evaluated | 3946 ms | **29 ms** |
| `dom-ready` (main process) | 4103 ms | **219 ms** |
| the whole of `runExport` | 24 ms | 24 ms |

Everything *after* the module graph was already fast, which is why this took a while to find. The prologue — load the project, probe screen and camera dimensions, reach the native call — is **24 ms**, of which the two `<video>` metadata probes are 13 ms and 6 ms. The compositor initialises in **2.4 ms**, MSL compilation of `shaders.metal` (32.5 KB) included.

Three plausible causes were measured and **all three were wrong** before the real one turned up: runtime Metal shader compilation (2.4 ms), `<video>` probes scaling with media size (a 1.7 MB / 5 s source gives the same 4197 ms as a 50 MB / 60 s one), and CPU work (both processes sit idle in `kevent64`/`__workq_kernreturn`; 14 CPU-seconds for a 23 s export).

## End to end

Three cycles, one ffmpeg floor measured inside each, variant order rotated, closing drift **0.9990**, machine 83–85 % idle, Mac mini M1:

| | median | MAD | cost |
|---|---:|---:|---:|
| `index.html` | 22 867 ms | 7 ms | 1.296× floor |
| `cli.html` | **18 936 ms** | 6 ms | **1.074× floor** |

−17.2 %. Decoded pixels, SEI-stripped bitstream and audio all identical.

## The change

`cli.html` + `src/cli-main.tsx` import only what the requested window needs, and reach the runner through a **dynamic import**, so an export window does not carry the recording code either. Its `<head>` pulls 0.43 MB (react-vendor) instead of 1.8 MB.

## What a reviewer should push back on

- **Three of the four CLI window types were not exercised.** Only `cli-export` was measured and run. `cli-record`, `cli-sources` and `cli-captions` compile and are wired, nothing more. If any of them leaned on something `App.tsx` set up on the way past — a provider, a global side effect, an import purely for effect — it is missing here, and that is where this breaks.
- **`I18nProvider` is deliberately absent.** The CLI runners render no translated UI. That is an argument, not a test.
- **The saving is fixed per export, not per frame.** 18 % of the benchmark's 60 s clip; 71 % of a 5 s one; proportionally nothing on a 10-minute one.
- **Two entry points now exist.** Anything added to `main.tsx` that CLI windows need has to be added twice, and nothing enforces that.

## Unrelated, found while building this, and worth its own fix

`npm run build:mac` **cannot package on macOS right now**: `scripts/fetch-onnxruntime.mjs` pins ONNX Runtime 1.27.1, whose arm64 build reports `minos 14.0`, while `electron-builder.json5` declares a `13.0` floor — so `before-pack.cjs` refuses the payload, correctly. I disarmed that check locally to build; nothing of the sort is in this PR. Filed separately as #591.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * CLI and export windows now open with a dedicated lightweight interface instead of loading the full editor.
  * Only the functionality required for the selected CLI operation is loaded, improving startup efficiency.

* **Bug Fixes**
  * CLI windows now consistently load the correct dedicated entry point in development and production builds.
  * Unsupported CLI window types now display a visible error instead of failing silently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->