### PR TITLE
ci(build): do not run the release matrix for internal v0.0.0-* tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,19 @@ on:
   push:
     tags:
       - "v*"
+      # `v0.0.0-*` is this repository's marker for a tag that is NOT a product
+      # version — a place to hang a binary that needs a permanent public URL, the
+      # way `v0.0.0-stt-models` hosts the 360 MB Whisper model. Without this
+      # exclusion, creating one runs the whole matrix — Windows, macOS x2, Linux,
+      # installers, notarisation — to publish an archive nobody asked it to build.
+      # That has already happened once.
+      #
+      # The other five release-triggered workflows do not need the same guard:
+      # AUR, Nix, winget and Homebrew all gate on
+      # `!github.event.release.prerelease`, and an internal release is marked as a
+      # prerelease. Only the Discord announcement still fires, which is noise
+      # rather than a wrong publication.
+      - "!v0.0.0-*"
   workflow_dispatch:
     inputs:
       arch:


### PR DESCRIPTION
`v0.0.0-*` is this repository's existing marker for a tag that is **not a product version** — a place to hang a binary that needs a permanent public URL, the way `v0.0.0-stt-models` hosts the 360 MB Whisper model.

`build.yml` triggers on `v*` with no further filter, so creating one runs **the entire release matrix** — Windows, macOS ×2, Linux, installers, notarisation — to publish an archive it was never asked to build. **That has already happened**: there is a `build.yml` run against a `v0.0.0` tag in the history.

It matters now because of #591: adopting a locally built ONNX Runtime means publishing it under such a tag, and that should not cost a full release build every time the pinned version moves.

## The other five release-triggered workflows are fine, and that was checked

| workflow | guard |
|---|---|
| `aur-publish` | `!github.event.release.prerelease` ✓ |
| `bump-nix-package` | `!github.event.release.prerelease` ✓ |
| `publish-winget` | `!github.event.release.prerelease` ✓ |
| `update-homebrew-cask` | `!github.event.release.prerelease` ✓ |
| `announce-release` | **none** — see below |

An internal release is marked as a prerelease (as `v0.0.0-stt-models` is), so **none of the four package-manager publishers can be tricked into pushing a bogus version.** That was the risk worth checking, and it is already covered.

`announce-release` has no prerelease gate and would post to Discord. That is noise rather than a wrong publication, and whether an internal release deserves an announcement is a call for whoever owns that channel — so this PR leaves it alone rather than deciding.

## What a reviewer should push back on

- **`!v0.0.0-*` encodes a convention that lives only in one tag name and one release title.** If `v0.0.0-` is not actually the intended marker for internal assets, this exclusion is wrong and something more explicit — a `deps/` prefix, or a tag-shape check inside the job — would be better.
- **Nothing enforces that internal releases are marked prerelease.** The four package-manager guards depend on it entirely. If someone publishes a `v0.0.0-*` release as a full release, this PR does nothing to stop AUR and Homebrew from acting on it.

<!-- discord-thread-id:1545446244221059154 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated build efficiency by preventing internal marker tags from triggering the full build workflow.
  - Release-tagged builds continue to run as expected, with clearer workflow documentation for related release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->