### PR TITLE
fix(macos): serve ONNX Runtime from a build that respects the 13.0 floor

### DIFF
--- a/.github/workflows/build-onnxruntime-macos.yml
+++ b/.github/workflows/build-onnxruntime-macos.yml
@@ -34,6 +34,11 @@ name: Build ONNX Runtime (macOS 13 floor)
 on:
   workflow_dispatch:
   push:
+    # BRANCHES ONLY. Without this, pushing a tag matches too — and publishing the
+    # artifact under `v0.0.0-onnxruntime-1.27.1` started a fresh 22-minute build of
+    # the very thing that had just been attached to the release.
+    branches:
+      - main
     paths:
       - ".github/workflows/build-onnxruntime-macos.yml"
       - "scripts/fetch-onnxruntime.mjs"

--- a/scripts/fetch-onnxruntime.mjs
+++ b/scripts/fetch-onnxruntime.mjs
@@ -114,12 +114,32 @@ const PINNED = {
 		member: "onnxruntime.dll",
 		out: "onnxruntime.dll",
 	},
+	// The one target that does NOT come from upstream, and it is not a preference.
+	// Microsoft's `onnxruntime-osx-arm64-1.27.1.tgz` is built for macOS 14, this app
+	// declares a 13.0 floor, and `before-pack.cjs` refuses a payload demanding more —
+	// correctly, since the deployment target decides which symbols the linker resolves
+	// against the OS rather than emitting locally (#515). So `npm run build:mac` could
+	// not package at all. No published release fixes that: every one from 1.24 on is
+	// `minos 14.0`, and every one before it is at least 13.3.
+	//
+	// This one is built by `.github/workflows/build-onnxruntime-macos.yml` from the
+	// commit above, with the deployment target pinned, and published under a
+	// `v0.0.0-*` tag — the marker this repo already uses for a binary that needs a
+	// permanent URL but is not a product version. Its provenance is attested:
+	//
+	//     gh attestation verify onnxruntime-osx-arm64-1.27.1.tgz --repo getopenscreen/openscreen
+	//
+	// Everything else about it is unchanged: immutable URL, SHA-256 verified before
+	// the archive is opened. What moved is who built the bytes, not how far they are
+	// trusted.
 	"darwin-arm64": {
 		slug: "osx-arm64",
 		ext: "tgz",
-		sha256: "e42b77a7281cc6e55141bf44fcfbac2c782b823a491bbb6ac33c781dd991f8a6",
+		sha256: "b8b7e62786eea42fc867bdbc2d3f573655a4b0e602c6938c4cea151a9ef71623",
 		member: `libonnxruntime.${VERSION}.dylib`,
 		out: "libonnxruntime.dylib",
+		baseUrl:
+			"https://github.com/getopenscreen/openscreen/releases/download/v0.0.0-onnxruntime-1.27.1",
 	},
 	// Linux is wired into `build:linux` since its back-end gained the capture half
 	// (`capture_webcam_rgb` + `set_webcam_mask` in `compositor_linux.rs`). Until


### PR DESCRIPTION
`npm run build:mac` does not package on this branch's parent. It fails in `before-pack.cjs`, and it is right to: Microsoft's published `onnxruntime-osx-arm64-1.27.1.tgz` is built with `minos 14.0`, the app declares a **13.0** floor, and a payload may not demand more than the app promises — the deployment target decides which symbols the linker resolves against the OS instead of emitting locally (#515).

No published release fixes this. Every ONNX Runtime release from 1.24 on is `minos 14.0`; every one before it is at least 13.3. There is no 13.0 build to point at, so this points at one we make.

## What changes

The `darwin-arm64` entry now resolves to an archive built by [`build-onnxruntime-macos.yml`](.github/workflows/build-onnxruntime-macos.yml) (merged in #595) from the **same upstream commit** already recorded in this file, with the deployment target pinned and `minos`, `OrtGetApiBase` and the CPU provider all checked before upload. Provenance is attested:

```bash
gh attestation verify onnxruntime-osx-arm64-1.27.1.tgz --repo getopenscreen/openscreen
```

Everything else about the fetch is untouched: immutable URL, SHA-256 verified before the archive is opened, license extracted and checked. **What moved is who built the bytes, not how far they are trusted.**

Second, unrelated but found while publishing: that workflow's `on.push` had `paths:` and no `branches:`, so pushing the artifact's own tag started a fresh 22-minute build of what had just been attached to the release (run 33887404444, cancelled). Now restricted to `main`.

## What I verified

Not "it should work" — run, on this machine, against these exact bytes.

| Check | Result |
|---|---|
| `node scripts/fetch-onnxruntime.mjs --force` | downloads from the release, `sha256 ok (7 MB)`, license MIT, exit 0 |
| Vendored library | `minos 13.0`, 21.7 MB, exports `OrtGetApiBase` + `…AppendExecutionProvider_CPU` |
| **`npx electron-builder --mac dir --arm64`** | **succeeds, `before-pack.cjs` untouched and un-disarmed** — this is the thing that was broken |
| Packaged app | carries the 13.0 dylib; no native binary in the bundle exceeds the 13.0 floor |
| Real inference | `cargo test -p openscreen-compositor --features segmentation --lib` → **8 passed**, log says `ONNX Runtime présent`, so the inference tests ran rather than skipped |
| Falsifiability control | with `ORT_DYLIB_PATH` pointing at nothing, three of those tests print `test sauté` — proving the pass above was not vacuous |

## What I don't know

- **Nobody has run this on macOS 13.** This Mac is on 26.5, and `minos 13.0` is a statement about what the linker targeted, not a test that the library executes there. It is the same guarantee every other native binary in the bundle ships with, and no stronger.
- **The bytes are not reproducible by re-running the workflow.** The compiler is whatever the runner image carries, and the run records `ImageOS` for that reason. Two builds of the same commit are not guaranteed byte-identical, so the SHA-256 here pins *this* artifact, not "any build of `df2ba1cf`".
- The CPU execution provider is the only one built; nothing else was requested and nothing else was checked for.

## What a reviewer should contest

1. **This is the project building its own dependency binary.** That is a real cost — a supply chain to maintain, and a rebuild needed at each version bump. The alternative I would rather have had is upstream shipping a 13.0 build, which they do not. The other real option is gating webcam blur off below macOS 14 and staying on Microsoft's archive; that trades a working feature on 13.x for one less thing to own, and it is a product call, not a technical one. Say so if you want it.
2. **The archive lives under a `v0.0.0-*` tag**, which is the marker this repo uses for a binary needing a permanent URL that is not a product version. #598 taught `build.yml` to ignore that prefix; the package-manager workflows already skip prereleases. The one thing that still fires is the Discord announcement.
3. `segmentation.rs` still says the macOS CI "ne la stage pas encore" — with this merged, CI *could* stage the library and actually run those three inference tests instead of skipping them. I did not widen the scope to do it; it is worth a follow-up.

Closes #591.

<!-- discord-thread-id:1545451761379184713 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * macOS builds now avoid being retriggered when release tags are pushed.
  * Apple Silicon builds use an artifact compatible with the app’s macOS 13.0 minimum requirement.
  * Artifact integrity verification has been updated for the new build source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->