### PR TITLE
fix(ci): read the runner image instead of interpolating an empty string

### DIFF
--- a/.github/workflows/build-whisper-stt.yml
+++ b/.github/workflows/build-whisper-stt.yml
@@ -16,6 +16,13 @@ name: Build whisper-stt binaries
 on:
   workflow_dispatch:
   push:
+    # ALL branches, NO tags. `paths:` alone also matches a tag push, and it has:
+    # publishing `v0.0.0-onnxruntime-1.27.1` started a four-platform whisper build
+    # for a tag that touched none of these files. Listing `branches` is what
+    # excludes tags; `'**'` keeps every branch working, which is the point of this
+    # workflow — contributors push a branch to get binaries built.
+    branches:
+      - "**"
     paths:
       - "scripts/build-whisper-stt.sh"
       - "electron/native/whisper-stt/**"
@@ -139,6 +146,23 @@ jobs:
           "${VCPKG_ROOT_DIR}/vcpkg" install spirv-headers:x64-windows
           echo "CMAKE_PREFIX_PATH=${VCPKG_ROOT_DIR}/installed/x64-windows" >> "$GITHUB_ENV"
 
+      # `${{ env.ImageOS }}` DOES NOT WORK, and it fails silently — the `env`
+      # expression context holds only what a workflow/job/step `env:` block put
+      # there, and the runner sets ImageOS/ImageVersion into its own process
+      # environment instead. Written that way, both halves expanded to the empty
+      # string and the cache below was keyed on the tag and the CMakeLists hash
+      # alone, for every platform, for as long as the line existed: the repo's
+      # own cache list read `whisper-stt-build-darwin-arm64---<hash>`. Reading
+      # them here in a shell is what actually gets their values.
+      #
+      # `shell: bash` is required, not decorative: this matrix includes
+      # windows-latest, where the default shell is PowerShell and `${VAR:-default}`
+      # is not syntax. GitHub ships bash on the Windows image.
+      - name: Read the runner image
+        id: image
+        shell: bash
+        run: echo "tag=${ImageOS:-unknown}-${ImageVersion:-unknown}" >> "$GITHUB_OUTPUT"
+
       - name: Cache whisper.cpp build tree
         uses: actions/cache@v6
         with:
@@ -151,15 +175,15 @@ jobs:
           # bump there invalidates the cache instead of silently reusing a stale
           # FetchContent checkout; falls back to the newest cache for the same
           # platform + runner image on a miss so incremental compilation still
-          # helps. The runner image version ($ImageOS/$ImageVersion) is part of
+          # helps. The runner image version (read by the step above) is part of
           # the key AND the restore-keys prefix because CMake bakes absolute
           # toolchain paths (e.g. the Xcode SDK's libz.tbd) into the cached build
           # tree — when GitHub rolls the image's Xcode/SDK, those paths vanish and
           # a restored tree fails with "No rule to make target …libz.tbd". Scoping
           # the cache to the image version auto-busts it on every toolchain roll.
-          key: whisper-stt-build-${{ matrix.tag }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ hashFiles('electron/native/whisper-stt/CMakeLists.txt') }}
+          key: whisper-stt-build-${{ matrix.tag }}-${{ steps.image.outputs.tag }}-${{ hashFiles('electron/native/whisper-stt/CMakeLists.txt') }}
           restore-keys: |
-            whisper-stt-build-${{ matrix.tag }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-
+            whisper-stt-build-${{ matrix.tag }}-${{ steps.image.outputs.tag }}-
 
       - name: Run whisper-stt build script
         run: bash scripts/build-whisper-stt.sh


### PR DESCRIPTION
Closes [#596](https://github.com/getopenscreen/openscreen/issues/596).

`build-whisper-stt.yml` keys its build cache on the runner image so a Xcode/SDK roll busts it, and carries a comment explaining precisely why that matters. **The mechanism has never once worked.** `${{ env.ImageOS }}` and `${{ env.ImageVersion }}` both expand to the empty string: the `env` expression context holds only what a workflow, job or step `env:` block put there, while the runner sets these two into its own process environment, visible to `run:` steps and to nothing else.

The repository's own cache list is the evidence — three consecutive hyphens where the image belongs:

```
whisper-stt-build-darwin-arm64---2ca5d2c75aac59ca…
whisper-stt-build-darwin-x64---2ca5d2c75aac59ca…
whisper-stt-build-linux-x64---2ca5d2c75aac59ca…
whisper-stt-build-win32-x64---2ca5d2c75aac59ca…
```

So the cache has been keyed on `matrix.tag` + the CMakeLists hash alone, and the failure the comment predicts — a restored tree full of dead absolute SDK paths, `No rule to make target …libz.tbd` — has been unguarded the whole time. Nothing broke yet because no roll happened to land badly; that is luck, not design.

## The fix

A shell step reads the values, and both `key:` and `restore-keys:` use its output — the same shape [#595](https://github.com/getopenscreen/openscreen/pull/595) uses.

**`shell: bash` is load-bearing, not decorative.** The issue's suggested snippet would have broken on this workflow: the matrix includes `windows-latest`, where the default shell is PowerShell and `${VAR:-default}` is not syntax. GitHub ships bash on the Windows image, so pinning the shell is what makes one step work across all four legs.

## Second fix, same file

`on.push` had `paths:` and no `branches:`, so a tag push matched it. This is not hypothetical — it is in the run list:

```
2026-09-04T15:04:42Z  push  v0.0.0-onnxruntime-1.27.1  success
```

Publishing that ONNX artifact started a **four-platform whisper build** for a tag touching none of these files. Fixed with `branches: ['**']`, which excludes tags while keeping every branch — deliberately not `branches: [main]` as in the ONNX workflow, because contributors push branches here specifically to get binaries built, and narrowing that would be a behaviour change nobody asked for.

## Verification

Pushing this branch triggers the workflow, which is the point: the proof is what lands in the cache list afterwards. The keys must carry a real image and must not contain `---`. I will post the actual keys before asking anyone to merge — an assertion that cannot fail is worth nothing here, and this is a fix whose entire failure mode was looking correct while doing nothing.

## What a reviewer should contest

1. **This invalidates every existing whisper cache** — the first run on each platform after merge rebuilds from scratch. That is the intended consequence (the old keys are wrong), but it is a real one-off cost across four legs.
2. **`branches: ['**']` is the permissive choice.** If the preference is that this workflow only build from `main` and PRs, say so; it is a one-line change and a product-of-workflow call rather than a technical one.
3. **The `:-unknown` fallbacks would silently degrade on a self-hosted runner** that sets neither variable — the key would read `unknown-unknown` and stop busting on toolchain rolls again. Every runner here is GitHub-hosted, so it does not bite today; failing loudly instead is defensible if you would rather.

<!-- discord-thread-id:1545468597202329651 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated build triggers to avoid unnecessary multi-platform builds when publishing tags.
  - Improved build caching by correctly accounting for the runner’s operating system and image version.
  - Added clearer build-environment detection, helping builds use the appropriate cached artifacts and run more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->