### PR TITLE
fix(editor): reset all parameters on audio track pane reset

### DIFF
--- a/src/components/ai-edition/RightPanes.audioTrack.test.tsx
+++ b/src/components/ai-edition/RightPanes.audioTrack.test.tsx
@@ -55,11 +55,24 @@ describe("AudioTrackPane reset button", () => {
 			updateAudioTrack,
 		} as unknown as TimelineApi;
 
-		render(
+		const { rerender } = render(
 			<I18nProvider>
 				<AudioTrackPane tl={tl} />
 			</I18nProvider>,
 		);
+
+		const gainSlider = screen.getByRole("slider", { name: "Output level" });
+		const fadeInSlider = screen.getByRole("slider", { name: "Fade in" });
+		const fadeOutSlider = screen.getByRole("slider", { name: "Fade out" });
+
+		// Draft in-progress slider changes without committing
+		fireEvent.change(gainSlider, { target: { value: "3" } });
+		fireEvent.change(fadeInSlider, { target: { value: "1500" } });
+		fireEvent.change(fadeOutSlider, { target: { value: "2000" } });
+
+		expect(gainSlider).toHaveValue("3");
+		expect(fadeInSlider).toHaveValue("1500");
+		expect(fadeOutSlider).toHaveValue("2000");
 
 		const resetBtn = screen.getByRole("button", { name: /reset/i });
 		fireEvent.click(resetBtn);
@@ -72,6 +85,30 @@ describe("AudioTrackPane reset button", () => {
 			muted: false,
 			loop: false,
 		});
+
+		// Draft values are cleared; inputs no longer display the drafted values
+		expect(gainSlider).not.toHaveValue("3");
+		expect(fadeInSlider).not.toHaveValue("1500");
+		expect(fadeOutSlider).not.toHaveValue("2000");
+
+		// When re-rendered with the reset track state, sliders show zeroed defaults
+		const resetTrack: AxcutAudioTrack = {
+			...mockTrack,
+			gainDb: 0,
+			fadeInMs: 0,
+			fadeOutMs: 0,
+			muted: false,
+			loop: false,
+		};
+		rerender(
+			<I18nProvider>
+				<AudioTrackPane tl={{ ...tl, audioTracks: [resetTrack] } as unknown as TimelineApi} />
+			</I18nProvider>,
+		);
+
+		expect(gainSlider).toHaveValue("0");
+		expect(fadeInSlider).toHaveValue("0");
+		expect(fadeOutSlider).toHaveValue("0");
 	});
 
 	it("resets all track parameters under French locale", () => {
@@ -111,11 +148,23 @@ describe("AudioTrackPane reset button", () => {
 			updateAudioTrack,
 		} as unknown as TimelineApi;
 
-		render(
+		const { rerender } = render(
 			<I18nProvider>
 				<AudioTrackPane tl={tl} />
 			</I18nProvider>,
 		);
+
+		const gainSlider = screen.getByRole("slider", { name: /niveau de sortie/i });
+		const fadeInSlider = screen.getByRole("slider", { name: /fondu d['’]entrée/i });
+		const fadeOutSlider = screen.getByRole("slider", { name: /fondu de sortie/i });
+
+		fireEvent.change(gainSlider, { target: { value: "-12" } });
+		fireEvent.change(fadeInSlider, { target: { value: "800" } });
+		fireEvent.change(fadeOutSlider, { target: { value: "1200" } });
+
+		expect(gainSlider).toHaveValue("-12");
+		expect(fadeInSlider).toHaveValue("800");
+		expect(fadeOutSlider).toHaveValue("1200");
 
 		// French label: "Réinitialiser l’audio"
 		const resetBtn = screen.getByRole("button", { name: /réinitialiser l’audio/i });
@@ -129,5 +178,27 @@ describe("AudioTrackPane reset button", () => {
 			muted: false,
 			loop: false,
 		});
+
+		expect(gainSlider).not.toHaveValue("-12");
+		expect(fadeInSlider).not.toHaveValue("800");
+		expect(fadeOutSlider).not.toHaveValue("1200");
+
+		const resetTrack: AxcutAudioTrack = {
+			...mockTrack,
+			gainDb: 0,
+			fadeInMs: 0,
+			fadeOutMs: 0,
+			muted: false,
+			loop: false,
+		};
+		rerender(
+			<I18nProvider>
+				<AudioTrackPane tl={{ ...tl, audioTracks: [resetTrack] } as unknown as TimelineApi} />
+			</I18nProvider>,
+		);
+
+		expect(gainSlider).toHaveValue("0");
+		expect(fadeInSlider).toHaveValue("0");
+		expect(fadeOutSlider).toHaveValue("0");
 	});
 });

--- a/src/components/ai-edition/RightPanes.audioTrack.test.tsx
+++ b/src/components/ai-edition/RightPanes.audioTrack.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import "@testing-library/jest-dom";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { I18nProvider } from "@/contexts/I18nContext";
 import { LOCALE_STORAGE_KEY } from "@/i18n/config";
@@ -200,5 +200,149 @@ describe("AudioTrackPane reset button", () => {
 		expect(gainSlider).toHaveValue("0");
 		expect(fadeInSlider).toHaveValue("0");
 		expect(fadeOutSlider).toHaveValue("0");
+	});
+
+	it("retains slider value on release while async commit is in flight without jumping back", async () => {
+		let resolveGain: () => void = () => undefined;
+		let resolveFadeIn: () => void = () => undefined;
+		let resolveFadeOut: () => void = () => undefined;
+
+		const setAudioTrackGain = vi.fn().mockImplementation(
+			() =>
+				new Promise<void>((res) => {
+					resolveGain = res;
+				}),
+		);
+		const updateAudioTrack = vi.fn().mockImplementation(
+			(_id: string, patch: { fadeInMs?: number; fadeOutMs?: number }) =>
+				new Promise<void>((res) => {
+					if (patch.fadeInMs !== undefined) resolveFadeIn = res;
+					if (patch.fadeOutMs !== undefined) resolveFadeOut = res;
+				}),
+		);
+
+		const mockTrack: AxcutAudioTrack = {
+			id: "audio_track_1",
+			clipId: "clip_1",
+			assetId: "asset_audio_1",
+			trackId: "audio_track_1",
+			startMs: 1000,
+			endMs: 5000,
+			durationSec: 10,
+			offsetMs: 0,
+			gainDb: -6,
+			fadeInMs: 500,
+			fadeOutMs: 1000,
+			muted: false,
+			loop: false,
+			kind: "music",
+			label: "test-audio.mp3",
+			origin: "user",
+		};
+
+		const tl = {
+			selectedAudioTrackId: "audio_track_1",
+			audioTracks: [mockTrack],
+			assets: [
+				{
+					id: "asset_audio_1",
+					kind: "audio",
+					label: "test-audio.mp3",
+					originalPath: "/path/test-audio.mp3",
+					durationSec: 10,
+				},
+			],
+			setAudioTrackGain,
+			updateAudioTrack,
+		} as unknown as TimelineApi;
+
+		const { rerender } = render(
+			<I18nProvider>
+				<AudioTrackPane tl={tl} />
+			</I18nProvider>,
+		);
+
+		const gainSlider = screen.getByRole("slider", { name: "Output level" });
+		const fadeInSlider = screen.getByRole("slider", { name: "Fade in" });
+		const fadeOutSlider = screen.getByRole("slider", { name: "Fade out" });
+
+		// 1. Gain slider: drag to 2.5 and release (onMouseUp)
+		fireEvent.change(gainSlider, { target: { value: "2.5" } });
+		fireEvent.mouseUp(gainSlider);
+
+		expect(setAudioTrackGain).toHaveBeenCalledWith("audio_track_1", 2.5);
+		// While save is in flight, the slider MUST NOT jump back to -6
+		expect(gainSlider).toHaveValue("2.5");
+
+		// Complete the async save and simulate the store update
+		await act(async () => {
+			resolveGain();
+		});
+
+		rerender(
+			<I18nProvider>
+				<AudioTrackPane
+					tl={
+						{
+							...tl,
+							audioTracks: [{ ...mockTrack, gainDb: 2.5 }],
+						} as unknown as TimelineApi
+					}
+				/>
+			</I18nProvider>,
+		);
+		expect(gainSlider).toHaveValue("2.5");
+
+		// 2. Fade in slider: drag to 1500 and release
+		fireEvent.change(fadeInSlider, { target: { value: "1500" } });
+		fireEvent.mouseUp(fadeInSlider);
+
+		expect(updateAudioTrack).toHaveBeenCalledWith("audio_track_1", { fadeInMs: 1500 });
+		// While save is in flight, the slider MUST NOT jump back to 500
+		expect(fadeInSlider).toHaveValue("1500");
+
+		await act(async () => {
+			resolveFadeIn();
+		});
+
+		rerender(
+			<I18nProvider>
+				<AudioTrackPane
+					tl={
+						{
+							...tl,
+							audioTracks: [{ ...mockTrack, gainDb: 2.5, fadeInMs: 1500 }],
+						} as unknown as TimelineApi
+					}
+				/>
+			</I18nProvider>,
+		);
+		expect(fadeInSlider).toHaveValue("1500");
+
+		// 3. Fade out slider: drag to 2500 and release
+		fireEvent.change(fadeOutSlider, { target: { value: "2500" } });
+		fireEvent.mouseUp(fadeOutSlider);
+
+		expect(updateAudioTrack).toHaveBeenCalledWith("audio_track_1", { fadeOutMs: 2500 });
+		// While save is in flight, the slider MUST NOT jump back to 1000
+		expect(fadeOutSlider).toHaveValue("2500");
+
+		await act(async () => {
+			resolveFadeOut();
+		});
+
+		rerender(
+			<I18nProvider>
+				<AudioTrackPane
+					tl={
+						{
+							...tl,
+							audioTracks: [{ ...mockTrack, gainDb: 2.5, fadeInMs: 1500, fadeOutMs: 2500 }],
+						} as unknown as TimelineApi
+					}
+				/>
+			</I18nProvider>,
+		);
+		expect(fadeOutSlider).toHaveValue("2500");
 	});
 });

--- a/src/components/ai-edition/RightPanes.audioTrack.test.tsx
+++ b/src/components/ai-edition/RightPanes.audioTrack.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { I18nProvider } from "@/contexts/I18nContext";
+import { LOCALE_STORAGE_KEY } from "@/i18n/config";
+import type { AxcutAudioTrack } from "@/lib/ai-edition/schema";
+import type { useTimeline } from "@/lib/ai-edition/store/useTimeline";
+import { AudioTrackPane } from "./RightPanes";
+
+type TimelineApi = ReturnType<typeof useTimeline>;
+
+describe("AudioTrackPane reset button", () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	afterEach(() => {
+		localStorage.clear();
+	});
+
+	it("resets all track parameters (gain, fades, mute, loop) on reset click", () => {
+		const updateAudioTrack = vi.fn();
+		const mockTrack: AxcutAudioTrack = {
+			id: "audio_track_1",
+			clipId: "clip_1",
+			assetId: "asset_audio_1",
+			trackId: "audio_track_1",
+			startMs: 1000,
+			endMs: 5000,
+			durationSec: 10,
+			offsetMs: 0,
+			gainDb: -6,
+			fadeInMs: 500,
+			fadeOutMs: 1000,
+			muted: true,
+			loop: true,
+			kind: "music",
+			label: "test-audio.mp3",
+			origin: "user",
+		};
+
+		const tl = {
+			selectedAudioTrackId: "audio_track_1",
+			audioTracks: [mockTrack],
+			assets: [
+				{
+					id: "asset_audio_1",
+					kind: "audio",
+					label: "test-audio.mp3",
+					originalPath: "/path/test-audio.mp3",
+					durationSec: 10,
+				},
+			],
+			updateAudioTrack,
+		} as unknown as TimelineApi;
+
+		render(
+			<I18nProvider>
+				<AudioTrackPane tl={tl} />
+			</I18nProvider>,
+		);
+
+		const resetBtn = screen.getByRole("button", { name: /reset/i });
+		fireEvent.click(resetBtn);
+
+		expect(updateAudioTrack).toHaveBeenCalledTimes(1);
+		expect(updateAudioTrack).toHaveBeenCalledWith("audio_track_1", {
+			gainDb: 0,
+			fadeInMs: 0,
+			fadeOutMs: 0,
+			muted: false,
+			loop: false,
+		});
+	});
+
+	it("resets all track parameters under French locale", () => {
+		localStorage.setItem(LOCALE_STORAGE_KEY, "fr");
+		const updateAudioTrack = vi.fn();
+		const mockTrack: AxcutAudioTrack = {
+			id: "audio_track_1",
+			clipId: "clip_1",
+			assetId: "asset_audio_1",
+			trackId: "audio_track_1",
+			startMs: 1000,
+			endMs: 5000,
+			durationSec: 10,
+			offsetMs: 0,
+			gainDb: -0.5,
+			fadeInMs: 300,
+			fadeOutMs: 400,
+			muted: true,
+			loop: false,
+			kind: "music",
+			label: "openscreen-test-voix.mp3",
+			origin: "user",
+		};
+
+		const tl = {
+			selectedAudioTrackId: "audio_track_1",
+			audioTracks: [mockTrack],
+			assets: [
+				{
+					id: "asset_audio_1",
+					kind: "audio",
+					label: "openscreen-test-voix.mp3",
+					originalPath: "/path/openscreen-test-voix.mp3",
+					durationSec: 10,
+				},
+			],
+			updateAudioTrack,
+		} as unknown as TimelineApi;
+
+		render(
+			<I18nProvider>
+				<AudioTrackPane tl={tl} />
+			</I18nProvider>,
+		);
+
+		// French label: "Réinitialiser l’audio"
+		const resetBtn = screen.getByRole("button", { name: /réinitialiser l’audio/i });
+		fireEvent.click(resetBtn);
+
+		expect(updateAudioTrack).toHaveBeenCalledTimes(1);
+		expect(updateAudioTrack).toHaveBeenCalledWith("audio_track_1", {
+			gainDb: 0,
+			fadeInMs: 0,
+			fadeOutMs: 0,
+			muted: false,
+			loop: false,
+		});
+	});
+});

--- a/src/components/ai-edition/RightPanes.tsx
+++ b/src/components/ai-edition/RightPanes.tsx
@@ -3118,9 +3118,15 @@ export function AudioTrackPane({ tl }: { tl: TimelineApi }) {
 					decimals={1}
 					suffix=" dB"
 					onChange={(value) => setLiveGain(value)}
-					onCommit={() => {
-						if (liveGain !== null) void tl.setAudioTrackGain(track.id, liveGain);
-						setLiveGain(null);
+					onCommit={async () => {
+						if (liveGain !== null) {
+							const target = liveGain;
+							try {
+								await tl.setAudioTrackGain(track.id, target);
+							} finally {
+								setLiveGain((current) => (current === target ? null : current));
+							}
+						}
 					}}
 				/>
 				<SliderCell
@@ -3132,9 +3138,15 @@ export function AudioTrackPane({ tl }: { tl: TimelineApi }) {
 					decimals={0}
 					suffix=" ms"
 					onChange={setLiveFadeIn}
-					onCommit={() => {
-						if (liveFadeIn !== null) void tl.updateAudioTrack(track.id, { fadeInMs: liveFadeIn });
-						setLiveFadeIn(null);
+					onCommit={async () => {
+						if (liveFadeIn !== null) {
+							const target = liveFadeIn;
+							try {
+								await tl.updateAudioTrack(track.id, { fadeInMs: target });
+							} finally {
+								setLiveFadeIn((current) => (current === target ? null : current));
+							}
+						}
 					}}
 				/>
 				<SliderCell
@@ -3146,10 +3158,15 @@ export function AudioTrackPane({ tl }: { tl: TimelineApi }) {
 					decimals={0}
 					suffix=" ms"
 					onChange={setLiveFadeOut}
-					onCommit={() => {
-						if (liveFadeOut !== null)
-							void tl.updateAudioTrack(track.id, { fadeOutMs: liveFadeOut });
-						setLiveFadeOut(null);
+					onCommit={async () => {
+						if (liveFadeOut !== null) {
+							const target = liveFadeOut;
+							try {
+								await tl.updateAudioTrack(track.id, { fadeOutMs: target });
+							} finally {
+								setLiveFadeOut((current) => (current === target ? null : current));
+							}
+						}
 					}}
 				/>
 			</div>

--- a/src/components/ai-edition/RightPanes.tsx
+++ b/src/components/ai-edition/RightPanes.tsx
@@ -3169,7 +3169,15 @@ export function AudioTrackPane({ tl }: { tl: TimelineApi }) {
 				className={styles.secondaryBtn}
 				onClick={() => {
 					setLiveGain(null);
-					void tl.setAudioTrackGain(track.id, 0);
+					setLiveFadeIn(null);
+					setLiveFadeOut(null);
+					void tl.updateAudioTrack(track.id, {
+						gainDb: 0,
+						fadeInMs: 0,
+						fadeOutMs: 0,
+						muted: false,
+						loop: false,
+					});
 				}}
 			>
 				{ts("audio.reset")}

--- a/src/components/ai-edition/RightPanes.tsx
+++ b/src/components/ai-edition/RightPanes.tsx
@@ -3039,6 +3039,13 @@ type TimelineApi = ReturnType<typeof useTimeline>;
 // anyway (`resolveFadeSecs` reduces one that does not fit).
 const FADE_MAX_MS = 5000;
 
+/**
+ * Per-track controls for the selected imported audio track (issue #350). Shown by
+ * the inspector in place of the facet when an audio track is selected (see
+ * FloatingInspector). The header is the generic "Audio track"; the body leads
+ * with the file name, then the volume, fade in/out, mute, and loop controls,
+ * with actions to reset all parameters or delete the track.
+ */
 export function AudioTrackPane({ tl }: { tl: TimelineApi }) {
 	const ts = useScopedT("settings");
 	const trackId = tl.selectedAudioTrackId;


### PR DESCRIPTION
## Summary
Clicking the "Reset audio" (`Réinitialiser l’audio`) button in the audio track inspector pane previously only reset the output gain (`gainDb`), leaving fade-in, fade-out, mute, and loop unchanged.

This PR updates the reset handler to:
- Reset all track parameters (`gainDb: 0`, `fadeInMs: 0`, `fadeOutMs: 0`, `muted: false`, `loop: false`) in a single `tl.updateAudioTrack` operation.
- Clear any active live slider drag states (`liveGain`, `liveFadeIn`, `liveFadeOut`).

## Related issue
<!-- Use "Fixes #123", "Closes #123", or "Resolves #123" only when this PR fully resolves the issue. -->

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [x] Patch
- [ ] Minor
- [ ] Major / breaking change
- [ ] No release note needed

## Desktop impact
- [ ] Windows
- [ ] macOS
- [ ] Linux
- [ ] Installer / packaging
- [x] Not platform-specific

## Screenshots / video
<!-- Include screenshots or a short video for UI or visual changes. -->

## Testing
- Added unit tests in `src/components/ai-edition/RightPanes.audioTrack.test.tsx` verifying reset of all fields in default and French locales (`npx vitest --run src/components/ai-edition/RightPanes.audioTrack.test.tsx`).
- Typecheck: `npx tsc --noEmit` and `npx tsc -p tsconfig.test.json --noEmit`
- Biome check: `npm run lint` and `npm run format`

<!-- discord-thread-id:1545555053715128561 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resetting an audio track now restores gain, fade-in, fade-out, mute, and loop settings together.
  - Resetting also clears in-progress slider edits and consistently updates visible audio track controls.
  - Slider changes now apply reliably while preserving newer edits made during updates.

- **Tests**
  - Added coverage for reset behavior in the default and French locales, including drafted slider changes and zeroed audio settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->