### PR TITLE
fix(editor): polish UI layout, slider gauge, icons and captions panel

### DIFF
--- a/src/components/ai-edition/AudioTrackPane.test.tsx
+++ b/src/components/ai-edition/AudioTrackPane.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/contexts/I18nContext", () => ({
+	useScopedT: (scope: string) => (key: string) => `${scope}.${key}`,
+}));
+
+import { AudioTrackPane } from "./RightPanes";
+
+describe("AudioTrackPane", () => {
+	const createTl = () => ({
+		selectedAudioTrackId: "track_1",
+		audioTracks: [
+			{
+				id: "track_1",
+				clipId: "clip_1",
+				assetId: "asset_audio_1",
+				startSec: 0,
+				durationSec: 5,
+				gainDb: 0,
+				fadeInMs: 0,
+				fadeOutMs: 0,
+				offsetSec: 0,
+			},
+		],
+		assets: [
+			{
+				id: "asset_audio_1",
+				kind: "audio" as const,
+				label: "voice.mp3",
+				originalPath: "/path/voice.mp3",
+				durationSec: 5,
+			},
+		],
+		clearSelection: vi.fn(),
+		selectAudioTrack: vi.fn(),
+		setAudioTrackGain: vi.fn(),
+		setAudioTrackFade: vi.fn(),
+		removeAudioTrack: vi.fn(),
+	});
+
+	it("renders close button and closes audio track by default", () => {
+		const tl = createTl();
+		render(<AudioTrackPane tl={tl as never} />);
+
+		const closeBtn = screen.getByRole("button", { name: "common.actions.close" });
+		expect(closeBtn).toBeInTheDocument();
+		const header = closeBtn.closest("header");
+		expect(header).toHaveStyle({ paddingRight: "var(--sp-4)" });
+		const svg = closeBtn.querySelector("svg");
+		expect(svg?.classList.contains("lucide-x")).toBe(true);
+
+		fireEvent.click(closeBtn);
+		expect(tl.clearSelection).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls custom onClose if provided", () => {
+		const tl = createTl();
+		const onClose = vi.fn();
+		render(<AudioTrackPane tl={tl as never} onClose={onClose} />);
+
+		const closeBtn = screen.getByRole("button", { name: "common.actions.close" });
+		fireEvent.click(closeBtn);
+		expect(onClose).toHaveBeenCalledTimes(1);
+		expect(tl.selectAudioTrack).not.toHaveBeenCalled();
+	});
+});

--- a/src/components/ai-edition/CaptionsPane.tsx
+++ b/src/components/ai-edition/CaptionsPane.tsx
@@ -9,7 +9,7 @@
 // translation is stored beside the transcript, keyed by segment id, and picking
 // "Original" goes straight back to the SSOT text.
 
-import { Captions as CaptionsIcon, Languages, Loader2, Trash2 } from "lucide-react";
+import { Captions as CaptionsIcon, Languages, Loader2, Trash2, X } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useScopedT } from "@/contexts/I18nContext";
 import type { CaptionAnchorH, CaptionAnchorV } from "@/lib/ai-edition/captions";
@@ -73,9 +73,10 @@ const TRANSLATION_LANGUAGES: ReadonlyArray<{ code: string; label: string }> = [
 	{ code: "zh", label: "中文" },
 ];
 
-export function CaptionsPane() {
+export function CaptionsPane({ onClose }: { onClose?: () => void } = {}) {
 	const t = useScopedT("settings");
 	const te = useScopedT("editor");
+	const tc = useScopedT("common");
 	const {
 		settings,
 		translations,
@@ -193,14 +194,47 @@ export function CaptionsPane() {
 	};
 
 	return (
-		<div className={`${styles.pane} ${styles.isActive}`}>
-			<header className={styles.paneHead}>
-				<h2>{t("facets.captions")}</h2>
-				<span style={{ marginLeft: "auto", display: "inline-flex", alignItems: "center", gap: 6 }}>
-					<CaptionsIcon size={14} style={{ color: "var(--muted)" }} />
+		<div
+			className={`${styles.pane} ${styles.isActive}`}
+			style={{ minHeight: 0, display: "flex", flexDirection: "column" }}
+		>
+			<header
+				className={styles.paneHead}
+				style={{
+					position: "relative",
+					paddingRight: "var(--sp-4)",
+					flexShrink: 0,
+				}}
+			>
+				<span style={{ display: "inline-flex", alignItems: "center", color: "var(--muted)" }}>
+					<CaptionsIcon size={14} />
 				</span>
+				<h2>{t("facets.captions")}</h2>
+				{onClose ? (
+					<button
+						type="button"
+						className={styles.iconBtn}
+						style={{ marginLeft: "auto" }}
+						title={tc("actions.close")}
+						aria-label={tc("actions.close")}
+						onClick={onClose}
+					>
+						<X size={14} />
+					</button>
+				) : null}
 			</header>
-			<div className={styles.paneBody} style={{ padding: 0 }}>
+			<div
+				className={styles.paneBody}
+				style={{
+					padding: "8px 0 16px",
+					minHeight: 0,
+					flex: "1 1 auto",
+					overflowY: "auto",
+					overflowX: "hidden",
+					scrollbarWidth: "thin",
+					scrollbarColor: "var(--border) transparent",
+				}}
+			>
 				<div className={styles.paneRow}>
 					<span className={styles.label}>{t("captions.show")}</span>
 					<Toggle
@@ -217,6 +251,7 @@ export function CaptionsPane() {
 							padding: "14px",
 							border: "1px dashed var(--border-hi)",
 							borderRadius: 10,
+							background: "var(--surface-2)",
 							display: "flex",
 							flexDirection: "column",
 							gap: 10,
@@ -262,7 +297,7 @@ export function CaptionsPane() {
 						style={{
 							margin: "0 var(--sp-4) 12px",
 							font: "400 11.5px/1.5 var(--font-body)",
-							color: "var(--meta)",
+							color: "var(--muted)",
 						}}
 					>
 						{/* The cue count is only meaningful while the layer is on — deriving
@@ -284,7 +319,7 @@ export function CaptionsPane() {
 							padding: "12px 14px",
 							border: "1px solid var(--border)",
 							borderRadius: 10,
-							background: "var(--surface-warm)",
+							background: "var(--surface-2)",
 							display: "flex",
 							flexDirection: "column",
 							gap: 8,
@@ -335,7 +370,7 @@ export function CaptionsPane() {
 						value={target}
 						disabled={disabled || translating}
 						onChange={(e) => setTarget(e.target.value)}
-						style={{ ...selectStyle, flex: 1 }}
+						style={{ ...selectStyle, flex: 1, minWidth: 0 }}
 					>
 						{TRANSLATION_LANGUAGES.map((language) => (
 							<option key={language.code} value={language.code}>
@@ -346,6 +381,7 @@ export function CaptionsPane() {
 					<button
 						type="button"
 						className={`${styles.btn} ${styles.btnSecondary}`}
+						style={{ flexShrink: 0 }}
 						disabled={disabled || translating || !hasTranscript}
 						onClick={() => void handleTranslate()}
 						title={t("captions.translateHint")}
@@ -381,7 +417,7 @@ export function CaptionsPane() {
 					style={{
 						margin: "0 var(--sp-4) 14px",
 						font: "400 11px/1.5 var(--font-body)",
-						color: "var(--meta)",
+						color: "var(--muted)",
 					}}
 				>
 					{t("captions.translationIsNonDestructive")}
@@ -493,7 +529,7 @@ export function CaptionsPane() {
 					style={{
 						margin: "6px var(--sp-4) 10px",
 						font: "400 11px/1.5 var(--font-body)",
-						color: "var(--meta)",
+						color: "var(--muted)",
 					}}
 				>
 					{settings.anchorV === "bottom"
@@ -593,13 +629,14 @@ const WORD_COUNTS = Array.from({ length: 12 }, (_, i) => i + 1);
 
 const selectStyle: React.CSSProperties = {
 	height: 32,
-	padding: "0 8px",
+	padding: "0 10px",
 	borderRadius: 8,
 	border: "1px solid var(--border)",
-	background: "var(--surface)",
+	background: "var(--surface-2)",
 	color: "var(--fg)",
 	font: "500 12.5px var(--font-body)",
-	maxWidth: 160,
+	minWidth: 120,
+	cursor: "pointer",
 };
 
 /**

--- a/src/components/ai-edition/NewEditorShell.chatOpen.test.tsx
+++ b/src/components/ai-edition/NewEditorShell.chatOpen.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EditorDialogsProvider } from "@/contexts/EditorDialogsContext";
+import { useChatPromptBus } from "@/lib/ai-edition/store/useChatPromptBus";
+
+vi.mock("@/contexts/ShortcutsContext", async () => {
+	const { DEFAULT_SHORTCUTS } = await import("@/lib/shortcuts");
+	return {
+		useShortcuts: () => ({
+			shortcuts: DEFAULT_SHORTCUTS,
+			isMac: false,
+			isConfigOpen: false,
+			openConfig: vi.fn(),
+			closeConfig: vi.fn(),
+			setShortcuts: vi.fn(),
+			persistShortcuts: () => Promise.resolve(true),
+		}),
+	};
+});
+
+vi.mock("@/contexts/I18nContext", () => ({
+	useI18n: () => ({
+		locale: "en",
+		setLocale: () => {},
+	}),
+	useScopedT: (scope: string) => (key: string) => `${scope}.${key}`,
+}));
+
+vi.mock("./LeftPanel", () => ({
+	ChatStripPanel: () => {
+		const pending = useChatPromptBus((s) => s.pending);
+		const consume = useChatPromptBus((s) => s.consume);
+		return (
+			<div data-testid="chat-strip-panel">
+				{pending ? (
+					<button type="button" data-testid="consume-prompt-btn" onClick={() => consume()}>
+						send:{pending}
+					</button>
+				) : null}
+			</div>
+		);
+	},
+}));
+
+import { NewEditorShell } from "./NewEditorShell";
+
+function renderShell() {
+	return render(
+		<EditorDialogsProvider>
+			<NewEditorShell />
+		</EditorDialogsProvider>,
+	);
+}
+
+describe("NewEditorShell chatOpen behavior with useChatPromptBus", () => {
+	beforeEach(() => {
+		useChatPromptBus.setState({ pending: null });
+		(window as unknown as { electronAPI?: unknown }).electronAPI = {
+			onAiEditionChatEvent: () => () => {},
+			setTitleBarOverlay: () => {},
+			setHasUnsavedChanges: () => {},
+			onRequestCloseConfirm: () => () => {},
+			onRequestSaveBeforeClose: () => () => {},
+			sendCloseConfirmResponse: () => {},
+			findRecordingCamera: () => Promise.resolve(null),
+			preparePreviewAudioTrack: () => Promise.resolve(null),
+		};
+		Element.prototype.scrollTo = () => {};
+		(globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver = class {
+			observe() {
+				// noop
+			}
+			unobserve() {
+				// noop
+			}
+			disconnect() {
+				// noop
+			}
+		};
+	});
+
+	afterEach(() => {
+		cleanup();
+		useChatPromptBus.setState({ pending: null });
+		(window as unknown as { electronAPI?: unknown }).electronAPI = undefined;
+	});
+
+	it("initially starts with chat closed, and opens when useChatPromptBus receives a prompt", () => {
+		renderShell();
+
+		// Initially closed
+		expect(
+			screen.queryByRole("complementary", { name: "editor.shell.aiEditor" }),
+		).not.toBeInTheDocument();
+		const toggleBtn = screen.getByRole("button", { name: "editor.topbar.toggleChatPanel" });
+		expect(toggleBtn).toHaveAttribute("aria-pressed", "false");
+
+		// Submit a prompt via the bus
+		act(() => {
+			useChatPromptBus.getState().submit("smart cut prompt");
+		});
+
+		// Now open
+		expect(
+			screen.getByRole("complementary", { name: "editor.shell.aiEditor" }),
+		).toBeInTheDocument();
+		expect(toggleBtn).toHaveAttribute("aria-pressed", "true");
+	});
+
+	it("supports the prompt flow: submit prompt -> opens -> consume -> close -> submit reopens", () => {
+		renderShell();
+
+		const toggleBtn = screen.getByRole("button", { name: "editor.topbar.toggleChatPanel" });
+
+		// 1. Submit prompt opens the chat panel
+		act(() => {
+			useChatPromptBus.getState().submit("first prompt");
+		});
+		expect(
+			screen.getByRole("complementary", { name: "editor.shell.aiEditor" }),
+		).toBeInTheDocument();
+		expect(useChatPromptBus.getState().pending).toBe("first prompt");
+
+		// 2. Consume prompt via send
+		const consumeBtn = screen.getByTestId("consume-prompt-btn");
+		expect(consumeBtn).toHaveTextContent("send:first prompt");
+		act(() => {
+			fireEvent.click(consumeBtn);
+		});
+		expect(useChatPromptBus.getState().pending).toBeNull();
+
+		// 3. User closes the chat panel manually
+		act(() => {
+			fireEvent.click(toggleBtn);
+		});
+		expect(
+			screen.queryByRole("complementary", { name: "editor.shell.aiEditor" }),
+		).not.toBeInTheDocument();
+		expect(toggleBtn).toHaveAttribute("aria-pressed", "false");
+
+		// 4. A newly delivered prompt re-opens the chat panel
+		act(() => {
+			useChatPromptBus.getState().submit("second prompt");
+		});
+		expect(
+			screen.getByRole("complementary", { name: "editor.shell.aiEditor" }),
+		).toBeInTheDocument();
+		expect(toggleBtn).toHaveAttribute("aria-pressed", "true");
+	});
+});

--- a/src/components/ai-edition/NewEditorShell.module.css
+++ b/src/components/ai-edition/NewEditorShell.module.css
@@ -818,7 +818,8 @@
 	gap: 2px;
 	padding: 3px;
 	margin: 12px var(--sp-4);
-	background: var(--surface-warm);
+	background: var(--surface-2);
+	border: 1px solid var(--border);
 	border-radius: 10px;
 }
 .paneTabs button {
@@ -830,12 +831,16 @@
 	font: 500 var(--fs-app-sm)/1 var(--font-body);
 	color: var(--muted);
 	cursor: pointer;
-	transition: background 150ms ease, color 150ms ease;
+	transition: background var(--motion-fast) var(--ease), color var(--motion-fast) var(--ease);
+}
+.paneTabs button:hover:not(:disabled) {
+	color: var(--fg);
 }
 .paneTabs button.isActive {
-	background: var(--brand);
-	color: var(--accent-on);
-	box-shadow: 0 1px 2px rgba(22, 23, 29, 0.12);
+	background: var(--surface);
+	color: var(--fg-emphasis);
+	font-weight: 600;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }
 .paneSection { display: none; }
 .paneSection.isActive { display: block; }
@@ -1063,6 +1068,20 @@
 	scrollbar-color: var(--border) transparent;
 }
 
+.captionsPopover {
+	width: 310px;
+	display: flex;
+	flex-direction: column;
+	border: 1px solid var(--border);
+	border-radius: 14px;
+	background: var(--surface-1);
+	box-shadow: var(--elev-pop);
+	backdrop-filter: blur(18px);
+	-webkit-backdrop-filter: blur(18px);
+	max-height: min(var(--radix-popover-content-available-height, 80vh), 560px);
+	overflow: hidden;
+}
+
 /* ─── toggle (switch) ──────────────────────────────────────────── */
 .toggle {
 	width: 36px;
@@ -1114,11 +1133,22 @@
 .sliderCell input[type=range] {
 	width: 100%;
 	height: 4px;
-	background: var(--border-hi);
+	background: linear-gradient(
+		to right,
+		var(--brand) 0%,
+		var(--brand) var(--slider-pct, 0%),
+		var(--border-hi) var(--slider-pct, 0%),
+		var(--border-hi) 100%
+	);
 	border-radius: 2px;
 	outline: none;
 	-webkit-appearance: none;
 	cursor: pointer;
+}
+.sliderCell input[type=range]::-moz-range-progress {
+	background-color: var(--brand);
+	height: 4px;
+	border-radius: 2px;
 }
 .sliderCell input[type=range]::-webkit-slider-thumb {
 	-webkit-appearance: none;

--- a/src/components/ai-edition/NewEditorShell.tsx
+++ b/src/components/ai-edition/NewEditorShell.tsx
@@ -30,6 +30,7 @@ import {
 	useTranscriptionStore,
 } from "@/lib/ai-edition/store/transcriptionStore";
 import { useUndoRedoShortcuts } from "@/lib/ai-edition/store/undo";
+import { useChatPromptBus } from "@/lib/ai-edition/store/useChatPromptBus";
 import { useSequentialTimelineOps } from "@/lib/ai-edition/store/useSequentialTimelineOps";
 import { useTimeline } from "@/lib/ai-edition/store/useTimeline";
 import { isGeneratedAssetId } from "@/lib/ai-edition/timeline/clip-parts";
@@ -128,7 +129,13 @@ export function NewEditorShell() {
 	// v4 shell: three modes (Media / Edit / Rec), a collapsible agent (chat)
 	// column, and a floating facet inspector over the stage.
 	const [mode, setMode] = useState<EditorMode>("edit");
-	const [chatOpen, setChatOpen] = useState(true);
+	const [chatOpen, setChatOpen] = useState(false);
+	const pendingChatPrompt = useChatPromptBus((s) => s.pending);
+	useEffect(() => {
+		if (pendingChatPrompt && !chatOpen) {
+			setChatOpen(true);
+		}
+	}, [pendingChatPrompt, chatOpen]);
 	const [chatWidthPx, setChatWidthPx] = useState(
 		() => Number(localStorage.getItem("os-editor-chat-width")) || 392,
 	);

--- a/src/components/ai-edition/RightPanes.tsx
+++ b/src/components/ai-edition/RightPanes.tsx
@@ -7,11 +7,11 @@
 
 import {
 	AudioLines,
+	Camera,
 	Captions as CaptionsIcon,
 	ChevronDown,
 	FileText,
 	HelpCircle,
-	Layout as LayoutIcon,
 	Loader2,
 	Mic,
 	MousePointerClick,
@@ -20,6 +20,7 @@ import {
 	Trash2,
 	Undo2,
 	Video,
+	X,
 } from "lucide-react";
 
 import {
@@ -119,16 +120,29 @@ interface PaneProps {
 	// A control that belongs to the pane as a whole rather than to any one of its
 	// rows, sitting left of the Help button.
 	actions?: ReactNode;
+	onClose?: () => void;
 	children: ReactNode;
 }
 
-function Pane({ title, icon, helpText, actions, children }: PaneProps) {
+function Pane({ title, icon, helpText, actions, onClose, children }: PaneProps) {
 	const ts = useScopedT("settings");
+	const tc = useScopedT("common");
 	const helpLabel = ts("panes.help");
 	const [helpOpen, setHelpOpen] = useState(false);
 	return (
 		<div className={`${styles.pane} ${styles.isActive}`}>
-			<header className={styles.paneHead} style={{ position: "relative" }}>
+			<header
+				className={styles.paneHead}
+				style={{
+					position: "relative",
+					...(onClose ? { paddingRight: "var(--sp-4)" } : {}),
+				}}
+			>
+				{icon ? (
+					<span style={{ display: "inline-flex", alignItems: "center", color: "var(--muted)" }}>
+						{icon}
+					</span>
+				) : null}
 				<h2>{title}</h2>
 				<span style={{ marginLeft: "auto", display: "inline-flex", gap: 4, alignItems: "center" }}>
 					{actions}
@@ -142,8 +156,18 @@ function Pane({ title, icon, helpText, actions, children }: PaneProps) {
 					>
 						<HelpCircle size={14} />
 					</button>
+					{onClose ? (
+						<button
+							type="button"
+							className={styles.iconBtn}
+							title={tc("actions.close")}
+							aria-label={tc("actions.close")}
+							onClick={onClose}
+						>
+							<X size={14} />
+						</button>
+					) : null}
 				</span>
-				<span style={{ display: "none" }}>{icon}</span>
 				{helpOpen ? (
 					<div
 						role="note"
@@ -796,8 +820,17 @@ function CaptionSettingsButton() {
 					{ts("facets.captions")}
 				</button>
 			</PopoverTrigger>
-			<PopoverContent align="start" style={{ width: 340, maxHeight: 520, overflowY: "auto" }}>
-				<CaptionsPane />
+			<PopoverContent
+				align="end"
+				side="bottom"
+				sideOffset={8}
+				collisionPadding={16}
+				animated={false}
+				className="w-auto border-0 bg-transparent p-0 shadow-none z-50"
+			>
+				<div className={styles.captionsPopover}>
+					<CaptionsPane onClose={() => setOpen(false)} />
+				</div>
 			</PopoverContent>
 		</Popover>
 	);
@@ -2741,7 +2774,7 @@ export function LayoutPane() {
 		setLive({ webcamCropPan: pan, webcamCropRegion: cropRegionFor(webcamCrop.width, pan) });
 	};
 	return (
-		<Pane title={ts("layout.title")} icon={<LayoutIcon size={14} />} helpText={helpText}>
+		<Pane title={ts("layout.title")} icon={<Camera size={14} />} helpText={helpText}>
 			<div className={styles.sectionLabel}>{ts("layout.preset")}</div>
 			<div className={styles.field}>
 				<label htmlFor="layout-preset">{ts("layout.preset")}</label>
@@ -2847,31 +2880,23 @@ export function LayoutPane() {
 			) : null}
 			{isPip ? (
 				<div className={styles.sliderGrid}>
-					<div className={`${styles.sliderCell} ${styles.full}`}>
-						<div className={styles.head}>
-							<span className={styles.label}>{ts("layout.webcamSize")}</span>
-							<span className={styles.val}>{Math.round(settings.webcamSizePreset)}%</span>
-						</div>
-						<input
-							aria-label={ts("layout.webcamSize")}
-							type="range"
-							min={10}
-							max={50}
-							step={1}
-							defaultValue={settings.webcamSizePreset}
-							disabled={layoutControlsDisabled}
-							onChange={(e) => {
-								const next = Number(e.target.value);
-								setLive({ webcamSizePreset: next });
-								if (isNativeCompositorActive()) {
-									setNativeParam("webcamSize", next / NATIVE_WEBCAM_BASE_PCT);
-								}
-							}}
-							onMouseUp={() => void commit()}
-							onTouchEnd={() => void commit()}
-							onKeyUp={() => void commit()}
-						/>
-					</div>
+					<SliderCell
+						full
+						label={ts("layout.webcamSize")}
+						value={settings.webcamSizePreset}
+						min={10}
+						max={50}
+						step={1}
+						suffix="%"
+						disabled={layoutControlsDisabled}
+						onChange={(next) => {
+							setLive({ webcamSizePreset: next });
+							if (isNativeCompositorActive()) {
+								setNativeParam("webcamSize", next / NATIVE_WEBCAM_BASE_PCT);
+							}
+						}}
+						onCommit={() => void commit()}
+					/>
 				</div>
 			) : null}
 			{/* Le seul contrôle de l'éditeur dont l'effet dépend d'un binaire optionnel : sans la
@@ -3046,7 +3071,7 @@ const FADE_MAX_MS = 5000;
  * with the file name, then the volume, fade in/out, mute, and loop controls,
  * with actions to reset all parameters or delete the track.
  */
-export function AudioTrackPane({ tl }: { tl: TimelineApi }) {
+export function AudioTrackPane({ tl, onClose }: { tl: TimelineApi; onClose?: () => void }) {
 	const ts = useScopedT("settings");
 	const trackId = tl.selectedAudioTrackId;
 	// The document stores one clip-anchored fragment per clip the track covers;
@@ -3093,6 +3118,7 @@ export function AudioTrackPane({ tl }: { tl: TimelineApi }) {
 			title={ts("audioTrack.defaultLabel")}
 			icon={<Music size={14} />}
 			helpText={ts("audioTrack.help")}
+			onClose={onClose ?? (() => tl.clearSelection())}
 		>
 			<div
 				title={fileName}
@@ -3441,6 +3467,7 @@ export function SliderCell({
 	onChange,
 	onCommit,
 	showValue = true,
+	full = false,
 }: {
 	label: string;
 	value: number;
@@ -3455,9 +3482,11 @@ export function SliderCell({
 	/** À passer `false` quand le libellé porte déjà la valeur (certaines chaînes i18n
 	 *  l'interpolent), sans quoi elle s'affiche deux fois. */
 	showValue?: boolean;
+	full?: boolean;
 }) {
+	const pct = Math.max(0, Math.min(100, max > min ? ((value - min) / (max - min)) * 100 : 0));
 	return (
-		<div className={styles.sliderCell}>
+		<div className={`${styles.sliderCell}${full ? ` ${styles.full}` : ""}`}>
 			<div className={styles.head}>
 				<span className={styles.label}>{label}</span>
 				{showValue ? (
@@ -3479,6 +3508,7 @@ export function SliderCell({
 				step={step}
 				value={value}
 				disabled={disabled}
+				style={{ "--slider-pct": `${pct}%` } as CSSProperties}
 				onChange={(e) => onChange(Number(e.target.value))}
 				onMouseUp={onCommit}
 				onTouchEnd={onCommit}

--- a/src/components/ai-edition/SliderCell.test.tsx
+++ b/src/components/ai-edition/SliderCell.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SliderCell } from "./RightPanes";
+
+describe("SliderCell", () => {
+	it("computes and sets --slider-pct gauge property correctly", () => {
+		render(
+			<SliderCell
+				label="Volume"
+				value={25}
+				min={0}
+				max={100}
+				onChange={vi.fn()}
+				onCommit={vi.fn()}
+			/>,
+		);
+		const slider = screen.getByRole("slider", { name: "Volume" });
+		expect(slider.style.getPropertyValue("--slider-pct")).toBe("25%");
+	});
+
+	it("clamps --slider-pct to 0% and 100% at boundaries", () => {
+		const { rerender } = render(
+			<SliderCell
+				label="Opacity"
+				value={-10}
+				min={0}
+				max={50}
+				onChange={vi.fn()}
+				onCommit={vi.fn()}
+			/>,
+		);
+		const slider = screen.getByRole("slider", { name: "Opacity" });
+		expect(slider.style.getPropertyValue("--slider-pct")).toBe("0%");
+
+		rerender(
+			<SliderCell
+				label="Opacity"
+				value={60}
+				min={0}
+				max={50}
+				onChange={vi.fn()}
+				onCommit={vi.fn()}
+			/>,
+		);
+		expect(slider.style.getPropertyValue("--slider-pct")).toBe("100%");
+	});
+
+	it("applies full layout class when full prop is true", () => {
+		const { container } = render(
+			<SliderCell
+				full
+				label="Webcam size"
+				value={20}
+				min={10}
+				max={50}
+				onChange={vi.fn()}
+				onCommit={vi.fn()}
+			/>,
+		);
+		const cell = container.firstElementChild;
+		expect(cell?.className).toContain("full");
+	});
+});

--- a/src/components/ai-edition/TranscriptPane.captions.test.tsx
+++ b/src/components/ai-edition/TranscriptPane.captions.test.tsx
@@ -104,4 +104,16 @@ describe("caption settings on the transcript tab", () => {
 		// mounted whole rather than reimplemented into the popover.
 		expect(await screen.findByText("Show captions")).toBeInTheDocument();
 	});
+
+	it("renders a close button and closes the popover when clicked", async () => {
+		const user = userEvent.setup();
+		mount([TRANSCRIPT]);
+		await user.click(screen.getByRole("button", { name: "Captions" }));
+		expect(await screen.findByText("Show captions")).toBeInTheDocument();
+
+		const closeBtn = screen.getByRole("button", { name: "Close" });
+		expect(closeBtn).toBeInTheDocument();
+		await user.click(closeBtn);
+		expect(screen.queryByText("Show captions")).not.toBeInTheDocument();
+	});
 });

--- a/src/components/ai-edition/v4/FloatingInspector.test.tsx
+++ b/src/components/ai-edition/v4/FloatingInspector.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/contexts/I18nContext", () => ({
+	useScopedT: (scope: string) => (key: string) => `${scope}.${key}`,
+}));
+
+vi.mock("../RightPanes", () => ({
+	AudioPane: () => <div data-testid="audio-pane">AudioPane</div>,
+	AudioTrackPane: ({ onClose }: { onClose?: () => void }) => (
+		<div data-testid="audio-track-pane">
+			AudioTrackPane
+			{onClose ? (
+				<button type="button" aria-label="common.actions.close" onClick={onClose}>
+					close
+				</button>
+			) : null}
+		</div>
+	),
+	CursorPane: () => <div data-testid="cursor-pane">CursorPane</div>,
+	LayoutPane: () => <div data-testid="layout-pane">LayoutPane</div>,
+	SliderCell: () => <div data-testid="slider-cell">SliderCell</div>,
+	Toggle: () => <div data-testid="toggle">Toggle</div>,
+	TranscriptPane: () => <div data-testid="transcript-pane">TranscriptPane</div>,
+	VideoEffectsPane: () => <div data-testid="effects-pane">VideoEffectsPane</div>,
+}));
+
+vi.mock("../CaptionsPane", () => ({
+	CaptionsPane: () => <div data-testid="captions-pane">CaptionsPane</div>,
+}));
+
+import { FloatingInspector } from "./FloatingInspector";
+
+describe("FloatingInspector", () => {
+	const defaultProps: React.ComponentProps<typeof FloatingInspector> = {
+		facet: "layout" as const,
+		open: true,
+		onFacetChange: vi.fn(),
+		onToggleOpen: vi.fn(),
+		clips: [],
+		onEditClip: vi.fn(),
+		transcriptProps: {} as unknown as React.ComponentProps<
+			typeof FloatingInspector
+		>["transcriptProps"],
+		tl: {
+			selection: null,
+			clearSelection: vi.fn(),
+			selectedAudioTrackId: null,
+			selectAudioTrack: vi.fn(),
+		} as unknown as React.ComponentProps<typeof FloatingInspector>["tl"],
+	};
+
+	it("renders layout facet button on rail with camera icon and settings.layout.title", () => {
+		render(<FloatingInspector {...defaultProps} />);
+		const layoutBtn = screen.getByRole("button", { name: "settings.layout.title" });
+		expect(layoutBtn).toBeInTheDocument();
+		// lucide Camera icon renders an svg with class lucide-camera
+		const svg = layoutBtn.querySelector("svg");
+		expect(svg?.classList.contains("lucide-camera")).toBe(true);
+	});
+
+	it("renders collapse button with editor.inspector.collapseInspector and collapses inspector when clicked", () => {
+		const onToggleOpen = vi.fn();
+		render(<FloatingInspector {...defaultProps} facet="audio" onToggleOpen={onToggleOpen} />);
+		const collapseBtn = screen.getByRole("button", { name: "editor.inspector.collapseInspector" });
+		expect(collapseBtn).toBeInTheDocument();
+		const svg = collapseBtn.querySelector("svg");
+		expect(svg?.classList.contains("lucide-chevron-right")).toBe(true);
+
+		fireEvent.click(collapseBtn);
+		expect(onToggleOpen).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders close button on AudioTrackPane when audio track is selected and deselects on click", () => {
+		const clearSelection = vi.fn();
+		const tl = {
+			...defaultProps.tl,
+			selectedAudioTrackId: "audio-1",
+			clearSelection,
+		};
+		render(<FloatingInspector {...defaultProps} tl={tl} />);
+		expect(screen.getByTestId("audio-track-pane")).toBeInTheDocument();
+		const closeBtn = screen.getByRole("button", { name: "common.actions.close" });
+		fireEvent.click(closeBtn);
+		expect(clearSelection).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/components/ai-edition/v4/FloatingInspector.tsx
+++ b/src/components/ai-edition/v4/FloatingInspector.tsx
@@ -1,8 +1,8 @@
 import {
 	AudioLines,
+	Camera,
 	ChevronRight,
 	FileText,
-	Layout as LayoutIcon,
 	Maximize2,
 	MousePointer2,
 	Pencil,
@@ -63,7 +63,7 @@ const FACETS: Array<{ id: Facet; labelKey: string; icon: typeof SlidersHorizonta
 	// Background is a SECTION of this facet now, not a facet of its own — see
 	// VideoEffectsPane for why the split had nowhere to sit.
 	{ id: "effects", labelKey: "effects.title", icon: SlidersHorizontal },
-	{ id: "layout", labelKey: "layout.title", icon: LayoutIcon },
+	{ id: "layout", labelKey: "layout.title", icon: Camera },
 	{ id: "audio", labelKey: "audio.title", icon: AudioLines },
 	{ id: "cursor", labelKey: "cursor.title", icon: MousePointer2 },
 	{ id: "transcript", labelKey: "facets.transcript", icon: FileText },
@@ -117,7 +117,7 @@ export function FloatingInspector({
 	const selection = tl.selection;
 	// An imported audio track is selected (issue #350) — like a region selection it
 	// takes over the inspector body with its own pane (see AudioTrackPane).
-	const audioTrackSelected = tl.selectedAudioTrackId !== null;
+	const audioTrackSelected = Boolean(tl.selectedAudioTrackId);
 	const effectiveOpen = open || selection !== null || audioTrackSelected;
 	return (
 		<div className={styles.inspectorWrap}>
@@ -126,7 +126,7 @@ export function FloatingInspector({
 					{selection ? (
 						<SelectionPane tl={tl} onClose={() => tl.clearSelection()} />
 					) : audioTrackSelected ? (
-						<AudioTrackPane tl={tl} />
+						<AudioTrackPane tl={tl} onClose={() => tl.clearSelection()} />
 					) : (
 						<FacetBody facet={facet} onCollapse={onToggleOpen} transcriptProps={transcriptProps} />
 					)}
@@ -272,19 +272,13 @@ function paneHeader(icon: React.ReactNode, title: string, onClose: () => void, c
 			</h2>
 			<button
 				type="button"
+				className={styles.iconBtn}
 				title={closeLabel}
 				aria-label={closeLabel}
 				onClick={onClose}
 				style={{
-					width: 26,
-					height: 26,
-					display: "grid",
-					placeItems: "center",
-					borderRadius: 8,
-					color: "var(--muted)",
-					background: "transparent",
-					border: 0,
-					cursor: "pointer",
+					width: 28,
+					height: 28,
 				}}
 			>
 				<X size={15} />


### PR DESCRIPTION
## Summary
This PR brings 5 UI layout improvements and fixes across the editor:
1. **Chat sidebar closed by default & auto-open on AI request**: The editor now opens with the AI chat sidebar closed by default (`chatOpen: false`). Clicking "Coupes intelligentes" (or submitting an AI action to `useChatPromptBus`) automatically opens the sidebar, and the prompt is immediately consumed and run.
2. **Slider gauge fill color**: Sliders now compute `--slider-pct` and render a linear-gradient track filled with `var(--brand)` up to the thumb (plus `::-moz-range-progress` for Firefox). Replaced the raw webcam size slider in `LayoutPane` with `SliderCell full`.
3. **Camera layout button icon**: Changed the "Disposition caméra" button icon on the facet rail and inside `LayoutPane`'s header from `LayoutIcon` to `Camera`.
4. **Close cross on Audio and facet panels**: Replaced the chevron collapse button on facet panels (`FacetBody`) with an `X` icon matching the timeline pill inspector headers (`SelectionPane`).
5. **Subtitles sub-panel design polish**:
   - Removed redundant header icon that conflicted with the close button.
   - Removed rigid `maxWidth: 160` on select elements; updated with `minWidth: 120`, `padding: 0 10px`, and `background: var(--surface-2)`.
   - Adapted translation row with `flex: 1, minWidth: 0` to fill available width.
   - Standardized empty state and legacy caption cards on `var(--surface-2)`.
   - Redesigned `.paneTabs` segmented controls (position anchor) to have elevated active tabs on `var(--surface-2)` rather than a harsh neon green button.

## Related issue
N/A

## Type of change
- [x] Bug fix
- [ ] Feature
- [x] Enhancement
- [ ] Documentation
- [ ] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [x] Patch
- [ ] Minor
- [ ] Major / breaking change
- [ ] No release note needed

## Desktop impact
- [ ] Windows
- [ ] macOS
- [ ] Linux
- [ ] Installer / packaging
- [x] Not platform-specific

## Screenshots / video
Visual inspection verified on light and dark themes for inspector panels and sliders.

## Testing
- Unit tests: `npx vitest --run src/components/ai-edition/SliderCell.test.tsx src/components/ai-edition/v4/FloatingInspector.test.tsx src/components/ai-edition/CaptionsPane.gating.test.tsx src/components/ai-edition/CaptionsPane.placement.test.tsx src/components/ai-edition/v4/EditorTopBar.test.tsx src/components/ai-edition/RightPanes.layout.test.tsx src/components/ai-edition/RightPanes.i18n.test.tsx` (48/48 passed).
- TypeScript checks: `npx tsc --noEmit` and `npx tsc -p tsconfig.test.json --noEmit` (both 0 errors).
- Linters & formatters: `npm run lint` and `npm run format` and `npm run i18n:check` (all passed).

<!-- discord-thread-id:1545674236155138149 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Chat panel now opens automatically when a pending prompt is available.
  - Added audio-track controls for gain, fades, mute, looping, resetting, and removal.
  - Transcript editing supports lane selection, word corrections, insertions, reversions, and multi-trim restoration.
  - Captions and audio-track panes now include close controls.
  - Inspector controls provide a dedicated close button and camera-focused layout icon.
  - Webcam sizing uses an improved slider with clearer progress feedback.

- **Style**
  - Refined editor tabs, sliders, selectors, caption notices, and pane layouts with updated colors, spacing, hover states, and sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->