### PR TITLE
fix(editor): keep the camera preset labels inside their button

### DIFF
--- a/src/components/ai-edition/NewEditorShell.module.css
+++ b/src/components/ai-edition/NewEditorShell.module.css
@@ -1202,6 +1202,17 @@
 	border-color: var(--brand);
 	box-shadow: 0 0 0 2px color-mix(in oklab, var(--brand), transparent 75%);
 }
+/* Same cell, reused for the icon+label rows (camera shape, camera background).
+   `minmax(0, 1fr)` stopped a long label from pushing the grid, but the text still
+   spilled over the button's own border and crowded its neighbour -- « Personnalisé »,
+   « Пользовательский », "Personalizzato" in a 61 px track. Clip it here, once, for
+   every labelled cell instead of hoping each locale stays short. */
+.cursorCell > span {
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
 
 /* ─── chat strip + input ───────────────────────────────────────── */
 .chatStrip {

--- a/src/components/ai-edition/RightPanes.tsx
+++ b/src/components/ai-edition/RightPanes.tsx
@@ -2845,7 +2845,7 @@ export function LayoutPane() {
 									style={{
 										flexDirection: "column",
 										gap: 4,
-										padding: 8,
+										padding: "8px 4px",
 										display: "flex",
 										alignItems: "center",
 										// Sans `minWidth: 0` le bouton garde son minimum de
@@ -2871,7 +2871,9 @@ export function LayoutPane() {
 									>
 										{shape.icon}
 									</svg>
-									<span style={{ font: "500 11px/1 var(--font-body)" }}>{ts(shape.labelKey)}</span>
+									<span title={ts(shape.labelKey)} style={{ font: "500 11px/1 var(--font-body)" }}>
+										{ts(shape.labelKey)}
+									</span>
 								</button>
 							);
 						})}
@@ -2926,7 +2928,7 @@ export function LayoutPane() {
 									style={{
 										flexDirection: "column",
 										gap: 4,
-										padding: 8,
+										padding: "8px 4px",
 										display: "flex",
 										alignItems: "center",
 										minWidth: 0,
@@ -2946,7 +2948,9 @@ export function LayoutPane() {
 									>
 										{mode.icon}
 									</svg>
-									<span style={{ font: "500 11px/1 var(--font-body)" }}>{ts(mode.labelKey)}</span>
+									<span title={ts(mode.labelKey)} style={{ font: "500 11px/1 var(--font-body)" }}>
+										{ts(mode.labelKey)}
+									</span>
 								</button>
 							);
 						})}


### PR DESCRIPTION
Les libellés des presets caméra (forme et arrière-plan) débordaient de leur bouton et venaient coller le cadre vert de la cellule active.

**Cause.** `.cursorCell` a été dessiné pour la grille de curseurs : une cellule carrée, icône seule. Les deux rangées « forme de la webcam » et « arrière-plan de la caméra » la réutilisent avec un libellé sous l'icône. L'inspecteur fait 300 px, la rangée fait quatre pistes, donc 61 px par cellule et 43 px utiles. « Personnalisé » demande ~65 px en 11 px : il peint hors de sa bordure. `minmax(0, 1fr)` et `minWidth: 0` empêchaient déjà le texte de pousser la piste, rien ne l'empêchait de sortir du bouton.

**Correctif.**
- `.cursorCell > span` clippé en ellipsis, une fois, pour les deux rangées et toute cellule libellée à venir. Ce n'est pas un problème de traduction française : es « Personalizado », it « Personalizzato », ru « Пользовательский » débordent pareil, et en « Original » est pile à la limite.
- Padding latéral 8 px → 4 px : 8 px de libellé récupérés, donc seuls les libellés vraiment trop longs atteignent l'ellipsis.
- `title` sur le libellé pour lire la chaîne complète au survol quand elle est tronquée.

**Vérification.** Repro isolée à la largeur réelle de l'inspecteur (300 px, tokens du thème sombre) : avant, « Détouré » et « Personnalisé » sortent de leur cadre ; après, « Original / Détouré / Flouté » tiennent en entier et « Personnalisé » se tronque proprement. Les tests n'ont pas été lancés, `node_modules` de ce clone est incomplet (`vitest` absent) ; le changement est du CSS plus un attribut `title`, les requêtes `getByText` existantes restent valides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1545707307030159361 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented long, localized labels from overflowing or crowding neighboring cells.
  - Improved handling of webcam shape and background mode controls so labels remain readable within their buttons.

- **Style**
  - Adjusted button spacing for a more consistent layout.
  - Added hover text for webcam controls to clarify each option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->