### PR TITLE
fix: stop background writes clobbering a concurrent user edit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,8 @@
 *.rs   text eol=lf
 *.ts   text eol=lf
 *.tsx  text eol=lf
+# Vite's SSR hashbang detection requires LF in imported executable modules.
+*.mjs  text eol=lf
 # Same drift, caught on the native helper's build file: an edit from Windows
 # rewrote all 67 lines as CRLF and buried a 22-line change in a 156-line diff.
 CMakeLists.txt text eol=lf

--- a/src/components/ai-edition/NewEditorShell.probedDuration.test.tsx
+++ b/src/components/ai-edition/NewEditorShell.probedDuration.test.tsx
@@ -1,9 +1,8 @@
-// @vitest-environment jsdom
 // The decision a `loadedmetadata` event makes, on its own.
 //
 // The event itself arrives through Preview -> PreviewCanvas -> VirtualPreview and a
-// real <video>, which jsdom never fires, so the component cannot be driven end to
-// end here. `documentAfterProbedDuration` is the part that decides what gets
+// real <video>, which no test environment here can decode, so the component cannot
+// be driven end to end. `documentAfterProbedDuration` is the part that decides what gets
 // written, and both guards below live in it: the queue the shell puts this write on
 // is what makes them necessary, because it puts real time between the event and the
 // write. The queue's own serialization is covered by useSequentialTimelineOps.test.

--- a/src/components/ai-edition/NewEditorShell.probedDuration.test.tsx
+++ b/src/components/ai-edition/NewEditorShell.probedDuration.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+// The decision a `loadedmetadata` event makes, on its own.
+//
+// The event itself arrives through Preview -> PreviewCanvas -> VirtualPreview and a
+// real <video>, which jsdom never fires, so the component cannot be driven end to
+// end here. `documentAfterProbedDuration` is the part that decides what gets
+// written, and both guards below live in it: the queue the shell puts this write on
+// is what makes them necessary, because it puts real time between the event and the
+// write. The queue's own serialization is covered by useSequentialTimelineOps.test.
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/contexts/ShortcutsContext", async () => {
+	const { DEFAULT_SHORTCUTS } = await import("@/lib/shortcuts");
+	return {
+		useShortcuts: () => ({
+			shortcuts: DEFAULT_SHORTCUTS,
+			isMac: false,
+			isConfigOpen: false,
+			openConfig: vi.fn(),
+			closeConfig: vi.fn(),
+			setShortcuts: vi.fn(),
+			persistShortcuts: () => Promise.resolve(true),
+		}),
+	};
+});
+
+vi.mock("@/contexts/I18nContext", () => ({
+	useI18n: () => ({ locale: "en", setLocale: vi.fn() }),
+	useScopedT: () => (key: string) => key,
+}));
+
+import { migrateProjectDataToAxcutDocument } from "@/lib/ai-edition/document/migrate";
+import { type AxcutDocument, createEmptyDocument, documentSchema } from "@/lib/ai-edition/schema";
+import { documentAfterProbedDuration } from "./NewEditorShell";
+
+const PROJECT = "proj_a";
+
+/** A fresh import: assets on the document, nothing on the timeline yet. */
+function emptyTimeline(primaryAssetId: string, assetIds: string[]): AxcutDocument {
+	const doc = createEmptyDocument({ projectId: PROJECT, title: "A" });
+	return {
+		...doc,
+		project: { ...doc.project, primaryAssetId },
+		assets: assetIds.map((id) => ({
+			id,
+			kind: "video" as const,
+			label: `${id}.mp4`,
+			originalPath: `/tmp/${id}.mp4`,
+			cameraTrack: null,
+		})),
+	};
+}
+
+/** A v1.7 project: one clip with no source extent, waiting for a real length. */
+function legacyWithClip(): AxcutDocument {
+	return documentSchema.parse(
+		migrateProjectDataToAxcutDocument({
+			version: 2,
+			videoPath: "C:/rec/screen.webm",
+			media: { videoPath: "C:/rec/screen.webm" },
+			editor: {
+				zoomRegions: [],
+				annotationRegions: [],
+				trimRegions: [],
+				speedRegions: [],
+				cameraFullscreenRegions: [],
+			},
+		} as never),
+	);
+}
+
+describe("documentAfterProbedDuration", () => {
+	it("seeds a full-duration clip when the primary asset reports its length", () => {
+		const doc = emptyTimeline("asset_1", ["asset_1"]);
+
+		const next = documentAfterProbedDuration(doc, "asset_1", 30, PROJECT);
+
+		expect(next).not.toBeNull();
+		expect(next?.assets[0].durationSec).toBe(30);
+		expect(next?.timeline.clips).toHaveLength(1);
+		expect(next?.timeline.clips[0].timelineStartSec).toBe(0);
+		expect(next?.timeline.clips[0].timelineEndSec).toBe(30);
+	});
+
+	// The write is queued, so the user can switch projects between the event and this
+	// decision. `knownSec` came off the OLD video; applying it to whatever is loaded
+	// now writes one recording's length into another project.
+	it("writes nothing when the project changed after the event fired", () => {
+		const doc = emptyTimeline("asset_1", ["asset_1"]);
+
+		expect(documentAfterProbedDuration(doc, "asset_1", 30, "proj_switched_to")).toBeNull();
+		expect(documentAfterProbedDuration(doc, "asset_1", 30, undefined)).toBeNull();
+	});
+
+	// `replaceTimeline` pins every clip it builds to the primary asset, and the seed
+	// sizes that clip from `knownSec` — so seeding on another asset's event would put
+	// one video's length under a different asset's id. The primary's own event seeds it.
+	it("does not seed from an asset that is not the one the seed is about", () => {
+		const doc = emptyTimeline("asset_1", ["asset_1", "asset_2"]);
+
+		expect(documentAfterProbedDuration(doc, "asset_2", 30, PROJECT)).toBeNull();
+		// And the primary still seeds normally on the same document.
+		expect(documentAfterProbedDuration(doc, "asset_1", 30, PROJECT)).not.toBeNull();
+	});
+
+	it("folds the length into a clip that was waiting for one", () => {
+		const doc = legacyWithClip();
+		const assetId = doc.assets[0].id;
+
+		const next = documentAfterProbedDuration(doc, assetId, 30, doc.project.id);
+
+		expect(next?.timeline.clips[0].sourceEndSec).toBe(30);
+		expect(next?.assets[0].durationSec).toBe(30);
+	});
+
+	it("writes nothing when the length is already recorded", () => {
+		const doc = legacyWithClip();
+		const assetId = doc.assets[0].id;
+		const settled = documentAfterProbedDuration(doc, assetId, 30, doc.project.id);
+
+		expect(settled).not.toBeNull();
+		expect(
+			documentAfterProbedDuration(settled as AxcutDocument, assetId, 30, doc.project.id),
+		).toBeNull();
+	});
+
+	it("writes nothing without a document or without assets", () => {
+		expect(documentAfterProbedDuration(null, "asset_1", 30, PROJECT)).toBeNull();
+		expect(documentAfterProbedDuration(emptyTimeline("asset_1", []), "asset_1", 30, PROJECT)).toBeNull();
+	});
+});

--- a/src/components/ai-edition/NewEditorShell.probedDuration.test.tsx
+++ b/src/components/ai-edition/NewEditorShell.probedDuration.test.tsx
@@ -126,6 +126,8 @@ describe("documentAfterProbedDuration", () => {
 
 	it("writes nothing without a document or without assets", () => {
 		expect(documentAfterProbedDuration(null, "asset_1", 30, PROJECT)).toBeNull();
-		expect(documentAfterProbedDuration(emptyTimeline("asset_1", []), "asset_1", 30, PROJECT)).toBeNull();
+		expect(
+			documentAfterProbedDuration(emptyTimeline("asset_1", []), "asset_1", 30, PROJECT),
+		).toBeNull();
 	});
 });

--- a/src/components/ai-edition/NewEditorShell.tsx
+++ b/src/components/ai-edition/NewEditorShell.tsx
@@ -14,10 +14,7 @@ import {
 	migrateProjectDataToAxcutDocument,
 	migrateRawDocumentToCurrent,
 } from "@/lib/ai-edition/document/migrate";
-import {
-	applyProbedDuration,
-	replaceTimeline as replaceTimelineOp,
-} from "@/lib/ai-edition/document/timeline";
+import { documentAfterProbedDuration } from "@/lib/ai-edition/document/timeline";
 import {
 	type InsertSide,
 	insertDocumentWord,
@@ -25,12 +22,7 @@ import {
 	setDocumentWordText,
 } from "@/lib/ai-edition/document/transcript";
 import { isModalOpen } from "@/lib/ai-edition/modalGuard";
-import {
-	type AxcutAudioTrack,
-	type AxcutClip,
-	type AxcutDocument,
-	documentSchema,
-} from "@/lib/ai-edition/schema";
+import { type AxcutAudioTrack, type AxcutClip, documentSchema } from "@/lib/ai-edition/schema";
 import { useProjectStore } from "@/lib/ai-edition/store/projectStore";
 import {
 	useAssetTranscriptions,
@@ -119,59 +111,6 @@ function NativePlaybackSync({
 export const DEFAULT_TIMELINE_HEIGHT_PX = 392;
 export const MIN_TIMELINE_HEIGHT_PX = 160;
 export const MAX_TIMELINE_HEIGHT_PX = 560;
-
-/**
- * What a `loadedmetadata` event should write, or `null` for "write nothing".
- *
- * Exported because it is the only part of this path a test can reach: the event
- * arrives through Preview -> PreviewCanvas -> VirtualPreview and a real <video>,
- * none of which jsdom fires. Keeping the decision here and the queueing in the
- * component means the two guards below are testable without standing all four up.
- *
- * `originatingProjectId` is the project that was open when the event fired. It
- * matters because the write is queued: by the time this runs the user may have
- * switched, and `knownSec` came off the OLD video, so applying it to the new
- * project is simply a wrong number. `saveDocument`'s epoch check cannot catch
- * that — the write is issued after the switch rather than across it.
- */
-export function documentAfterProbedDuration(
-	doc: AxcutDocument | null,
-	assetId: string,
-	knownSec: number,
-	originatingProjectId: string | undefined,
-): AxcutDocument | null {
-	if (!doc || doc.assets.length === 0) return null;
-	if (doc.project.id !== originatingProjectId) return null;
-	if (doc.timeline.clips.length === 0) {
-		// ponytail: replaceTimeline derives clip length from asset.durationSec, which
-		// import never populates — without this the first auto-created clip silently
-		// comes out empty (normalizeIntervals clamps against a 0 duration, dropping it).
-		const primaryAssetId = doc.project.primaryAssetId ?? doc.assets[0]?.id;
-		// Only the asset that actually fired. `replaceTimeline` pins every clip it
-		// builds to the primary asset, and the seed sizes that clip from `knownSec` —
-		// so seeding on an event from any OTHER asset writes one video's length under
-		// another's id. Not a lost seed: the primary's own event does its own seeding.
-		if (!primaryAssetId || primaryAssetId !== assetId) return null;
-		const docWithDuration: AxcutDocument = {
-			...doc,
-			assets: doc.assets.map((a) =>
-				a.id === primaryAssetId ? { ...a, durationSec: knownSec } : a,
-			),
-		};
-		return replaceTimelineOp(
-			docWithDuration,
-			[{ startSec: 0, endSec: knownSec }],
-			"Auto-created full-duration clip",
-		);
-	}
-	// The pure document layer patches only the clips of THIS asset that are still
-	// waiting for a real length (the pre-probe placeholder, or the extent-less clip a
-	// legacy v2 import mints), shifts what follows, and brings the modifiers along —
-	// anchoring the ones migration had to leave unanchored. It returns the document
-	// untouched when nothing is waiting, which is this function's "write nothing".
-	const next = applyProbedDuration(doc, assetId, knownSec);
-	return next === doc ? null : next;
-}
 
 export function NewEditorShell() {
 	const te = useScopedT("editor");

--- a/src/components/ai-edition/NewEditorShell.tsx
+++ b/src/components/ai-edition/NewEditorShell.tsx
@@ -154,7 +154,9 @@ export function documentAfterProbedDuration(
 		if (!primaryAssetId || primaryAssetId !== assetId) return null;
 		const docWithDuration: AxcutDocument = {
 			...doc,
-			assets: doc.assets.map((a) => (a.id === primaryAssetId ? { ...a, durationSec: knownSec } : a)),
+			assets: doc.assets.map((a) =>
+				a.id === primaryAssetId ? { ...a, durationSec: knownSec } : a,
+			),
 		};
 		return replaceTimelineOp(
 			docWithDuration,
@@ -497,7 +499,12 @@ export function NewEditorShell() {
 			// from it lands after theirs and takes their edit with it.
 			void enqueueTimelineWrite(async () => {
 				const state = useProjectStore.getState();
-				const next = documentAfterProbedDuration(state.document, assetId, known, originatingProjectId);
+				const next = documentAfterProbedDuration(
+					state.document,
+					assetId,
+					known,
+					originatingProjectId,
+				);
 				if (!next) return;
 				// `history: false`: this is the probed duration being folded into the
 				// document on load, not something the user did — an undo landing on it would

--- a/src/components/ai-edition/NewEditorShell.tsx
+++ b/src/components/ai-edition/NewEditorShell.tsx
@@ -437,16 +437,30 @@ export function NewEditorShell() {
 			// returns the PRE-edit document while a user's save is still in flight (the
 			// store is only written once the bridge answers), and the full snapshot built
 			// from it lands after theirs and takes their edit with it.
+			// Bound to the project that was open when the event fired. Queueing puts real
+			// time between the two, and `known` came off THAT video: applied to a project
+			// the user switched to meanwhile it is simply a wrong number, and
+			// `saveDocument`'s epoch check cannot catch it because the write is issued
+			// after the switch, not across it.
+			const originatingProjectId = useProjectStore.getState().document?.project.id;
 			void enqueueTimelineWrite(async () => {
 				const state = useProjectStore.getState();
 				const doc = state.document;
 				if (!doc || doc.assets.length === 0) return;
+				if (doc.project.id !== originatingProjectId) return;
 				if (doc.timeline.clips.length === 0) {
 					// ponytail: replaceTimeline derives clip length from
 					// asset.durationSec, which import never populates — without this
 					// patch the first auto-created clip silently comes out empty
 					// (normalizeIntervals clamps against a 0 duration and drops it).
 					const primaryAssetId = doc.project.primaryAssetId ?? doc.assets[0]?.id;
+					// Only the asset that actually fired this event. The seed stamps `known`
+					// on the primary asset and sizes the whole clip from it, so on a project
+					// whose primary is some OTHER asset that is one video's length written as
+					// another's -- a full-duration clip at the wrong length. The sibling
+					// branch never had this hole: `applyProbedDuration` is handed `assetId`
+					// and returns the document untouched when it does not hold it.
+					if (primaryAssetId !== assetId) return;
 					const docWithDuration = primaryAssetId
 						? {
 								...doc,

--- a/src/components/ai-edition/NewEditorShell.tsx
+++ b/src/components/ai-edition/NewEditorShell.tsx
@@ -1606,6 +1606,10 @@ export function NewEditorShell() {
 									hasProject={hasProject}
 									hasAsset={hasAsset}
 									videoSources={videoSources}
+									// While the timeline is empty the preview mounts this asset rather
+									// than whichever one sorts first, so the clip `handleLoadedMetadata`
+									// seeds comes from the video it is sized against.
+									primaryAssetId={document?.project.primaryAssetId}
 									// Imported audio tracks (issue #350). `videoSources` already
 									// resolves a URL for every asset (audio included), so it doubles as
 									// the audio source list; VirtualPreview looks each track up by assetId.

--- a/src/components/ai-edition/NewEditorShell.tsx
+++ b/src/components/ai-edition/NewEditorShell.tsx
@@ -25,7 +25,12 @@ import {
 	setDocumentWordText,
 } from "@/lib/ai-edition/document/transcript";
 import { isModalOpen } from "@/lib/ai-edition/modalGuard";
-import { type AxcutAudioTrack, type AxcutClip, documentSchema } from "@/lib/ai-edition/schema";
+import {
+	type AxcutAudioTrack,
+	type AxcutClip,
+	type AxcutDocument,
+	documentSchema,
+} from "@/lib/ai-edition/schema";
 import { useProjectStore } from "@/lib/ai-edition/store/projectStore";
 import {
 	useAssetTranscriptions,
@@ -114,6 +119,57 @@ function NativePlaybackSync({
 export const DEFAULT_TIMELINE_HEIGHT_PX = 392;
 export const MIN_TIMELINE_HEIGHT_PX = 160;
 export const MAX_TIMELINE_HEIGHT_PX = 560;
+
+/**
+ * What a `loadedmetadata` event should write, or `null` for "write nothing".
+ *
+ * Exported because it is the only part of this path a test can reach: the event
+ * arrives through Preview -> PreviewCanvas -> VirtualPreview and a real <video>,
+ * none of which jsdom fires. Keeping the decision here and the queueing in the
+ * component means the two guards below are testable without standing all four up.
+ *
+ * `originatingProjectId` is the project that was open when the event fired. It
+ * matters because the write is queued: by the time this runs the user may have
+ * switched, and `knownSec` came off the OLD video, so applying it to the new
+ * project is simply a wrong number. `saveDocument`'s epoch check cannot catch
+ * that — the write is issued after the switch rather than across it.
+ */
+export function documentAfterProbedDuration(
+	doc: AxcutDocument | null,
+	assetId: string,
+	knownSec: number,
+	originatingProjectId: string | undefined,
+): AxcutDocument | null {
+	if (!doc || doc.assets.length === 0) return null;
+	if (doc.project.id !== originatingProjectId) return null;
+	if (doc.timeline.clips.length === 0) {
+		// ponytail: replaceTimeline derives clip length from asset.durationSec, which
+		// import never populates — without this the first auto-created clip silently
+		// comes out empty (normalizeIntervals clamps against a 0 duration, dropping it).
+		const primaryAssetId = doc.project.primaryAssetId ?? doc.assets[0]?.id;
+		// Only the asset that actually fired. `replaceTimeline` pins every clip it
+		// builds to the primary asset, and the seed sizes that clip from `knownSec` —
+		// so seeding on an event from any OTHER asset writes one video's length under
+		// another's id. Not a lost seed: the primary's own event does its own seeding.
+		if (!primaryAssetId || primaryAssetId !== assetId) return null;
+		const docWithDuration: AxcutDocument = {
+			...doc,
+			assets: doc.assets.map((a) => (a.id === primaryAssetId ? { ...a, durationSec: knownSec } : a)),
+		};
+		return replaceTimelineOp(
+			docWithDuration,
+			[{ startSec: 0, endSec: knownSec }],
+			"Auto-created full-duration clip",
+		);
+	}
+	// The pure document layer patches only the clips of THIS asset that are still
+	// waiting for a real length (the pre-probe placeholder, or the extent-less clip a
+	// legacy v2 import mints), shifts what follows, and brings the modifiers along —
+	// anchoring the ones migration had to leave unanchored. It returns the document
+	// untouched when nothing is waiting, which is this function's "write nothing".
+	const next = applyProbedDuration(doc, assetId, knownSec);
+	return next === doc ? null : next;
+}
 
 export function NewEditorShell() {
 	const te = useScopedT("editor");
@@ -426,10 +482,12 @@ export function NewEditorShell() {
 			// ponytail: WebM recordings from MediaRecorder report NaN/Infinity
 			// until the main-process EBML fix lands. Fall back to a 60s seed if
 			// duration is unknown so the timeline never gets stuck on an empty
-			// placeholder. All store reads go through getState() to avoid
-			// stale-closure bugs.
+			// placeholder.
 			const known = Number.isFinite(durationSec) && durationSec > 0 ? durationSec : 60;
 			setSourceDuration(known);
+			// Read before queueing: this is the project the event belongs to. What the
+			// decision does with it is `documentAfterProbedDuration`'s business.
+			const originatingProjectId = useProjectStore.getState().document?.project.id;
 			// On the shared write queue, and reading the document inside it. Folding a
 			// probed duration in is a read-modify-write of the whole document, which is
 			// what `useSequentialTimelineOps` exists for -- its header says anything that
@@ -437,63 +495,18 @@ export function NewEditorShell() {
 			// returns the PRE-edit document while a user's save is still in flight (the
 			// store is only written once the bridge answers), and the full snapshot built
 			// from it lands after theirs and takes their edit with it.
-			// Bound to the project that was open when the event fired. Queueing puts real
-			// time between the two, and `known` came off THAT video: applied to a project
-			// the user switched to meanwhile it is simply a wrong number, and
-			// `saveDocument`'s epoch check cannot catch it because the write is issued
-			// after the switch, not across it.
-			const originatingProjectId = useProjectStore.getState().document?.project.id;
 			void enqueueTimelineWrite(async () => {
 				const state = useProjectStore.getState();
-				const doc = state.document;
-				if (!doc || doc.assets.length === 0) return;
-				if (doc.project.id !== originatingProjectId) return;
-				if (doc.timeline.clips.length === 0) {
-					// ponytail: replaceTimeline derives clip length from
-					// asset.durationSec, which import never populates — without this
-					// patch the first auto-created clip silently comes out empty
-					// (normalizeIntervals clamps against a 0 duration and drops it).
-					const primaryAssetId = doc.project.primaryAssetId ?? doc.assets[0]?.id;
-					// Only the asset that actually fired this event. The seed stamps `known`
-					// on the primary asset and sizes the whole clip from it, so on a project
-					// whose primary is some OTHER asset that is one video's length written as
-					// another's -- a full-duration clip at the wrong length. The sibling
-					// branch never had this hole: `applyProbedDuration` is handed `assetId`
-					// and returns the document untouched when it does not hold it.
-					if (primaryAssetId !== assetId) return;
-					const docWithDuration = primaryAssetId
-						? {
-								...doc,
-								assets: doc.assets.map((a) =>
-									a.id === primaryAssetId ? { ...a, durationSec: known } : a,
-								),
-							}
-						: doc;
-					const next = replaceTimelineOp(
-						docWithDuration,
-						[{ startSec: 0, endSec: known }],
-						"Auto-created full-duration clip",
-					);
-					// `history: false` for both writes in this callback: they are the probed
-					// duration being folded into the document on load, not something the user
-					// did — an undo landing on one of them would empty their timeline.
-					//
-					// Awaited, not `void`ed: the queue only serialises what it can see finish,
-					// so a fire-and-forget write here would let the next queued edit read the
-					// document this one has not committed yet.
-					await state.saveDocument(next, { history: false });
-					return;
-				}
-				// Hand the probed duration to the pure document layer: it patches only the
-				// clips of THIS asset that are still waiting for a real length (the
-				// pre-probe placeholder, or the extent-less clip a legacy v2 import mints),
-				// shifts what follows, and brings the modifiers along — anchoring the ones
-				// migration had to leave unanchored. Returns the document untouched when
-				// nothing is waiting, so there is nothing to guard here.
-				const next = applyProbedDuration(doc, assetId, known);
-				if (next !== doc) {
-					await state.saveDocument(next, { history: false });
-				}
+				const next = documentAfterProbedDuration(state.document, assetId, known, originatingProjectId);
+				if (!next) return;
+				// `history: false`: this is the probed duration being folded into the
+				// document on load, not something the user did — an undo landing on it would
+				// empty their timeline.
+				//
+				// Awaited, not `void`ed: the queue only serialises what it can see finish, so
+				// a fire-and-forget write would let the next queued edit read a document this
+				// one has not committed yet.
+				await state.saveDocument(next, { history: false });
 			});
 		},
 		[setSourceDuration, enqueueTimelineWrite],

--- a/src/components/ai-edition/NewEditorShell.tsx
+++ b/src/components/ai-edition/NewEditorShell.tsx
@@ -429,47 +429,60 @@ export function NewEditorShell() {
 			// placeholder. All store reads go through getState() to avoid
 			// stale-closure bugs.
 			const known = Number.isFinite(durationSec) && durationSec > 0 ? durationSec : 60;
-			const state = useProjectStore.getState();
 			setSourceDuration(known);
-			const doc = state.document;
-			if (!doc || doc.assets.length === 0) return;
-			if (doc.timeline.clips.length === 0) {
-				// ponytail: replaceTimeline derives clip length from
-				// asset.durationSec, which import never populates — without this
-				// patch the first auto-created clip silently comes out empty
-				// (normalizeIntervals clamps against a 0 duration and drops it).
-				const primaryAssetId = doc.project.primaryAssetId ?? doc.assets[0]?.id;
-				const docWithDuration = primaryAssetId
-					? {
-							...doc,
-							assets: doc.assets.map((a) =>
-								a.id === primaryAssetId ? { ...a, durationSec: known } : a,
-							),
-						}
-					: doc;
-				const next = replaceTimelineOp(
-					docWithDuration,
-					[{ startSec: 0, endSec: known }],
-					"Auto-created full-duration clip",
-				);
-				// `history: false` for both writes in this callback: they are the probed
-				// duration being folded into the document on load, not something the user
-				// did — an undo landing on one of them would empty their timeline.
-				void state.saveDocument(next, { history: false });
-				return;
-			}
-			// Hand the probed duration to the pure document layer: it patches only the
-			// clips of THIS asset that are still waiting for a real length (the
-			// pre-probe placeholder, or the extent-less clip a legacy v2 import mints),
-			// shifts what follows, and brings the modifiers along — anchoring the ones
-			// migration had to leave unanchored. Returns the document untouched when
-			// nothing is waiting, so there is nothing to guard here.
-			const next = applyProbedDuration(doc, assetId, known);
-			if (next !== doc) {
-				void state.saveDocument(next, { history: false });
-			}
+			// On the shared write queue, and reading the document inside it. Folding a
+			// probed duration in is a read-modify-write of the whole document, which is
+			// what `useSequentialTimelineOps` exists for -- its header says anything that
+			// reads the doc and saves it back belongs there. Off the queue, `getState()`
+			// returns the PRE-edit document while a user's save is still in flight (the
+			// store is only written once the bridge answers), and the full snapshot built
+			// from it lands after theirs and takes their edit with it.
+			void enqueueTimelineWrite(async () => {
+				const state = useProjectStore.getState();
+				const doc = state.document;
+				if (!doc || doc.assets.length === 0) return;
+				if (doc.timeline.clips.length === 0) {
+					// ponytail: replaceTimeline derives clip length from
+					// asset.durationSec, which import never populates — without this
+					// patch the first auto-created clip silently comes out empty
+					// (normalizeIntervals clamps against a 0 duration and drops it).
+					const primaryAssetId = doc.project.primaryAssetId ?? doc.assets[0]?.id;
+					const docWithDuration = primaryAssetId
+						? {
+								...doc,
+								assets: doc.assets.map((a) =>
+									a.id === primaryAssetId ? { ...a, durationSec: known } : a,
+								),
+							}
+						: doc;
+					const next = replaceTimelineOp(
+						docWithDuration,
+						[{ startSec: 0, endSec: known }],
+						"Auto-created full-duration clip",
+					);
+					// `history: false` for both writes in this callback: they are the probed
+					// duration being folded into the document on load, not something the user
+					// did — an undo landing on one of them would empty their timeline.
+					//
+					// Awaited, not `void`ed: the queue only serialises what it can see finish,
+					// so a fire-and-forget write here would let the next queued edit read the
+					// document this one has not committed yet.
+					await state.saveDocument(next, { history: false });
+					return;
+				}
+				// Hand the probed duration to the pure document layer: it patches only the
+				// clips of THIS asset that are still waiting for a real length (the
+				// pre-probe placeholder, or the extent-less clip a legacy v2 import mints),
+				// shifts what follows, and brings the modifiers along — anchoring the ones
+				// migration had to leave unanchored. Returns the document untouched when
+				// nothing is waiting, so there is nothing to guard here.
+				const next = applyProbedDuration(doc, assetId, known);
+				if (next !== doc) {
+					await state.saveDocument(next, { history: false });
+				}
+			});
 		},
-		[setSourceDuration],
+		[setSourceDuration, enqueueTimelineWrite],
 	);
 
 	const handleSeek = useCallback(

--- a/src/components/ai-edition/Preview.test.tsx
+++ b/src/components/ai-edition/Preview.test.tsx
@@ -75,6 +75,7 @@ function source(id: string): VideoSource {
 function previewProps(props: {
 	videoSources: VideoSource[];
 	clips: AxcutClip[];
+	primaryAssetId?: string;
 	hasAsset?: boolean;
 	hasProject?: boolean;
 }) {
@@ -84,6 +85,7 @@ function previewProps(props: {
 				hasProject={props.hasProject ?? true}
 				hasAsset={props.hasAsset ?? true}
 				videoSources={props.videoSources}
+				primaryAssetId={props.primaryAssetId}
 				clips={props.clips}
 				seekTarget={null}
 				onTimeChange={vi.fn()}
@@ -157,10 +159,46 @@ describe("Preview follows the timeline, not the asset list", () => {
 	// The bootstrap path: `handleLoadedMetadata` mints the very first clip from
 	// the <video>'s own metadata, so a just-imported asset has to be mounted
 	// while nothing references it yet.
-	it("falls back to every asset while the timeline is empty", () => {
+	it("mounts the asset while the timeline is empty", () => {
 		renderPreview({ videoSources: [source("fresh_import")], clips: [] });
 
 		expect(canvas()).toHaveAttribute("data-sources", "fresh_import");
+	});
+
+	// A project whose first import was audio: audio never claims the empty primary
+	// slot, so `assets[0]` is the audio track and the primary is the video added
+	// after it. Only one source is mounted at a time and nothing on an empty
+	// timeline moves that index off 0 — so mounting the audio would hand
+	// `handleLoadedMetadata` an event for an asset it refuses to seed from, and the
+	// timeline would never get its first clip at all.
+	it("mounts the primary asset, not the one that sorts first", () => {
+		renderPreview({
+			videoSources: [source("bgm"), source("screen")],
+			primaryAssetId: "screen",
+			clips: [],
+		});
+
+		expect(canvas()).toHaveAttribute("data-sources", "screen");
+	});
+
+	// No primary recorded (a v1.7 project that predates the field): fall back to
+	// `assets[0]`, which is what the seed itself falls back to.
+	it("mounts the first asset when the project has no primary", () => {
+		renderPreview({ videoSources: [source("first"), source("second")], clips: [] });
+
+		expect(canvas()).toHaveAttribute("data-sources", "first");
+	});
+
+	// A primary id pointing at an asset with no source would otherwise mount
+	// nothing and collapse the stage to the empty state.
+	it("keeps every asset when the primary has no source", () => {
+		renderPreview({
+			videoSources: [source("a"), source("b")],
+			primaryAssetId: "gone",
+			clips: [],
+		});
+
+		expect(canvas()).toHaveAttribute("data-sources", "a,b");
 	});
 
 	// A clip landing on a healthy asset takes over the preview regardless of what

--- a/src/components/ai-edition/Preview.tsx
+++ b/src/components/ai-edition/Preview.tsx
@@ -23,6 +23,9 @@ interface PreviewProps {
 	hasProject: boolean;
 	hasAsset: boolean;
 	videoSources: VideoSource[];
+	/** `document.project.primaryAssetId`, when the project has one. Read only while
+	 *  the timeline is empty — see `previewSources`. */
+	primaryAssetId?: string;
 	/** Imported audio tracks and the (unfiltered) asset URLs they resolve to
 	 *  (issue #350). Passed straight through to VirtualPreview — unlike the video
 	 *  `previewSources` below, these are NOT narrowed to clip-referenced assets,
@@ -61,6 +64,7 @@ export function Preview({
 	hasProject,
 	hasAsset,
 	videoSources,
+	primaryAssetId,
 	audioTracks = [],
 	audioSources = [],
 	clips,
@@ -116,8 +120,23 @@ export function Preview({
 			const source = videoSources.find((s) => s.id === clip.assetId);
 			if (source) referenced.push(source);
 		}
-		return referenced.length > 0 ? referenced : videoSources;
-	}, [clips, videoSources]);
+		if (referenced.length > 0) return referenced;
+		// Empty timeline: mount the asset the seed is minted FOR, not whichever asset
+		// happens to sort first. `handleLoadedMetadata` sizes that first clip against
+		// `primaryAssetId ?? assets[0]` and ignores an event from any other asset, and
+		// only ONE source is ever mounted (`videoSources[sourceIndex]` in
+		// VirtualPreview, index 0 while nothing on the timeline moves it) — so mounting
+		// a non-primary asset here fires an event nothing acts on and the timeline
+		// stays empty for good. A project whose first import was audio is exactly that
+		// case: audio never claims the empty primary slot (document-service.addAsset),
+		// so `assets[0]` is the audio and the primary is the video added after it.
+		// `videoSources` mirrors `document.assets` in order, so index 0 is the same
+		// `assets[0]` the seed itself falls back to.
+		const primary = primaryAssetId
+			? videoSources.find((source) => source.id === primaryAssetId)
+			: videoSources[0];
+		return primary ? [primary] : videoSources;
+	}, [clips, videoSources, primaryAssetId]);
 
 	// ponytail: a media failure used to fall through to `EditorEmptyState`, and
 	// that is issue #395: ONE `error` event on the hidden <video> — including the

--- a/src/components/ai-edition/v4/V4Timeline.tsx
+++ b/src/components/ai-edition/v4/V4Timeline.tsx
@@ -1491,27 +1491,38 @@ export function V4Timeline({
 		}
 		setAutoBusy(true);
 		try {
-			// Read once, up front: every clip reserves against the zooms the document
-			// ALREADY holds, and two clips can never contest the same stretch of ruler, so
-			// nothing here depends on the order the assets are visited — which is what lets
-			// their telemetry be fetched concurrently rather than one IPC round trip after
-			// another. `Promise.all` preserves input order, so the suggestions come out in
-			// the same sequence a loop would have produced.
-			const existingRegions = tl.zoomRegions.map((z) => ({ startMs: z.startMs, endMs: z.endMs }));
+			// Telemetry first, and nothing derived from the document until it is back.
+			// `Promise.all` preserves input order, so the suggestions still come out in the
+			// same sequence a loop would have produced.
 			const perSource = await Promise.all(
-				sources.map(async (source) => {
-					const telemetry =
-						(await nativeBridgeClient.cursor.getTelemetry(fromFileUrl(source.src))) ?? [];
-					return buildAutoZoomSuggestionsForClips({
-						cursorTelemetry: telemetry,
-						assetId: source.id,
-						clips,
-						existingRegions,
-						defaultDurationMs: 2000,
-					});
+				sources.map(async (source) => ({
+					assetId: source.id,
+					telemetry: (await nativeBridgeClient.cursor.getTelemetry(fromFileUrl(source.src))) ?? [],
+				})),
+			);
+			// Read AFTER the round trip, not before it. `addZoomsBulk` anchors what comes out
+			// of here against the document IT reads at write time, so building the spans from
+			// the pre-await `clips` puts the two halves on different rulers: a trim landing
+			// during the wait moves every clip, and a span that no longer falls in one is
+			// stored unanchored. A stale `zoomRegions` is the same shape one step over — a
+			// zoom the user added during the wait would not be reserved, and the region
+			// minted here would sit on top of it.
+			//
+			// Still read ONCE for every asset rather than per asset: each clip reserves
+			// against the zooms the document already holds, and two clips can never contest
+			// the same stretch of ruler, so nothing depends on the order they are visited.
+			const doc = useProjectStore.getState().document;
+			if (!doc) return;
+			const existingRegions = doc.zoomRanges.map((z) => ({ startMs: z.startMs, endMs: z.endMs }));
+			const suggestions: AutoZoomSuggestion[] = perSource.flatMap(({ assetId, telemetry }) =>
+				buildAutoZoomSuggestionsForClips({
+					cursorTelemetry: telemetry,
+					assetId,
+					clips: doc.timeline.clips,
+					existingRegions,
+					defaultDurationMs: 2000,
 				}),
 			);
-			const suggestions: AutoZoomSuggestion[] = perSource.flat();
 			if (suggestions.length === 0) {
 				toast.info(t("toolbar.noAutoZoomMoments"), {
 					description: t("toolbar.noAutoZoomMomentsDescription"),

--- a/src/lib/ai-edition/document/probedDuration.test.ts
+++ b/src/lib/ai-edition/document/probedDuration.test.ts
@@ -1,36 +1,15 @@
 // The decision a `loadedmetadata` event makes, on its own.
 //
 // The event itself arrives through Preview -> PreviewCanvas -> VirtualPreview and a
-// real <video>, which no test environment here can decode, so the component cannot
-// be driven end to end. `documentAfterProbedDuration` is the part that decides what gets
-// written, and both guards below live in it: the queue the shell puts this write on
+// real <video>, which no test environment here can decode, so the component cannot be
+// driven end to end. `documentAfterProbedDuration` is the part that decides what gets
+// written, and every guard below lives in it: the queue the shell puts this write on
 // is what makes them necessary, because it puts real time between the event and the
 // write. The queue's own serialization is covered by useSequentialTimelineOps.test.
-import { describe, expect, it, vi } from "vitest";
-
-vi.mock("@/contexts/ShortcutsContext", async () => {
-	const { DEFAULT_SHORTCUTS } = await import("@/lib/shortcuts");
-	return {
-		useShortcuts: () => ({
-			shortcuts: DEFAULT_SHORTCUTS,
-			isMac: false,
-			isConfigOpen: false,
-			openConfig: vi.fn(),
-			closeConfig: vi.fn(),
-			setShortcuts: vi.fn(),
-			persistShortcuts: () => Promise.resolve(true),
-		}),
-	};
-});
-
-vi.mock("@/contexts/I18nContext", () => ({
-	useI18n: () => ({ locale: "en", setLocale: vi.fn() }),
-	useScopedT: () => (key: string) => key,
-}));
-
-import { migrateProjectDataToAxcutDocument } from "@/lib/ai-edition/document/migrate";
+import { describe, expect, it } from "vitest";
 import { type AxcutDocument, createEmptyDocument, documentSchema } from "@/lib/ai-edition/schema";
-import { documentAfterProbedDuration } from "./NewEditorShell";
+import { migrateProjectDataToAxcutDocument } from "./migrate";
+import { documentAfterProbedDuration } from "./timeline";
 
 const PROJECT = "proj_a";
 
@@ -121,6 +100,22 @@ describe("documentAfterProbedDuration", () => {
 		expect(
 			documentAfterProbedDuration(settled as AxcutDocument, assetId, 30, doc.project.id),
 		).toBeNull();
+	});
+
+	// Empty is not the same as unseeded — the user can delete their only clip — and
+	// `knownSec` is 60 whenever the <video> reports a non-finite duration. Overwriting
+	// here traded a real length for the fallback under `history: false`.
+	it("keeps a length the asset already carries, and sizes the seed against it", () => {
+		const doc = emptyTimeline("asset_1", ["asset_1"]);
+		const measured: AxcutDocument = {
+			...doc,
+			assets: doc.assets.map((a) => ({ ...a, durationSec: 26.517 })),
+		};
+
+		const next = documentAfterProbedDuration(measured, "asset_1", 60, PROJECT);
+
+		expect(next?.assets[0].durationSec).toBe(26.517);
+		expect(next?.timeline.clips[0].timelineEndSec).toBeCloseTo(26.517, 3);
 	});
 
 	it("writes nothing without a document or without assets", () => {

--- a/src/lib/ai-edition/document/probedDuration.test.ts
+++ b/src/lib/ai-edition/document/probedDuration.test.ts
@@ -48,6 +48,29 @@ function legacyWithClip(): AxcutDocument {
 }
 
 describe("documentAfterProbedDuration", () => {
+	it("resolves a missing primary asset before seeding the fallback", () => {
+		const doc = emptyTimeline("deleted_asset", ["asset_1", "asset_2"]);
+		const next = documentAfterProbedDuration(doc, "asset_1", 30, PROJECT);
+		expect(next?.project.primaryAssetId).toBe("asset_1");
+		expect(next?.timeline.clips).toHaveLength(1);
+		expect(next?.timeline.clips[0]).toMatchObject({
+			assetId: "asset_1",
+			sourceStartSec: 0,
+			sourceEndSec: 30,
+		});
+		expect(next?.assets[1].durationSec).toBeUndefined();
+		expect(doc.project.primaryAssetId).toBe("deleted_asset");
+		expect(documentAfterProbedDuration(doc, "asset_2", 30, PROJECT)).toBeNull();
+	});
+
+	it("keeps a valid primary asset even when it is not first", () => {
+		const doc = emptyTimeline("asset_2", ["asset_1", "asset_2"]);
+		expect(documentAfterProbedDuration(doc, "asset_1", 30, PROJECT)).toBeNull();
+		const next = documentAfterProbedDuration(doc, "asset_2", 30, PROJECT);
+		expect(next?.project.primaryAssetId).toBe("asset_2");
+		expect(next?.timeline.clips[0].assetId).toBe("asset_2");
+	});
+
 	it("seeds a full-duration clip when the primary asset reports its length", () => {
 		const doc = emptyTimeline("asset_1", ["asset_1"]);
 

--- a/src/lib/ai-edition/document/timeline.ts
+++ b/src/lib/ai-edition/document/timeline.ts
@@ -587,7 +587,9 @@ export function documentAfterProbedDuration(
 		// ponytail: replaceTimeline derives clip length from asset.durationSec, which
 		// import never populates — without this the first auto-created clip silently
 		// comes out empty (normalizeIntervals clamps against a 0 duration, dropping it).
-		const primaryAssetId = doc.project.primaryAssetId ?? doc.assets[0]?.id;
+		const primaryAsset =
+			doc.assets.find((asset) => asset.id === doc.project.primaryAssetId) ?? doc.assets[0];
+		const primaryAssetId = primaryAsset.id;
 		// Only the asset that actually fired. `replaceTimeline` pins every clip it
 		// builds to the primary asset, and the seed sizes that clip from `knownSec` —
 		// so seeding on an event from any OTHER asset writes one video's length under
@@ -595,6 +597,7 @@ export function documentAfterProbedDuration(
 		if (!primaryAssetId || primaryAssetId !== assetId) return null;
 		const docWithDuration: AxcutDocument = {
 			...doc,
+			project: { ...doc.project, primaryAssetId },
 			// Only a length that was never measured, which is `applyProbedDuration`'s rule
 			// above widened to cover a stored 0 — the seed exists to give `replaceTimeline` a
 			// duration to clamp against, and a 0 defeats that exactly as a missing one does.

--- a/src/lib/ai-edition/document/timeline.ts
+++ b/src/lib/ai-edition/document/timeline.ts
@@ -562,6 +562,70 @@ export function applyProbedDuration(
 	);
 }
 
+/**
+ * What a `loadedmetadata` event should write, or `null` for "write nothing".
+ *
+ * Lives here rather than in the component that fires it because it is pure document
+ * logic: `applyProbedDuration` above and `replaceTimeline` below are the whole body.
+ *
+ * `originatingProjectId` is the project that was open when the event fired. It matters
+ * because the write is queued (`NewEditorShell.handleLoadedMetadata` puts it on the
+ * shared timeline write queue): by the time this runs the user may have switched, and
+ * `knownSec` came off the OLD video, so applying it to the new project is simply a wrong
+ * number. `saveDocument`'s epoch check cannot catch that — the write is issued after the
+ * switch rather than across it.
+ */
+export function documentAfterProbedDuration(
+	doc: AxcutDocument | null,
+	assetId: string,
+	knownSec: number,
+	originatingProjectId: string | undefined,
+): AxcutDocument | null {
+	if (!doc || doc.assets.length === 0) return null;
+	if (doc.project.id !== originatingProjectId) return null;
+	if (doc.timeline.clips.length === 0) {
+		// ponytail: replaceTimeline derives clip length from asset.durationSec, which
+		// import never populates — without this the first auto-created clip silently
+		// comes out empty (normalizeIntervals clamps against a 0 duration, dropping it).
+		const primaryAssetId = doc.project.primaryAssetId ?? doc.assets[0]?.id;
+		// Only the asset that actually fired. `replaceTimeline` pins every clip it
+		// builds to the primary asset, and the seed sizes that clip from `knownSec` —
+		// so seeding on an event from any OTHER asset writes one video's length under
+		// another's id. Not a lost seed: the primary's own event does its own seeding.
+		if (!primaryAssetId || primaryAssetId !== assetId) return null;
+		const docWithDuration: AxcutDocument = {
+			...doc,
+			// Only a length that was never measured, which is `applyProbedDuration`'s rule
+			// above widened to cover a stored 0 — the seed exists to give `replaceTimeline` a
+			// duration to clamp against, and a 0 defeats that exactly as a missing one does.
+			//
+			// An empty timeline is NOT proof the asset is unmeasured: the user can delete
+			// their only clip. And `knownSec` is the 60 s fallback whenever a MediaRecorder
+			// WebM reports a non-finite duration, so writing it unconditionally traded a real
+			// 26.517 for 60 under `history: false`, with no undo to get it back. Left alone,
+			// the recorded length is what the clip below is clamped against, which is the
+			// right number either way.
+			assets: doc.assets.map((a) =>
+				a.id === primaryAssetId && !(a.durationSec && a.durationSec > 0)
+					? { ...a, durationSec: knownSec }
+					: a,
+			),
+		};
+		return replaceTimeline(
+			docWithDuration,
+			[{ startSec: 0, endSec: knownSec }],
+			"Auto-created full-duration clip",
+		);
+	}
+	// The pure document layer patches only the clips of THIS asset that are still
+	// waiting for a real length (the pre-probe placeholder, or the extent-less clip a
+	// legacy v2 import mints), shifts what follows, and brings the modifiers along —
+	// anchoring the ones migration had to leave unanchored. It returns the document
+	// untouched when nothing is waiting, which is this function's "write nothing".
+	const next = applyProbedDuration(doc, assetId, knownSec);
+	return next === doc ? null : next;
+}
+
 /** One interval of a rebuilt timeline, plus the identity it inherits. `keepClipId`
  *  is set when the CALLER'S raw interval is (to the epsilon) an existing clip's own
  *  source window: the same stretch of media, so the same clip. */

--- a/src/lib/ai-edition/store/documentWriteAudit.test.ts
+++ b/src/lib/ai-edition/store/documentWriteAudit.test.ts
@@ -126,7 +126,6 @@ const DECLARED: WritePath[] = [
 	// The probed duration folded into the document when the <video> loads. Twice:
 	// the first clip seed, and the backfill for clips still on a placeholder length.
 	w("src/components/ai-edition/NewEditorShell.tsx", "handleLoadedMetadata", "save", "automatic"),
-	w("src/components/ai-edition/NewEditorShell.tsx", "handleLoadedMetadata", "save", "automatic"),
 	// Renaming the project from the title field.
 	w("src/components/ai-edition/NewEditorShell.tsx", "handleRenameProject", "save", "gesture"),
 	// Ctrl+S / File > Save.

--- a/src/lib/ai-edition/store/useTimeline.test.ts
+++ b/src/lib/ai-edition/store/useTimeline.test.ts
@@ -1596,3 +1596,63 @@ describe("useTimeline audio tracks", () => {
 		expect(probeAudioDurationMock).toHaveBeenCalledTimes(1);
 	});
 });
+
+// The wand (`V4Timeline.runAutoZooms`) captures this callback, awaits a
+// multi-second cursor-telemetry IPC, and only then calls it. Anything the user
+// commits during that wait is in the store but not in the callback's render
+// closure, so reading the closure writes back a snapshot that drops their edit.
+// Its `add*` siblings compute and save in the same tick, which is why this one
+// is the reachable case.
+describe("useTimeline.addZoomsBulk reads the document at write time", () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	beforeEach(() => {
+		useProjectStore.getState().clear();
+		for (const mock of Object.values(bridgeMocks)) mock.mockReset();
+		toastErrorMock.mockReset();
+		bridgeMocks.save.mockImplementation(async (document: AxcutDocument) => ({
+			success: true,
+			document,
+		}));
+		useProjectStore.setState({
+			projectId: "proj_test",
+			document: sampleDoc,
+			revision: 1,
+			status: "ready",
+			error: null,
+		});
+	});
+
+	it("does not write back the document from before the telemetry wait", async () => {
+		const { result } = renderTimeline();
+		// Captured the way the wand captures it: before the wait, not after.
+		const addZoomsBulk = result.current.addZoomsBulk;
+
+		// The user's edit lands while the wand is off fetching telemetry.
+		const edited: AxcutDocument = {
+			...sampleDoc,
+			project: { ...sampleDoc.project, title: "Edited while the wand was busy" },
+		};
+		act(() => {
+			useProjectStore.setState({ document: edited, revision: 2 });
+		});
+
+		let added: number | undefined;
+		await act(async () => {
+			added = await addZoomsBulk([
+				{ span: { start: 1000, end: 2000 }, focus: { cx: 0.5, cy: 0.5 } },
+			]);
+		});
+
+		expect(added).toBe(1);
+		const saved = bridgeMocks.save.mock.calls.at(-1)?.[0] as AxcutDocument;
+		// The zoom was added, and the edit is still there.
+		expect(saved.zoomRanges).toHaveLength(1);
+		expect(saved.project.title).toBe("Edited while the wand was busy");
+		expect(useProjectStore.getState().document?.project.title).toBe(
+			"Edited while the wand was busy",
+		);
+	});
+});

--- a/src/lib/ai-edition/store/useTimeline.test.ts
+++ b/src/lib/ai-edition/store/useTimeline.test.ts
@@ -1655,4 +1655,32 @@ describe("useTimeline.addZoomsBulk reads the document at write time", () => {
 			"Edited while the wand was busy",
 		);
 	});
+
+	// Reading the document fresh is what makes this reachable: the spans were built
+	// from the OLD project's telemetry and its ruler, so writing them into whatever is
+	// loaded now puts one project's zooms in another. `saveDocument`'s epoch check does
+	// not cover it -- the write is issued after the switch, not across it.
+	it("writes nothing when the project changed during the telemetry wait", async () => {
+		const { result } = renderTimeline();
+		const addZoomsBulk = result.current.addZoomsBulk;
+
+		// The user switches projects while the wand is off fetching telemetry.
+		act(() => {
+			useProjectStore.setState({
+				projectId: "proj_switched_to",
+				document: sampleDoc,
+				revision: 2,
+			});
+		});
+
+		let added: number | undefined;
+		await act(async () => {
+			added = await addZoomsBulk([
+				{ span: { start: 1000, end: 2000 }, focus: { cx: 0.5, cy: 0.5 } },
+			]);
+		});
+
+		expect(added).toBe(0);
+		expect(bridgeMocks.save).not.toHaveBeenCalled();
+	});
 });

--- a/src/lib/ai-edition/store/useTimeline.ts
+++ b/src/lib/ai-edition/store/useTimeline.ts
@@ -343,6 +343,13 @@ export function useTimeline() {
 			// reason as `applyClipEdit`, `setTrimEntries` and `insertClipAt`.
 			const doc = useProjectStore.getState().document;
 			if (!doc || suggestions.length === 0) return 0;
+			// The same wait makes the PROJECT stale, and reading the document fresh is what
+			// exposes it: the suggestions were built from the OLD project's telemetry and its
+			// ruler, so applying them to whatever is loaded now writes one project's zooms into
+			// another. `saveDocument`'s epoch check cannot see this one -- the write is issued
+			// after the switch, not across it -- which is the same reason
+			// `documentAfterProbedDuration` carries an `originatingProjectId`.
+			if (useProjectStore.getState().projectId !== projectId) return 0;
 			const anchored = suggestions.flatMap((s) =>
 				anchorRegionsWithDerivedMs(
 					[
@@ -369,7 +376,7 @@ export function useTimeline() {
 			if (!(await saveDocument(next, { history: true }))) return 0;
 			return suggestions.length;
 		},
-		[saveDocument],
+		[projectId, saveDocument],
 	);
 
 	const addTrim = useCallback(

--- a/src/lib/ai-edition/store/useTimeline.ts
+++ b/src/lib/ai-edition/store/useTimeline.ts
@@ -334,7 +334,15 @@ export function useTimeline() {
 	// Returns the count actually added (0 when there's no doc/suggestions).
 	const addZoomsBulk = useCallback(
 		async (suggestions: AutoZoomSuggestion[]) => {
-			if (!document || suggestions.length === 0) return 0;
+			// Read from the store, not off the render closure. Unlike its `add*` siblings,
+			// which compute and save in the same tick, this one is reached from the wand
+			// AFTER a multi-second cursor-telemetry IPC: the closure document is the one
+			// from before that wait, so anything the user committed during it is missing
+			// from the snapshot, and writing the snapshot back drops their edit. Reading
+			// here is also what lets this compose with `useSequentialTimelineOps` -- same
+			// reason as `applyClipEdit`, `setTrimEntries` and `insertClipAt`.
+			const doc = useProjectStore.getState().document;
+			if (!doc || suggestions.length === 0) return 0;
 			const anchored = suggestions.flatMap((s) =>
 				anchorRegionsWithDerivedMs(
 					[
@@ -347,18 +355,21 @@ export function useTimeline() {
 							focusMode: "auto" as const,
 						},
 					],
-					document.timeline.clips,
+					// Anchored against the SAME document the write is built from: anchoring
+					// on the stale clips and saving the fresh document would place regions
+					// against a timeline that no longer exists.
+					doc.timeline.clips,
 					() => createId("zoom"),
 				),
 			);
 			const next: AxcutDocument = {
-				...document,
-				zoomRanges: [...document.zoomRanges, ...anchored] as AxcutDocument["zoomRanges"],
+				...doc,
+				zoomRanges: [...doc.zoomRanges, ...anchored] as AxcutDocument["zoomRanges"],
 			};
 			if (!(await saveDocument(next, { history: true }))) return 0;
 			return suggestions.length;
 		},
-		[document, saveDocument],
+		[saveDocument],
 	);
 
 	const addTrim = useCallback(


### PR DESCRIPTION
## Summary

Two background paths read the document, build a whole-document snapshot and save it, so whatever the user committed in between is dropped.

The window is real because the store is only written once the bridge answers. While a user's save is in flight, `useProjectStore.getState().document` still returns the pre-edit document; a task that reads it and saves a snapshot built from it lands second and takes their edit with it. `saveDocument`'s epoch check does not cover this — `currentWriteEpoch` changes on undo, redo and project switch, not on a concurrent save.

- The `loadedmetadata` probe now folds its duration in on the shared write queue, reading the document inside the task and awaiting the save. `useSequentialTimelineOps` exists for exactly this, and says so: "every timeline edit is a read-modify-write of the whole document ... Anything that reads the doc and saves it back belongs here."
- `addZoomsBulk` now reads the document at write time instead of off the render closure, and anchors the new regions against that same document. Its `add*` siblings compute and save in the same tick; this one is reached from the wand only after a multi-second cursor-telemetry IPC, so its closure is stale by seconds rather than by a render.
- Queueing the probe opens a narrower window of its own, so the event is bound to the project that was open when it fired, and the empty-timeline seed runs only for the asset the seed is actually about — `replaceTimeline` pins every clip it builds to the primary asset, so an event from any other asset would write one video's length under another's id.
- That guard needs the preview to agree with it, so while the timeline is empty the preview now mounts the resolved primary asset instead of falling back to the whole asset list. Only one source is ever mounted (`videoSources[sourceIndex]`, index 0 while no clip moves it), so guarding the seed alone would leave the mounted asset firing an event the seed refuses and the timeline empty for good. The whole-list fallback stays for a primary id that resolves to nothing.

## Related issue

None. Both turned up while reviewing #619, and neither was introduced there, so they are here rather than folded into it.

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [x] Patch
- [ ] Minor
- [ ] Major / breaking change
- [ ] No release note needed

## Desktop impact
- [ ] Windows
- [ ] macOS
- [ ] Linux
- [ ] Installer / packaging
- [x] Not platform-specific

## Screenshots / video

Nothing visible changes on the ordinary path. What changes is which document reaches disk when two writes overlap, and — for a project whose first asset is not its primary — which asset the preview mounts while the timeline is still empty.

## Testing

`addZoomsBulk` has a regression test that captures the callback before the store moves, the way the wand does. Against the old closure read it fails by reproducing the defect: the saved document comes back carrying the pre-edit title, with the user's edit gone.

The probe's decision moved out of the component into an exported `documentAfterProbedDuration` so it could be tested at all — the event reaches the shell through Preview, PreviewCanvas, VirtualPreview and a real `<video>` decoding real media, which no test environment here provides. Both of its guards fail their tests when removed, and the seed, the fold-in and the already-settled cases are covered too.

Collapsing the handler's two `saveDocument` calls into one changed the write topology, which `documentWriteAudit.test.ts` caught until its table was updated.

`npx tsc --noEmit`, `npx tsc -p tsconfig.test.json --noEmit` and `npm run lint` are clean. The full suite passes.

Driven on a real machine as well, because the riskiest edit here is a guard that can suppress the timeline seed — an editor opening with no clip is exactly what that seed exists to prevent. A HUD recording on Windows opened in the editor with the probed length folded in: one clip at 0–26.517 s against an asset reporting 26.516667 s, bound to the primary asset. Auto enhance then wrote four `focusMode: auto` regions onto that same project with the clip and its duration unchanged.

The case the guard needs the preview for was driven too, since it is the one the ordinary recording flow never reaches. A project holding a 5.000 s audio asset first and a 26.516667 s recording as its primary, with an empty timeline, opened against a real `<video>`: with the guard alone the mounted source is the audio and no clip is ever seeded; with the preview change the mounted source is the recording and the seed writes one clip at 0–26.516667 s on it. The ordinary single-video project seeds the same clip either way.

## Scope

This does not give the editor general concurrency control over document writes, and it should not be read as if it did.

`enqueueTimelineWrite` only coordinates writes that go through it, and most callers reach `saveDocument` directly — `handleRenameProject` among them. So two concurrent read-modify-write saves in the same project can still overwrite each other, and nothing here changes that.

Closing that properly means either a shared read-modify-write coordinator every caller goes through, or version-conditional writes at the persistence layer. Two cheaper things do not work and were tried on paper first: a revision check before the bridge call adds nothing, because a save that already landed is visible to the read inside the queued task anyway; and one after the await keeps the store right while leaving the losing document on disk, since the bytes are written by then. Serialising sends inside `saveDocument` does not help either, because the defect is in when each caller read, not in what order they sent.

What this change does is narrow the two paths where the read and the write are separated by a multi-second await, which is where the window is wide enough to lose an edit in ordinary use rather than by interleaving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timeline initialization so the primary video is used when creating the first full-duration clip.
  - Corrected duration updates from loaded media, including legacy clips and existing asset durations.
  - Prevented stale metadata or AI-generated zoom updates from affecting a different project.
  - Preserved edits made while cursor telemetry is being processed.
  - Avoided unnecessary document saves when no timeline changes are needed.
- **Preview**
  - Empty timelines now prefer the recorded primary asset, with safe fallback behavior when it is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->