### PR TITLE
chore: name @Beetix code owner for Linux/Wayland capture

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,8 @@
 * @EtienneLescot
+
+# Linux / Wayland capture — @Beetix
+/electron/native/pipewire-capture/                          @Beetix @EtienneLescot
+/electron/native-bridge/capture/linuxNativeCaptureSession*  @Beetix @EtienneLescot
+/electron/native-bridge/cursor/recording/pipeWire*          @Beetix @EtienneLescot
+/crates/compositor/src/linux_*.rs                           @Beetix @EtienneLescot
+/crates/compositor/src/*_linux.rs                           @Beetix @EtienneLescot


### PR DESCRIPTION
@Beetix has taken the Linux/Wayland capture side. This names him code owner on the paths he already wrote, so reviews there get routed to him automatically.

Paths: `pipewire-capture`, the Linux capture session and PipeWire cursor recording bridges, and the `*_linux.rs` compositor sources.

Both of us are listed on each path so neither is blocked on the other. The `main-protection` ruleset already requires code-owner review, so this takes effect as soon as it lands — and it means Linux PRs no longer need a maintainer bypass to merge, since there is finally a second code owner who can approve them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)