### PR TITLE
fix(rec): the microphone can't be disabled in the Studio Rec tab

### DIFF
--- a/src/components/ai-edition/v4/EditorShellV4.module.css
+++ b/src/components/ai-edition/v4/EditorShellV4.module.css
@@ -950,6 +950,24 @@
 	border-radius: 50%;
 	background: var(--danger);
 }
+/* Mic level lives on the preview (bottom-left), not in the settings row — that
+   keeps the microphone row as compact as the others so its On/Off toggle is
+   always in view (issue #624). */
+.recMicMeter {
+	position: absolute;
+	left: 16px;
+	bottom: 16px;
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 10px;
+	border-radius: 9999px;
+	background: rgba(8, 10, 13, 0.5);
+	backdrop-filter: blur(12px);
+	-webkit-backdrop-filter: blur(12px);
+	border: 1px solid rgba(255, 255, 255, 0.14);
+	color: #fff;
+}
 .recPanel {
 	width: 360px;
 	flex-shrink: 0;
@@ -999,6 +1017,9 @@
 	display: flex;
 	align-items: center;
 	gap: 10px;
+	/* Let the control group shrink within the row so a long device name in the
+	   dropdown can't push the On/Off toggle off the panel edge (issue #624). */
+	min-width: 0;
 }
 .recRowMuted {
 	display: inline-flex;
@@ -1035,6 +1056,11 @@
 .recSelect {
 	height: 32px;
 	max-width: 200px;
+	/* Absorb the row's shrink and truncate a long device name instead of forcing
+	   the row wider than the panel and clipping the toggle. */
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
 	padding: 0 8px;
 	border-radius: 9px;
 	border: 1px solid var(--border);
@@ -1052,6 +1078,9 @@
 	align-items: center;
 	justify-content: center;
 	min-width: 44px;
+	/* The toggle keeps its size; the device dropdown yields space instead, so the
+	   On/Off control is always fully visible (issue #624). */
+	flex-shrink: 0;
 	height: 28px;
 	padding: 0 10px;
 	border-radius: 8px;

--- a/src/components/ai-edition/v4/RecStage.tsx
+++ b/src/components/ai-edition/v4/RecStage.tsx
@@ -202,6 +202,12 @@ export function RecStage({
 							<span className={styles.recDot} aria-hidden />
 							<span>{sourceLabel}</span>
 						</div>
+						{prefs.micEnabled && (
+							<div className={styles.recMicMeter}>
+								<MicOn size={13} />
+								<AudioLevelMeter level={micLevel} className={styles.recLevelMeter} />
+							</div>
+						)}
 					</div>
 				</div>
 
@@ -263,38 +269,35 @@ export function RecStage({
 						</div>
 						<div className={styles.recRowControl}>
 							{prefs.micEnabled ? (
-								<>
-									{micDevices.isLoading ? (
-										<span className={styles.recRowMuted}>
-											<Loader2 size={13} className="animate-spin" />
-											{t("rec.loading")}
-										</span>
-									) : (
-										<select
-											className={styles.recSelect}
-											value={prefs.micDeviceId ?? micDevices.selectedDeviceId}
-											onChange={(e) => {
-												const deviceId = e.target.value;
-												micDevices.setSelectedDeviceId(deviceId);
-												// The label travels with the id: the native Windows
-												// helper selects a microphone by NAME, and records the
-												// Windows default endpoint when it is missing.
-												updatePrefs({
-													micDeviceId: deviceId,
-													micDeviceName:
-														micDevices.devices.find((d) => d.deviceId === deviceId)?.label ?? null,
-												});
-											}}
-										>
-											{micDevices.devices.map((d) => (
-												<option key={d.deviceId} value={d.deviceId}>
-													{d.label}
-												</option>
-											))}
-										</select>
-									)}
-									<AudioLevelMeter level={micLevel} className={styles.recLevelMeter} />
-								</>
+								micDevices.isLoading ? (
+									<span className={styles.recRowMuted}>
+										<Loader2 size={13} className="animate-spin" />
+										{t("rec.loading")}
+									</span>
+								) : (
+									<select
+										className={styles.recSelect}
+										value={prefs.micDeviceId ?? micDevices.selectedDeviceId}
+										onChange={(e) => {
+											const deviceId = e.target.value;
+											micDevices.setSelectedDeviceId(deviceId);
+											// The label travels with the id: the native Windows
+											// helper selects a microphone by NAME, and records the
+											// Windows default endpoint when it is missing.
+											updatePrefs({
+												micDeviceId: deviceId,
+												micDeviceName:
+													micDevices.devices.find((d) => d.deviceId === deviceId)?.label ?? null,
+											});
+										}}
+									>
+										{micDevices.devices.map((d) => (
+											<option key={d.deviceId} value={d.deviceId}>
+												{d.label}
+											</option>
+										))}
+									</select>
+								)
 							) : null}
 							<button
 								type="button"


### PR DESCRIPTION
## Summary
In the Studio **Rec** tab, the microphone could not be turned off. The mic row was the only settings row carrying an inline audio-level meter, so its controls — device dropdown + meter + On/Off toggle — overflowed the fixed 360px settings panel. The On/Off toggle was pushed off the right edge, reachable only via a non-obvious horizontal scrollbar, so in practice the mic looked impossible to disable. Camera and System audio, which have no meter, were unaffected.

This PR:
- **Moves the mic level meter onto the preview** as a bottom-left overlay, so the mic row matches the Camera row (label · device selector · On/Off toggle).
- **Guards the row against overflow**: the control group and device `<select>` may shrink and the selected name truncates (`min-width: 0`), while the On/Off toggle never shrinks (`flex-shrink: 0`), so it is always fully visible. This also hardens the Camera row against long device names.

The mic enable/disable logic was already correct — the toggle was simply unreachable. This is a layout-only change.

## Related issue

Fixes #624

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [x] Patch
- [ ] Minor
- [ ] Major / breaking change
- [ ] No release note needed

## Desktop impact
- [ ] Windows
- [ ] macOS
- [ ] Linux
- [ ] Installer / packaging
- [x] Not platform-specific

## Screenshots / video
**Before** (see #624 for the image): the Microphone row's On/Off toggle sits off the right edge of the 360px panel and is only reachable via a horizontal scrollbar; Camera and System audio show their toggle normally.

**After**: the mic level meter moves to the preview (bottom-left), the Microphone row matches the Camera row, and the On/Off toggle is always visible with no horizontal scrollbar — even with a long device name (the dropdown truncates).

<img width="1885" height="1024" alt="screenshot" src="https://github.com/user-attachments/assets/1f114095-b120-4e2c-b46a-6de3e2e46020" />

## Testing
- `npx tsc` — passes.
- `npx biome check` on the changed `.tsx` — passes (CSS modules are outside biome's configured paths).
- Built a Linux AppImage from this branch and verified in the running app: the mic On/Off toggle is fully visible and disables the mic; the level meter now renders on the preview and responds to input; the mic-row icon is intact; Camera and System audio behave as before. Verified with a long microphone device name so the dropdown truncates instead of overflowing.

<!-- discord-thread-id:1546656141604429967 -->