### PR TITLE
chore: bump nix package to v1.11.0

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -51,7 +51,7 @@ buildNpmPackage {
       );
     };
 
-  npmDepsHash = "sha256-LkKX1edTPHZq5nQRrbLAn11oVw36kb0smNQMmVRMEPA=";
+  npmDepsHash = "sha256-MCiWpmrqpkxU0AygHMYE7/MMNX1c/J0PoWuOad3MoLE=";
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 


### PR DESCRIPTION
Automated bump triggered by release `v1.11.0`.

- `version` → `1.11.0`
- `npmDepsHash` → `sha256-MCiWpmrqpkxU0AygHMYE7/MMNX1c/J0PoWuOad3MoLE=` (computed via `prefetch-npm-deps package-lock.json`)

Merge this so Nix users (NixOS, Home Manager, `nix run github:getopenscreen/openscreen`) pick up the new release.

<!-- discord-thread-id:1547255929198747709 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency metadata to reflect the current locked dependency set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->