### PR TITLE
fix(windows): let the default microphone id veto the device name

### DIFF
--- a/electron/native/wgc-capture/src/wasapi_loopback_capture.cpp
+++ b/electron/native/wgc-capture/src/wasapi_loopback_capture.cpp
@@ -203,9 +203,15 @@ bool WasapiLoopbackCapture::initialize(WasapiCaptureEndpoint endpoint, const std
         // resolve one in time, but a name that simply matches no endpoint lands
         // in exactly the same place. Either way the take sounds like the wrong
         // microphone with nothing explaining why (getopenscreen/openscreen#404).
+        // "default" vetoes the name, it does not merely sit beside it. The picker
+        // persists BOTH fields from whichever entry was clicked, and Chromium's own
+        // Default entry carries the label "Default - Microphone (…)" — a string no
+        // endpoint FriendlyName ever matches. Reading the name as an alternative
+        // therefore warned about a microphone the user never chose, every time they
+        // picked Default explicitly instead of leaving the picker alone.
         const bool wantedAParticularMicrophone =
-            endpoint == WasapiCaptureEndpoint::Microphone &&
-            ((!deviceId.empty() && deviceId != L"default") || !deviceName.empty());
+            endpoint == WasapiCaptureEndpoint::Microphone && deviceId != L"default" &&
+            (!deviceId.empty() || !deviceName.empty());
         if (wantedAParticularMicrophone) {
             std::cerr << "{\"event\":\"warning\",\"code\":\"microphone-defaulted\","
                          "\"message\":\"The requested microphone could not be resolved; "


### PR DESCRIPTION
## Summary

Picking Chromium's own **Default** entry in the microphone picker warned that the requested microphone could not be resolved — for a microphone the user never asked for.

Both pickers (`LaunchWindow.tsx:747`, `RecStage.tsx:283`) persist `micDeviceId` **and** `micDeviceName` from whichever entry was clicked. Chromium's Default entry is `deviceId: "default"` with the label `"Default - Microphone (…)"`, so both land in the request together. The predicate read them as alternatives:

```cpp
((!deviceId.empty() && deviceId != L"default") || !deviceName.empty())
```

The non-empty name alone made the request look specific, no endpoint `FriendlyName` matches that label, so `device_` stayed null and the warning fired on a perfectly ordinary take. `"default"` now vetoes the name instead of sitting beside it.

Leaving the picker untouched was already silent — only an explicit click on Default was affected, which is why this survived #404.

## Related issue

Refs #402

## Type of change
- [x] Bug fix

## Release impact
- [x] Patch

## Desktop impact
- [x] Windows

## Testing

Predicate change only, no behaviour change to device resolution itself. The twin defect in the macOS helper is fixed in #521 by the same rule; this one is already shipped, hence its own change.

Not covered by a test: the predicate is inline in `initialize()` and the branch needs a real WASAPI enumeration to reach. `scripts/test-windows-wgc-helper.mjs` exercises the helper but not this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1547547955593089065 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an incorrect warning that could appear when selecting the system’s Default microphone.
  * Default microphone selection now works without triggering a misleading fallback notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->