### PR TITLE
fix: treat recordings without audio as a non-error transcription state

### DIFF
--- a/src/components/ai-edition/TranscriptionStatus.test.tsx
+++ b/src/components/ai-edition/TranscriptionStatus.test.tsx
@@ -114,4 +114,44 @@ describe("TranscriptionStatusDot", () => {
 		expect(container.querySelector("svg")).toBeNull();
 		expect(container.querySelector("span")).toHaveAttribute("title", "mediaStage.transcriptReady");
 	});
+
+	it("renders amber dot and clean title for silent media (no-audio)", () => {
+		const { container } = render(
+			<TranscriptionStatusDot
+				view={{
+					assetId: "a",
+					status: "failed",
+					failure: {
+						kind: "no-audio",
+						message:
+							"No decodable audio in /tmp/silent.mp4: Output file #0 does not contain any stream",
+					},
+				}}
+			/>,
+		);
+		const span = container.querySelector("span");
+		expect(span).toHaveStyle({ background: "#f59e0b" });
+		expect(span).toHaveAttribute("title", "mediaStage.noAudioTrack");
+	});
+
+	it("renders danger dot and detail title for actual error failure", () => {
+		const { container } = render(
+			<TranscriptionStatusDot
+				view={{
+					assetId: "a",
+					status: "failed",
+					failure: {
+						kind: "error",
+						message: "whisper-server exited unexpectedly",
+					},
+				}}
+			/>,
+		);
+		const span = container.querySelector("span");
+		expect(span).toHaveStyle({ background: "var(--danger)" });
+		expect(span).toHaveAttribute(
+			"title",
+			"mediaStage.transcriptionFailed — whisper-server exited unexpectedly",
+		);
+	});
 });

--- a/src/components/ai-edition/TranscriptionStatus.tsx
+++ b/src/components/ai-edition/TranscriptionStatus.tsx
@@ -105,7 +105,10 @@ export function TranscriptionStatusDot({
 			</Loader2>
 		);
 	}
-	const { fill, halo } = DOT_COLOR[view.status];
+	const isSilence = view.failure?.kind === "no-audio" || view.failure?.kind === "unsupported-audio";
+	const { fill, halo } = isSilence
+		? { fill: "#f59e0b", halo: "0 0 0 3px rgba(245, 158, 11, 0.2)" }
+		: DOT_COLOR[view.status];
 	return (
 		<span
 			style={{
@@ -117,7 +120,11 @@ export function TranscriptionStatusDot({
 				flexShrink: 0,
 			}}
 			aria-label={label}
-			title={view.failure?.message ? `${label} — ${view.failure.message}` : label}
+			title={
+				view.failure?.kind === "error" && view.failure?.message
+					? `${label} — ${view.failure.message}`
+					: label
+			}
 		/>
 	);
 }

--- a/src/components/ai-edition/v4/MediaStage.tsx
+++ b/src/components/ai-edition/v4/MediaStage.tsx
@@ -94,6 +94,9 @@ export function MediaStage({
 		: { assetId: "", status: "idle" };
 	const selectedBusy =
 		selectedTranscription.status === "running" || selectedTranscription.status === "queued";
+	const selectedSilence =
+		selectedTranscription.failure?.kind === "no-audio" ||
+		selectedTranscription.failure?.kind === "unsupported-audio";
 
 	const handleImport = async () => {
 		if (!projectId) {
@@ -308,13 +311,17 @@ export function MediaStage({
 										borderRadius: 9999,
 										background:
 											selectedTranscription.status === "failed"
-												? "var(--danger-soft)"
+												? selectedSilence
+													? "var(--warn-soft)"
+													: "var(--danger-soft)"
 												: selectedTranscription.status === "ready"
 													? "var(--success-soft)"
 													: "var(--accent-soft)",
 										color:
 											selectedTranscription.status === "failed"
-												? "var(--danger)"
+												? selectedSilence
+													? "var(--warn)"
+													: "var(--danger)"
 												: selectedTranscription.status === "ready"
 													? "var(--success)"
 													: "var(--accent)",
@@ -452,7 +459,9 @@ export function MediaStage({
 										{selectedBusy
 											? transcriptionLabel(selectedTranscription)
 											: selectedTranscription.status === "failed"
-												? t("mediaStage.generationFailedHint")
+												? selectedSilence
+													? t("mediaStage.noAudioTrackHint")
+													: t("mediaStage.generationFailedHint")
 												: t("mediaStage.notGeneratedHint")}
 									</span>
 								)}

--- a/src/lib/ai-edition/store/transcriptionStore.test.ts
+++ b/src/lib/ai-edition/store/transcriptionStore.test.ts
@@ -195,6 +195,29 @@ describe("useTranscriptionStore", () => {
 		expect(transcribeMocks.transcribeAsset).toHaveBeenCalledTimes(1);
 	});
 
+	it("remembers NoAudioTrackError as a no-audio verdict and does not toast an error", async () => {
+		const err = Object.assign(
+			new Error(
+				"Error invoking remote method 'stt:transcribe': NoAudioTrackError: No decodable audio in /path/to/rec.mp4: Output file #0 does not contain any stream",
+			),
+			{ name: "NoAudioTrackError" },
+		);
+		transcribeMocks.transcribeAsset.mockRejectedValue(err);
+		loadDocument(makeDoc(["asset_1"]));
+
+		const { sync } = useTranscriptionStore.getState();
+		sync(useProjectStore.getState().document);
+		await whenTranscriptionIdle();
+
+		const job = useTranscriptionStore.getState().jobs.asset_1;
+		expect(job?.status).toBe("failed");
+		expect(job?.failure?.kind).toBe("no-audio");
+		expect(useProjectStore.getState().document?.assets[0].transcriptionFailure?.kind).toBe(
+			"no-audio",
+		);
+		expect(toastMocks.error).not.toHaveBeenCalled();
+	});
+
 	it("skips an asset that already carries a persisted failure on a fresh load", async () => {
 		const doc = makeDoc(["asset_1"]);
 		loadDocument({

--- a/src/lib/ai-edition/transcription/status.test.ts
+++ b/src/lib/ai-edition/transcription/status.test.ts
@@ -64,6 +64,28 @@ describe("classifyTranscriptionError", () => {
 		).toBe("no-audio");
 	});
 
+	it("recognises native extraction NoAudioTrackError", () => {
+		const err = Object.assign(
+			new Error("No decodable audio in /tmp/rec.mp4: Output file #0 does not contain any stream"),
+			{
+				name: "NoAudioTrackError",
+			},
+		);
+		const failure = classifyTranscriptionError(err);
+		expect(failure.kind).toBe("no-audio");
+		expect(isPermanentFailure(failure.kind)).toBe(true);
+	});
+
+	it("recognises remote IPC wrapped NoAudioTrackError", () => {
+		const failure = classifyTranscriptionError(
+			new Error(
+				"Error invoking remote method 'stt:transcribe': NoAudioTrackError: No decodable audio in C:\\test\\rec.mp4: Output file #0 does not contain any stream",
+			),
+		);
+		expect(failure.kind).toBe("no-audio");
+		expect(isPermanentFailure(failure.kind)).toBe(true);
+	});
+
 	it("recognises an audio codec the caption path cannot read", () => {
 		const failure = classifyTranscriptionError(
 			new Error("Audio codec not supported for captions: ac-3"),

--- a/src/lib/ai-edition/transcription/status.ts
+++ b/src/lib/ai-edition/transcription/status.ts
@@ -117,12 +117,19 @@ export type PersistableFailureKind = Exclude<TranscriptionFailureKind, "error">;
 
 /**
  * Map an exception out of `transcribeAsset` onto a failure the UI can explain.
- * The two deterministic cases come from `extractMono16kWebDemuxer` — it is the
- * only layer that knows whether the container actually holds audio.
+ * The deterministic silence cases come from `electron/stt/extractAudio` (`NoAudioTrackError`,
+ * "No decodable audio") or renderer extraction (`extractMono16kWebDemuxer`).
  */
 export function classifyTranscriptionError(error: unknown): TranscriptionFailure {
 	const message = error instanceof Error ? error.message : String(error);
-	if (/no audio track/i.test(message) || /zero audio frames/i.test(message)) {
+	const name = (error as { name?: string })?.name ?? "";
+	if (
+		name === "NoAudioTrackError" ||
+		/noaudiotrackerror/i.test(message) ||
+		/no decodable audio/i.test(message) ||
+		/no audio track/i.test(message) ||
+		/zero audio frames/i.test(message)
+	) {
 		return { kind: "no-audio", message };
 	}
 	if (/audio codec not supported/i.test(message)) {


### PR DESCRIPTION
## Problem

A screen-only recording with **no system audio and no microphone** was recorded successfully, but opening the Transcription inspector showed `NoAudioTrackError` as a red **transcription failure**. The recording itself — cursor sidecar, editing flow, and export — all succeeded; this was purely a UX error-state bug.

Closes getopenscreen/openscreen#628

## Root cause

`classifyTranscriptionError()` only matched the old renderer-side error strings (`"no audio track"`, `"zero audio frames"`). The native Windows WGC capture helper throws a `NoAudioTrackError` exception whose IPC-serialised form looks like:

```
Error invoking remote method 'stt:transcribe': NoAudioTrackError: No decodable audio in C:\rec.mp4: Output file #0 does not contain any stream
```

Neither the error `.name` nor the `"No decodable audio"` substring was being matched, so the error fell through to the generic `"error"` bucket — rendered in red as a failed transcription job rather than the expected informational empty state.

## Changes

### `src/lib/ai-edition/transcription/status.ts`
- `classifyTranscriptionError()` now checks:
  1. `error.name === "NoAudioTrackError"` (direct throw from the main process)
  2. `/noaudiotrackerror/i` in the message (IPC-serialised wrapper string)
  3. `/no decodable audio/i` (the actual ffmpeg diagnostic in the message)
  
  All three map to `kind: "no-audio"` — a permanent, non-retryable, non-error state.

### `src/components/ai-edition/TranscriptionStatus.tsx`
- `TranscriptionStatusDot`: silent media (`no-audio` / `unsupported-audio`) now renders an **amber** dot, not a red error dot.
- The tooltip for silence shows only the human-readable label — not the raw ffmpeg error string. Raw engine messages are still shown for genuine (retryable) errors.

### `src/components/ai-edition/v4/MediaStage.tsx`
- The status pill in the media detail panel uses **amber** (`--warn` / `--warn-soft`) for silence failures instead of red (`--danger` / `--danger-soft`).
- The transcript body area shows `noAudioTrackHint` copy for silence failures, keeping the generic failure hint only for retryable errors.

## Tests added (all passing — 78 tests across 3 files)

| File | New tests |
|---|---|
| `status.test.ts` | Native `NoAudioTrackError` → `"no-audio"`; IPC-wrapped variant → `"no-audio"`; both `isPermanentFailure` |
| `transcriptionStore.test.ts` | `NoAudioTrackError` persisted as `"no-audio"` on the asset; no error toast shown |
| `TranscriptionStatus.test.tsx` | Amber dot + clean title for silence; red dot + error-message title for real errors |

## Before / After

| State | Before | After |
|---|---|---|
| Silent recording in Transcription inspector | 🔴 Red "Transcription failed" pill + raw error text | 🟡 Amber "No audio track" pill + friendly hint |
| Status dot on media card | 🔴 Red error dot | 🟡 Amber informational dot |
| Error toast | ❌ Toast shown for a non-error condition | ✅ No toast — silence is not a failure |
| Persisted on asset | ✅ Already persisted (no-retry) | ✅ Still persisted, now correctly as `"no-audio"` |

<!-- discord-thread-id:1547593258677444751 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transcription failure detection for recordings with missing, unsupported, or silent audio.
  - These cases now display a warning-style indicator and a dedicated message explaining the issue.
  - Other transcription failures continue to use error styling and provide the relevant failure message.
  - Missing-audio failures no longer trigger an error notification, reducing unnecessary alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->