### PR TITLE
fix(transcription): a recording with no audio is a verdict, not a failed job

### DIFF
--- a/src/components/ai-edition/TranscriptionStatus.tsx
+++ b/src/components/ai-edition/TranscriptionStatus.tsx
@@ -13,6 +13,7 @@ import {
 	type AssetTranscriptionView,
 	isCpuBackend,
 	isModelDownloadInFlight,
+	isSilentFailure,
 	progressFraction,
 	realtimeSpeed,
 } from "@/lib/ai-edition/transcription/status";
@@ -105,7 +106,11 @@ export function TranscriptionStatusDot({
 			</Loader2>
 		);
 	}
-	const { fill, halo } = DOT_COLOR[view.status];
+	// A recording made with no system audio and no mic is not a broken job, so it
+	// gets the same amber as "no speech detected" rather than the danger red, and
+	// its label alone rather than a tooltip full of ffmpeg stderr (issue #628).
+	const silent = isSilentFailure(view);
+	const { fill, halo } = silent ? DOT_COLOR.empty : DOT_COLOR[view.status];
 	return (
 		<span
 			style={{
@@ -117,7 +122,7 @@ export function TranscriptionStatusDot({
 				flexShrink: 0,
 			}}
 			aria-label={label}
-			title={view.failure?.message ? `${label} — ${view.failure.message}` : label}
+			title={!silent && view.failure?.message ? `${label} — ${view.failure.message}` : label}
 		/>
 	);
 }

--- a/src/components/ai-edition/v4/MediaStage.tsx
+++ b/src/components/ai-edition/v4/MediaStage.tsx
@@ -13,9 +13,10 @@ import {
 	languageLabel,
 	sortedLanguageOptions,
 } from "@/lib/ai-edition/transcription/languageLabels";
-import type {
-	AssetTranscriptionStatus,
-	AssetTranscriptionView,
+import {
+	type AssetTranscriptionStatus,
+	type AssetTranscriptionView,
+	isSilentFailure,
 } from "@/lib/ai-edition/transcription/status";
 import { formatBytes } from "@/utils/formatBytes";
 import {
@@ -306,14 +307,19 @@ export function MediaStage({
 										gap: 6,
 										padding: "5px 10px 5px 8px",
 										borderRadius: 9999,
+										// A silent recording reads as a verdict about the media, not as a
+										// broken run, so it keeps the neutral accent rather than the danger
+										// red the engine failures get (issue #628).
 										background:
-											selectedTranscription.status === "failed"
+											selectedTranscription.status === "failed" &&
+											!isSilentFailure(selectedTranscription)
 												? "var(--danger-soft)"
 												: selectedTranscription.status === "ready"
 													? "var(--success-soft)"
 													: "var(--accent-soft)",
 										color:
-											selectedTranscription.status === "failed"
+											selectedTranscription.status === "failed" &&
+											!isSilentFailure(selectedTranscription)
 												? "var(--danger)"
 												: selectedTranscription.status === "ready"
 													? "var(--success)"
@@ -451,9 +457,11 @@ export function MediaStage({
 									<span style={{ color: "var(--muted)" }}>
 										{selectedBusy
 											? transcriptionLabel(selectedTranscription)
-											: selectedTranscription.status === "failed"
-												? t("mediaStage.generationFailedHint")
-												: t("mediaStage.notGeneratedHint")}
+											: isSilentFailure(selectedTranscription)
+												? t("mediaStage.noAudioTrackHint")
+												: selectedTranscription.status === "failed"
+													? t("mediaStage.generationFailedHint")
+													: t("mediaStage.notGeneratedHint")}
 									</span>
 								)}
 							</div>

--- a/src/lib/ai-edition/store/transcriptionStore.test.ts
+++ b/src/lib/ai-edition/store/transcriptionStore.test.ts
@@ -15,6 +15,7 @@ const transcribeMocks = vi.hoisted(() => ({
 const toastMocks = vi.hoisted(() => ({
 	success: vi.fn(),
 	error: vi.fn(),
+	info: vi.fn(),
 }));
 
 vi.mock("@/native/client", () => ({
@@ -26,7 +27,9 @@ vi.mock("../document/transcribe", async (importOriginal) => {
 	return { ...actual, transcribeAsset: transcribeMocks.transcribeAsset };
 });
 
-vi.mock("sonner", () => ({ toast: { success: toastMocks.success, error: toastMocks.error } }));
+vi.mock("sonner", () => ({
+	toast: { success: toastMocks.success, error: toastMocks.error, info: toastMocks.info },
+}));
 
 function asset(id: string, extra: Record<string, unknown> = {}) {
 	return {
@@ -112,6 +115,7 @@ describe("useTranscriptionStore", () => {
 		transcribeMocks.transcribeAsset.mockReset();
 		toastMocks.success.mockReset();
 		toastMocks.error.mockReset();
+		toastMocks.info.mockReset();
 		// biome-ignore lint/suspicious/noExplicitAny: test-only stub of the preload bridge
 		(window as any).electronAPI = { stt: { transcribe: vi.fn() } };
 	});
@@ -238,6 +242,31 @@ describe("useTranscriptionStore", () => {
 		expect(Object.values(jobs).map((j) => j.status)).toEqual(["failed", "failed", "failed"]);
 		expect(jobs.asset_3?.failure?.message).toBe("whisper-server exited");
 		expect(toastMocks.error).toHaveBeenCalledTimes(1);
+	});
+
+	// The verdict is about the FILE, so a run the user asked for by hand answers
+	// it as information rather than as a broken job — issue #628 showed a red
+	// "Transcription failed" carrying ffmpeg's stderr on a muted screen recording.
+	it("answers a hand-asked run on a silent media without calling it a failure", async () => {
+		transcribeMocks.transcribeAsset.mockRejectedValue(
+			new Error("No decodable audio in /rec.mp4: Output file #0 does not contain any stream"),
+		);
+		loadDocument(makeDoc(["asset_1"]));
+
+		// The background pass discovers the silence first, and says nothing about it.
+		useTranscriptionStore.getState().sync(useProjectStore.getState().document);
+		await whenTranscriptionIdle();
+		expect(useTranscriptionStore.getState().jobs.asset_1?.failure?.kind).toBe("no-audio");
+		expect(toastMocks.info).not.toHaveBeenCalled();
+
+		// Asking by hand deserves an answer — an informational one. `request`
+		// resolves as soon as the job settles, which is before the run has finished
+		// writing the verdict and reporting it, so wait for the queue too.
+		await useTranscriptionStore.getState().request("asset_1", "auto");
+		await whenTranscriptionIdle();
+
+		expect(toastMocks.error).not.toHaveBeenCalled();
+		expect(toastMocks.info).toHaveBeenCalledTimes(1);
 	});
 
 	it("request() re-runs a failed asset and clears the remembered verdict", async () => {

--- a/src/lib/ai-edition/store/transcriptionStore.test.ts
+++ b/src/lib/ai-edition/store/transcriptionStore.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { toastText } from "@/i18n/toastText";
 import type { AxcutDocument, AxcutTranscript } from "../schema";
 import { useProjectStore } from "./projectStore";
 import { useTranscriptionStore, whenTranscriptionIdle } from "./transcriptionStore";
@@ -267,6 +268,12 @@ describe("useTranscriptionStore", () => {
 
 		expect(toastMocks.error).not.toHaveBeenCalled();
 		expect(toastMocks.info).toHaveBeenCalledTimes(1);
+		// The COPY, not just the count: the point of the toast is that it says the
+		// file has no audio. Resolved through the same helper the store uses, so a
+		// reworded string stays a translation change rather than a test failure.
+		expect(toastMocks.info).toHaveBeenCalledWith(
+			toastText("editor", "mediaStage.noAudioTrackHint"),
+		);
 	});
 
 	it("request() re-runs a failed asset and clears the remembered verdict", async () => {

--- a/src/lib/ai-edition/store/transcriptionStore.ts
+++ b/src/lib/ai-edition/store/transcriptionStore.ts
@@ -461,10 +461,14 @@ async function runJob(assetId: string, job: TranscriptionJob): Promise<void> {
 		// instead — the gate then reads "failed" (not "queued forever"), and one
 		// manual retry re-runs them all once the engine is back.
 		if (failure.kind === "error") failRemainingQueue(projectId, failure);
-		// A silent recording is an expected outcome, not an incident: the media
-		// card and every gated button already say so. Only surface the noisy
-		// (retryable) failures, plus anything the user asked for by hand.
-		if (failure.kind === "error" || job.manual) {
+		// A silent recording is an expected outcome, not an incident: the media card
+		// and every gated button already say so, so the background pass stays quiet.
+		// A run the user asked for by hand still gets an answer — but an
+		// informational one, because "this file has no audio" is the answer. Issue
+		// #628 got a red "Transcription failed" quoting ffmpeg's stderr instead.
+		if (isPermanentFailure(failure.kind)) {
+			if (job.manual) toast.info(toastText("mediaStage.noAudioTrackHint"));
+		} else {
 			toast.error(toastText("mediaStage.transcriptionFailed"), { description: failure.message });
 		}
 	} finally {

--- a/src/lib/ai-edition/transcription/status.test.ts
+++ b/src/lib/ai-edition/transcription/status.test.ts
@@ -10,6 +10,7 @@ import {
 	isCpuBackend,
 	isModelDownloadInFlight,
 	isPermanentFailure,
+	isSilentFailure,
 	progressFraction,
 	realtimeSpeed,
 	resolveTranscriptGate,
@@ -64,12 +65,35 @@ describe("classifyTranscriptionError", () => {
 		).toBe("no-audio");
 	});
 
+	// The native extractor phrases it its own way, and `ipcRenderer.invoke` wraps
+	// the rejection before the renderer ever sees it — this is the shape that
+	// reached `classifyTranscriptionError` in issue #628 and fell through to
+	// "error", turning a muted screen recording into a failed job.
+	it("recognises the native extractor's verdict, through the IPC wrapper", () => {
+		const failure = classifyTranscriptionError(
+			new Error(
+				"Error invoking remote method 'stt:transcribe': Error: No decodable audio in /rec.mp4: Output file #0 does not contain any stream",
+			),
+		);
+		expect(failure.kind).toBe("no-audio");
+		expect(isPermanentFailure(failure.kind)).toBe(true);
+	});
+
 	it("recognises an audio codec the caption path cannot read", () => {
 		const failure = classifyTranscriptionError(
 			new Error("Audio codec not supported for captions: ac-3"),
 		);
 		expect(failure.kind).toBe("unsupported-audio");
 		expect(isPermanentFailure(failure.kind)).toBe(true);
+	});
+
+	it("marks the media verdicts as silent, and an engine failure as not", () => {
+		expect(isSilentFailure(view("a", "failed", "no-audio"))).toBe(true);
+		expect(isSilentFailure(view("a", "failed", "unsupported-audio"))).toBe(true);
+		expect(isSilentFailure(view("a", "failed", "error"))).toBe(false);
+		// A stored transcript outranks a failed job (`deriveAssetStatus`), and that
+		// view still carries the failure — it must not be styled as silence.
+		expect(isSilentFailure(view("a", "ready", "no-audio"))).toBe(false);
 	});
 
 	it("treats anything else as a transient error worth retrying", () => {

--- a/src/lib/ai-edition/transcription/status.ts
+++ b/src/lib/ai-edition/transcription/status.ts
@@ -117,18 +117,40 @@ export type PersistableFailureKind = Exclude<TranscriptionFailureKind, "error">;
 
 /**
  * Map an exception out of `transcribeAsset` onto a failure the UI can explain.
- * The two deterministic cases come from `extractMono16kWebDemuxer` — it is the
- * only layer that knows whether the container actually holds audio.
+ * The deterministic cases come from whichever layer decoded the audio, and there
+ * are two of them: `extractMono16kWebDemuxer` in the renderer, and — since
+ * native extraction landed — `extractAudio.ts`'s `NoAudioTrackError` in the main
+ * process, whose wording ("No decodable audio in …") is its own.
+ *
+ * Matched on the message rather than on the class because `ipcRenderer.invoke`
+ * rebuilds a plain `Error` and drops both the prototype and the `name`. Missing
+ * the native phrasing here is not cosmetic: it demotes a silent screen recording
+ * to a generic `"error"`, which reads as a failed job, re-queues on every project
+ * open, and pops a toast carrying raw ffmpeg stderr (issue #628).
  */
 export function classifyTranscriptionError(error: unknown): TranscriptionFailure {
 	const message = error instanceof Error ? error.message : String(error);
-	if (/no audio track/i.test(message) || /zero audio frames/i.test(message)) {
+	if (/no audio track|zero audio frames|no decodable audio/i.test(message)) {
 		return { kind: "no-audio", message };
 	}
 	if (/audio codec not supported/i.test(message)) {
 		return { kind: "unsupported-audio", message };
 	}
 	return { kind: "error", message };
+}
+
+/**
+ * True when this asset's job ended on a verdict about the MEDIA rather than on
+ * something that went wrong: no audio track, or an audio codec nothing here can
+ * read. Both are expected outcomes of recording a screen with everything muted,
+ * so they get the "nothing to say" treatment (amber, a hint) rather than the
+ * error one (red, an engine message) — see issue #628.
+ */
+export function isSilentFailure(view: {
+	status: AssetTranscriptionStatus;
+	failure?: TranscriptionFailure;
+}): boolean {
+	return view.status === "failed" && view.failure !== undefined && view.failure.kind !== "error";
 }
 
 export function isAbortError(error: unknown): boolean {

--- a/technical-documentation/architecture/transcription-and-captions.md
+++ b/technical-documentation/architecture/transcription-and-captions.md
@@ -85,7 +85,10 @@ What the store owns and what it does not:
   auto pass skips it on the next load instead of re-extracting its audio to
   rediscover it. Everything else stays in memory for the session and is retried
   on the next load. A successful manual retry clears the stored verdict in the
-  same save that writes the transcript.
+  same save that writes the transcript. The verdict is read off the exception
+  MESSAGE (`classifyTranscriptionError`), because `ipcRenderer.invoke` rebuilds a
+  plain `Error` and drops the class — so a new decoder phrasing has to be added
+  there or its silence gets filed as a generic failure, which is issue #628.
 - **No local engine, no background pass.** Without `window.electronAPI.stt`
   (browser preview, e2e shim) nothing is queued; a manual request still runs.
 


### PR DESCRIPTION
## Summary

A screen capture recorded with no system audio and no microphone was reported as a failed transcription job, `NoAudioTrackError` and all.

The root cause is one classifier. `classifyTranscriptionError` still only knew the phrasings the renderer's web-demuxer produces ("no audio track", "zero audio frames"). Native ffmpeg extraction landed with its own — `NoAudioTrackError` says "No decodable audio in …" — so the verdict fell through to the generic `"error"` kind, and every consequence of that kind followed: a red failed job in the Transcription inspector, a toast carrying raw ffmpeg stderr, and no persisted verdict, so the auto pass re-extracted the same silent file on every project open.

Matching on the message rather than on the class is not a shortcut: `ipcRenderer.invoke` rebuilds a plain `Error` and drops both the prototype and the `name`, so the message is what crosses. The new phrasing joins the other two, and the architecture doc now says why a new decoder has to register itself there.

Everything downstream already treated `"no-audio"` as an expected outcome rather than an incident — it was simply never reached. What was still styled as an incident once it is:

- the media-card dot and the media-stage pill go amber, the colour "no speech detected" already uses, rather than danger red. Behind `isSilentFailure`, because four call sites were painting on `status === "failed"` alone;
- the dot's tooltip drops the raw engine message, and the stage says "this media has no audio track" instead of "generation failed";
- a run the user asked for by hand gets an informational toast instead of a red one. The background pass stays silent, as before.

## Related issue

Fixes #628

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation
- [ ] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [x] Patch
- [ ] Minor
- [ ] Major / breaking change
- [ ] No release note needed

## Desktop impact
- [ ] Windows
- [ ] macOS
- [ ] Linux
- [ ] Installer / packaging
- [x] Not platform-specific

## Screenshots / video

None. The change swaps copy and two colour tokens on states that already existed; the states themselves are covered by the unit tests below.

## Testing

```
npx vitest run src/components/ai-edition src/lib/ai-edition electron/stt
```

108 files, 1356 tests pass. `biome check` and `tsc --noEmit` are clean.

Three tests added:

- the native extractor's message, wrapped the way `ipcRenderer.invoke` wraps it, classifies as `no-audio`;
- `isSilentFailure` separates the media verdicts from an engine failure, and does not fire on a view that carries a failure alongside a usable transcript;
- a hand-asked run on a silent media toasts informationally, and the background pass that found the silence first said nothing.

Not covered by unit tests, and worth a look on the reproduction from the issue: the Transcription inspector's own empty state, which already keyed off the gate reason and only ever needed the classification to be right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- discord-thread-id:1547597295590183047 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of recordings with no audio track.
  - Manual transcription attempts now show an informational “no audio track” notification instead of an error.
  - Automatic background transcription remains unobtrusive for silent recordings.
  - Silent recordings now use neutral status styling and display a more relevant empty-transcript message.
  - Genuine transcription and media failures continue to display their appropriate error states.

- **Documentation**
  - Clarified how silent recording results are identified and retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->