### PR TITLE
ci(whisper-stt): drop the msvc-dev-cmd step the Windows build never used

### DIFF
--- a/.github/workflows/build-whisper-stt.yml
+++ b/.github/workflows/build-whisper-stt.yml
@@ -91,11 +91,21 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: brew install ninja
 
-      - name: Setup MSVC (Windows)
-        if: matrix.os == 'windows-latest'
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
+      # There is deliberately no "Setup MSVC" step for the Windows leg. It used to
+      # run ilammy/msvc-dev-cmd here, and nothing consumed what that action set up:
+      # scripts/build-whisper-stt.sh calls cmake without -G, so on Windows CMake
+      # picks its Visual Studio generator (the job log reads "Building for: Visual
+      # Studio 18 2026"), which locates MSVC through the Visual Studio installer
+      # and builds with MSBuild, whose VC targets set up the compiler environment
+      # themselves rather than inheriting the PATH/INCLUDE/LIB vcvarsall exported.
+      # vcpkg, in the SPIRV-Headers step below, finds the
+      # compiler on its own the same way, and windows-latest ships a single VS
+      # instance, so there is nothing for vcvars to disambiguate either. The
+      # action was also the last node20 action in the repo, with an upstream that
+      # stopped in 2024 (#317), so this drops a dependency rather than replacing
+      # it. Should the Windows build ever move to Ninja, that is the point where a
+      # vcvars step becomes necessary again; scripts/msvcEnv.mjs already has the
+      # vcvarsall discovery for it.
 
       - name: Install Vulkan SDK
         if: matrix.vulkan


### PR DESCRIPTION
## Summary

**Problem.** `ilammy/msvc-dev-cmd@v1` in `build-whisper-stt.yml` is the last `node20` action in the repo, and there is nothing to bump it to: upstream's last push to `master` is from 2024-03-30 and its `action.yml` still declares `using: node20`. Every Windows run of this workflow logs the deprecation warning, and once GitHub drops the shim the Windows `whisper-stt-server` build stops at that step (#317).

**What the step actually did.** #317 lists three replacements on the assumption that the step feeds a Ninja build. It does not. `scripts/build-whisper-stt.sh` calls `cmake` without `-G`, so on Windows CMake picks its default generator, and the [Windows job of the latest upstream run](https://github.com/getopenscreen/openscreen/actions/runs/34466021639/job/102834681397) (branch `claude/drop-dead-autotranscribe`, 2026-09-10; its workflow file and build script are identical to `main`'s) shows which one:

```
-- Building for: Visual Studio 18 2026
-- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/18/Enterprise/VC/Tools/MSVC/14.51.36231/bin/Hostx64/x64/cl.exe - skipped
```

The Visual Studio generator locates the instance through the Visual Studio installer and builds with MSBuild, whose VC targets set the compiler environment themselves. Nothing reads the `PATH`/`INCLUDE`/`LIB` that `vcvarsall` exported. The other Windows-only step, vcpkg installing `spirv-headers`, does its own toolchain detection too (`Compiler found: .../Hostx64/x64/cl.exe` in its output). So the issue's option 2, building with the VS generator, is the state the workflow has been in all along, and that leaves nothing for a vcvars step to do.

**Fix.** Remove the step. A comment at the spot says why there is none, and when one would become necessary again: a move to Ninja, at which point `scripts/msvcEnv.mjs` already has the vcvarsall discovery.

Two things the vcvars environment could have influenced, checked:

- **Instance selection.** With `VS180COMNTOOLS` set (which `vcvarsall` does), CMake uses that instance; without it, per the [`CMAKE_GENERATOR_INSTANCE` docs](https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR_INSTANCE.html), "if more than one VS instance is installed we do not define which one is chosen by default". `windows-latest` ships exactly one, Visual Studio Enterprise 2026 ([image README](https://github.com/actions/runner-images/blob/win25-vs2026/20260907.229/images/windows/Windows2025-VS2026-Readme.md)), so the choice is the same either way. Should GitHub ever add a second instance, it would show up as a different compiler path in the configure log, not as a silent miscompile.
- **Host tools.** The docs for the `Visual Studio 18 2026` generator (under [cmake-generators(7)](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#visual-studio-generators)): "By default this generator uses the 64-bit variant on x64 hosts". `Hostx64/x64/cl.exe` does not come from the action's `arch: x64`.

## Related issue

Fixes #317

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation
- [x] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [ ] Patch
- [ ] Minor
- [ ] Major / breaking change
- [x] No release note needed

## Desktop impact
- [x] Windows
- [ ] macOS
- [ ] Linux
- [ ] Installer / packaging
- [ ] Not platform-specific

CI only: the Windows leg of `build-whisper-stt.yml`. The produced binary is unchanged (same generator, same compiler).

## Screenshots / video

n/a

## Testing

This workflow's `push` trigger covers every branch and its `paths` filter includes the workflow file, so the change ran for real on my fork, at this exact commit:

- [Push run](https://github.com/My-Denia/openscreen/actions/runs/34504248458): every leg green, Windows staged and uploaded `whisper-stt-win32-x64.tar.gz`. The Windows log has no `Node.js 20 is deprecated` warning and no `Setup MSVC` step. It did restore the whisper build-tree cache, though, so CMake reused a persisted instance choice there.
- [Cold run](https://github.com/My-Denia/openscreen/actions/runs/34504942459): `workflow_dispatch` after deleting the fork's `whisper-stt-build-win32-x64-*` caches, so CMake had to configure from scratch with no vcvars environment. Its Windows log reads `Cache not found for input keys: whisper-stt-build-win32-x64-…`, then `-- Building for: Visual Studio 18 2026` and `The C compiler identification is MSVC 19.51.36256.0` at the same `…/VC/Tools/MSVC/14.51.36231/bin/Hostx64/x64/cl.exe` path as the upstream run above, and vcpkg reports the same `Compiler found:` path. Every leg green again; the Windows artifact is within a few hundred bytes of the one that upstream run produced (gzip timestamps).

`grep -rn msvc-dev-cmd` finds no other use of the action in the repo.

<!-- discord-thread-id:1547657308178350103 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows build process to use CMake and MSBuild for compiler discovery.
  * Streamlined compiler setup during dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->