### PR TITLE
docs(linux): bring the platform table back in line with what the code does

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Everything in the editor and export is the same on macOS, Windows, and Linux: zo
 
 - **Native recording**: macOS (ScreenCaptureKit), Windows (Windows Graphics Capture), and Linux (PipeWire via the ScreenCast portal) all record through a native pipeline for higher quality and clean window-level capture. On Linux the browser pipeline stays as an automatic fallback if the helper isn't available.
 - **Custom cursors**: on macOS and Windows the real cursor is captured with shape, type, and clicks. Linux captures position and cursor shape through the portal, so cursor themes and the editable cursor overlay work there too. Click effects work on Linux as well, but not through the portal — Wayland exposes no portal for mouse buttons, so the capture helper reads the left button from evdev, which needs your user in the `input` group. Without that, recording is unaffected and every cursor sample is simply a move.
-- **Webcam**: Windows muxes the webcam natively into the recording; macOS and Linux record it alongside as a separate file. It works as a picture-in-picture overlay on all three.
+- **Webcam**: every platform saves the webcam as a separate file next to the screen recording. Windows captures it natively in the recording helper; macOS and Linux record it in the app. It works as a picture-in-picture overlay on all three.
 - **System audio** support varies by OS:
   - **macOS**: works on every supported version. On macOS 14.2+ you'll be prompted to grant audio capture permission.
   - **Windows**: works out of the box.

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -127,20 +127,20 @@ The scope is deliberately narrow: only the left mouse button (`BTN_LEFT`) is eve
 
 ## Platform differences
 
-The editing tools are the same everywhere — zooms, backgrounds, crop/trim/speed, annotations, transcription, captions, and projects. Every export format works on every platform; what differs is **capture**, and how fast MP4 encodes on Linux:
+The editing tools are the same everywhere — zooms, backgrounds, crop/trim/speed, annotations, transcription, captions, and projects. Every export format works on every platform; what differs is **capture**, and which encoder the Linux MP4 export can use:
 
 | | macOS | Windows | Linux |
 |---|---|---|---|
 | Capture pipeline | Native (ScreenCaptureKit) | Native (Windows Graphics Capture) | Native (PipeWire via the ScreenCast portal); browser fallback without the helper, losing hardware encode and cursor telemetry |
 | Custom cursor themes / click effects | ✅ | ✅ | ✅ on Wayland — click capture needs the `input` group ([details](#mouse-clicks-on-wayland)) |
-| Webcam | Native capture | Native capture | Browser capture (still works as PiP) |
+| Webcam | Browser capture, saved as a separate file (still works as PiP) | Native capture, muxed into the recording | Browser capture, saved as a separate file (still works as PiP) |
 | System audio | Works out of the box; permission prompt on macOS 14.2+ | Works out of the box | Needs PipeWire (default on Ubuntu 22.04+, Fedora 34+) |
-| MP4 export | ✅ | ✅ | ✅ (software encode) |
+| MP4 export | ✅ | ✅ | ✅ — H.264 on the GPU through VAAPI where the driver offers it, software otherwise; H.265 is software-only |
 | GIF export | ✅ | ✅ | ✅ |
 | On-device transcription | Metal (Apple Silicon) / CPU | Vulkan / CPU | Vulkan / CPU |
 
 :::note MP4 export on Linux
-The GPU compositor behind the live preview and MP4 export has three backends — Direct3D 11 on Windows, Metal on macOS, wgpu/WGSL on Linux — and ships in all three builds. The Linux one encodes in software rather than on the GPU, so an export there takes longer than the same one on Windows or macOS; hardware encode is tracked on the [roadmap](https://github.com/getopenscreen/openscreen/blob/main/ROADMAP.md).
+The GPU compositor behind the live preview and MP4 export has three backends — Direct3D 11 on Windows, Metal on macOS, wgpu/WGSL on Linux — and ships in all three builds. On Linux, an H.264 export hands each composited frame to `h264_vaapi` without a CPU copy when the GPU driver exposes VAAPI. When it does not — no render node, or a driver without VAAPI — the export falls back to a software encoder and simply takes longer; nothing else changes. H.265 exports always use the software encoder on Linux.
 :::
 
 Next: [Quick start](./quick-start.md) walks through your first recording.

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -133,14 +133,14 @@ The editing tools are the same everywhere — zooms, backgrounds, crop/trim/spee
 |---|---|---|---|
 | Capture pipeline | Native (ScreenCaptureKit) | Native (Windows Graphics Capture) | Native (PipeWire via the ScreenCast portal); browser fallback without the helper, losing hardware encode and cursor telemetry |
 | Custom cursor themes / click effects | ✅ | ✅ | ✅ on Wayland — click capture needs the `input` group ([details](#mouse-clicks-on-wayland)) |
-| Webcam | Browser capture, saved as a separate file (still works as PiP) | Native capture, muxed into the recording | Browser capture, saved as a separate file (still works as PiP) |
+| Webcam | Browser capture, saved as a separate file (still works as PiP) | Native capture, saved as a separate file | Browser capture, saved as a separate file (still works as PiP) |
 | System audio | Works out of the box; permission prompt on macOS 14.2+ | Works out of the box | Needs PipeWire (default on Ubuntu 22.04+, Fedora 34+) |
-| MP4 export | ✅ | ✅ | ✅ — H.264 on the GPU through VAAPI where the driver offers it, software otherwise; H.265 is software-only |
+| MP4 export | ✅ | ✅ | ✅ — H.264 on the GPU through VAAPI when the GPU stack allows it (see the note below), software otherwise; H.265 is software-only |
 | GIF export | ✅ | ✅ | ✅ |
 | On-device transcription | Metal (Apple Silicon) / CPU | Vulkan / CPU | Vulkan / CPU |
 
 :::note MP4 export on Linux
-The GPU compositor behind the live preview and MP4 export has three backends — Direct3D 11 on Windows, Metal on macOS, wgpu/WGSL on Linux — and ships in all three builds. On Linux, an H.264 export hands each composited frame to `h264_vaapi` without a CPU copy when the GPU driver exposes VAAPI. When it does not — no render node, or a driver without VAAPI — the export falls back to a software encoder and simply takes longer; nothing else changes. H.265 exports always use the software encoder on Linux.
+The GPU compositor behind the live preview and MP4 export has three backends — Direct3D 11 on Windows, Metal on macOS, wgpu/WGSL on Linux — and ships in all three builds. On Linux, an H.264 export hands each composited frame to `h264_vaapi` without a CPU copy when the GPU driver exposes VAAPI *and* the Vulkan device can hand the frame over as a dmabuf (`VK_KHR_external_memory_fd` and `VK_EXT_external_memory_dma_buf`). When any of that is missing — no render node, a driver without VAAPI, a Vulkan device without those extensions — the export falls back to a software encoder and simply takes longer; nothing else changes. H.265 exports always use the software encoder on Linux.
 :::
 
 Next: [Quick start](./quick-start.md) walks through your first recording.


### PR DESCRIPTION
## Summary

**Problem.** The *Platform differences* table on the installation page still described Linux MP4 export as `software encode`, the note under it said the Linux compositor "encodes in software rather than on the GPU" and pointed at a roadmap entry for hardware encode, and the webcam row said macOS captures the camera natively. None of that matches the code on `main`.

**What the code does, checked against the source rather than the docs:**

- **MP4 export on Linux is hardware-encoded where it can be.** Since 6ba8f4c0 (`feat(export): encode on the GPU when VAAPI is available (Linux)`), `crates/compositor/src/pipeline_linux.rs` opens `h264_vaapi` against a dmabuf exported from the compositor when the driver offers VAAPI, and only falls back to the software encoder when it cannot: no render node, no VAAPI, or a wgpu device opened without `VK_KHR_external_memory_fd` / `VK_EXT_external_memory_dma_buf` (`d3d_linux.rs`, `open_device_with_dmabuf_export`), in which case the hardware sink is rejected before the first frame. The VAAPI attempt is guarded by `matches!(params.codec, ExportCodec::H264)`, so H.265 always goes to `libkvazaar`. The row and the note now say exactly that, and the roadmap link is gone because it pointed at work that has landed.
- **The webcam is a separate file everywhere, and only Windows captures it natively.** `src/lib/nativeMacRecording.ts` carries a `webcam` field in the helper request, but `ScreenCaptureRecorder.swift` only decodes it and never opens a camera device (its `AVCaptureDevice` calls are all `.audio`); `src/hooks/useScreenRecorder.ts` records the camera with a `MediaRecorder` in the renderer and attaches the file afterwards, and `nativeLinuxRecording.ts` documents the Linux path as "Like macOS, the camera stays with the renderer's MediaRecorder". On Windows the helper captures the camera itself, but `electron/ipc/handlers.ts` passes `outputs.webcamPath` on every recording and `wgc-capture/src/main.cpp` turns that into `writeSeparateWebcam`, so it is written to its own MP4 rather than muxed; the helper's mux branch exists but nothing in the app takes it. The row now says that for all three columns, and the one README sentence that claimed Windows muxes the webcam says the same. Those are cells beyond the Linux column the issue is about; they are the same row, checked the same way, and leaving cells I had just found wrong felt worse than touching them — happy to split them out if you would rather keep this PR Linux-only.
- **The capture-pipeline row** from the issue was already corrected by 1c66ca34, so it is untouched here.
- **The remaining Linux cells** (cursor/click effects, system audio, GIF export, transcription) still match the code and stay as they are.

**Not in this PR.** `ROADMAP.md` lines 42 and 47 still say the Linux export is software-encoded and list "Hardware encode on Linux" as open. That is the same staleness, but ticking a roadmap item is your call, so I left it and am flagging it here.

## Related issue

Fixes #535

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Enhancement
- [x] Documentation
- [ ] Refactor / maintenance
- [ ] Performance
- [ ] Security

## Release impact
- [ ] Patch
- [ ] Minor
- [ ] Major / breaking change
- [x] No release note needed

## Desktop impact
- [ ] Windows
- [x] macOS
- [x] Linux
- [ ] Installer / packaging
- [ ] Not platform-specific

Docs only; the macOS tick is for the webcam cell.

## Screenshots / video

n/a

## Testing

- `npm run docs:check` at the root: `check-docs: OK (34 files)`.
- Local Docusaurus build of `website/` (`npm ci && npm run build`), rerun after the second commit: `[SUCCESS] Generated static files in "build"`; the built `docs/installation/index.html` renders the table with the new cells and no longer mentions the roadmap.
- Every claim above was read from the files named, at `main` fbe461e9; I have no Linux machine, so the VAAPI selection itself is the maintainer's measurement in #535 plus the source, not something I re-ran.

<!-- discord-thread-id:1547670060708003871 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated platform differences to clarify webcam recording behavior: Windows uses native capture, while macOS and Linux save browser-captured webcam footage as a separate file.
  * Documented Linux H.264 MP4 hardware encoding through VAAPI when supported, with software fallback.
  * Clarified that H.265 encoding remains software-only and that webcam footage continues to work as picture-in-picture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->